### PR TITLE
v3.3.0 — pagination, adaptive delta crawler, query-layer speedups

### DIFF
--- a/.github/workflows/docker.yaml
+++ b/.github/workflows/docker.yaml
@@ -18,6 +18,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0   # full history so gitleaks can resolve the PR commit range
 
       - name: Lint Dockerfile
         uses: hadolint/hadolint-action@v3.0.0

--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,7 @@ cookies.txt
 .pytest_cache/
 test-results/
 auth-state.json
+
+# Benchmark run artifacts (may contain real bucket names / sizes) — keep scripts, not run outputs
+benchmark/results/prod-*.json
+benchmark/results/qlbench-*.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,30 @@
 
 All notable changes to Sairo are documented here. This project uses [Semantic Versioning](https://semver.org/).
 
+## [3.3.0] - 2026-06-13
+
+Performance & freshness release: validated end-to-end against a 1M-object / 241 TB production bucket.
+
+### Added
+
+- **Keyset pagination for listings** — `/api/buckets/{bucket}/list` accepts `cursor` + `limit` and returns `next_cursor`. The UI fetches folders in pages and paints the first page immediately, so million-object folders open instantly instead of streaming the whole listing. Listing a 1M-file folder's first page dropped from ~1.4 s / 122 MB to ~73 ms / 0.12 MB. (Omitting `limit` keeps the legacy whole-folder response, so existing API/CLI clients are unaffected.)
+- **Adaptive crawl scheduler** — large buckets are kept fresh with fast incremental **delta crawls** (re-listing only the prefixes where new data lands, in parallel) every interval, plus a periodic full reconcile; small buckets keep doing cheap full recrawls. A 1M-object bucket now picks up new objects in ~30 s instead of a ~7-minute full re-list. New tunables: `FULL_CRAWL_INTERVAL`, `LARGE_BUCKET_SECONDS`, `DELTA_SAMPLE`, `DELTA_MAX_TARGETS`.
+- **Direct (presigned-PUT) uploads** — files upload straight to object storage via presigned URLs by default, with proxy upload as fallback. Removes the in-memory buffering path for large files.
+- **Restart resumes from the existing index** — on startup, already-indexed buckets seed the scheduler from their crawl state instead of triggering a full re-crawl of every bucket.
+
+### Changed
+
+- **Covering index** — `objects` now uses a covering index `(prefix, key, size, last_modified)`, so folder listings and breakdowns are index-only (no temp B-tree sort, no row lookups). Replaces the prior `prefix`-only index; migrated automatically in place on first start (existing index reused, no re-crawl).
+- **Storage breakdown & folder-size** use covered prefix-range scans instead of `LIKE` full-table scans — 1.5–2.2x faster on large subtrees; top-level breakdown ~2.5 ms.
+- **FTS index rebuild** runs only when object keys were added or removed, skipping the expensive trigram rebuild on no-change recrawls.
+- **SQLite tuning** — larger page size for new databases, memory-mapped I/O on all connections, `synchronous=NORMAL` on the write path, WAL autocheckpoint.
+
+### Fixed
+
+- **Empty folder stats after large-bucket crawls** — the post-crawl FTS rebuild could hold the SQLite writer long enough to starve the folder-stats/prefix-children rebuild, leaving top-level breakdown falling back to a ~1 s full scan. Rebuilds are now ordered and serialized so this can't happen (top-level breakdown returns in ~2.5 ms).
+- **Stale folder shown after navigation** — a background refresh could overwrite the current folder's contents with a previous folder's data; refreshes are now aborted on navigation and guarded against the current view.
+- Background refresh now updates crawl status and the last-crawl timestamp, so the UI reflects when the index was last refreshed.
+
 ## [3.2.0] - 2026-04-11
 
 ### Added

--- a/backend/main.py
+++ b/backend/main.py
@@ -198,7 +198,7 @@ async def s3_error_handler(request, exc):
 
 
 _app_start_time = time.time()
-SAIRO_VERSION = "3.2.0"
+SAIRO_VERSION = "3.3.0"
 TELEMETRY = os.environ.get("TELEMETRY", "true").lower() != "false"
 
 S3_ENDPOINT = os.environ.get("S3_ENDPOINT", "")
@@ -663,11 +663,14 @@ def _db_path(bucket, endpoint_id=None):
 def _init_db(bucket, endpoint_id=None):
     os.makedirs(DB_DIR, exist_ok=True)
     conn = sqlite3.connect(_db_path(bucket, endpoint_id), timeout=30)
+    conn.execute("PRAGMA page_size = 8192")          # larger pages → shallower B-trees (new DBs only)
     conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute("PRAGMA busy_timeout = 5000")   # wait up to 5s for locks
+    conn.execute("PRAGMA busy_timeout = 5000")       # wait up to 5s for locks
     conn.execute("PRAGMA synchronous=NORMAL")
-    conn.execute("PRAGMA cache_size = -64000")   # 64MB page cache (default 2MB)
-    conn.execute("PRAGMA temp_store = MEMORY")    # temp tables in RAM
+    conn.execute("PRAGMA cache_size = -64000")       # 64MB page cache (default 2MB)
+    conn.execute("PRAGMA mmap_size = 268435456")     # 256MB memory-mapped I/O
+    conn.execute("PRAGMA temp_store = MEMORY")       # temp tables in RAM
+    conn.execute("PRAGMA wal_autocheckpoint = 2000") # checkpoint ~every 16MB of WAL
     conn.execute("""
         CREATE TABLE IF NOT EXISTS objects (
             key TEXT PRIMARY KEY,
@@ -684,7 +687,24 @@ def _init_db(bucket, endpoint_id=None):
         conn.execute("ALTER TABLE objects ADD COLUMN crawl_gen INTEGER DEFAULT 0")
     except Exception:
         pass  # Column already exists
-    conn.execute("CREATE INDEX IF NOT EXISTS idx_prefix ON objects(prefix)")
+    # Covering index: serves WHERE prefix=? and prefix-range scans, supplies
+    # key/size/last_modified without heap lookups, and is pre-sorted by key so
+    # ORDER BY key needs no temp B-tree. Supersedes the old idx_prefix(prefix).
+    # Detect an upgrade-in-place from an older build: a pre-existing DB that still
+    # has the legacy idx_prefix and not yet the covering index. Logged once per
+    # bucket so operators can see the one-time migration happen on first startup.
+    _upgrading = bool(conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_prefix'").fetchone()) and not bool(
+        conn.execute("SELECT 1 FROM sqlite_master WHERE type='index' AND name='idx_prefix_cover'").fetchone())
+    conn.execute("CREATE INDEX IF NOT EXISTS idx_prefix_cover ON objects(prefix, key, size, last_modified)")
+    conn.execute("DROP INDEX IF EXISTS idx_prefix")
+    if _upgrading:
+        try:
+            _n = conn.execute("SELECT COUNT(*) FROM objects").fetchone()[0]
+        except Exception:
+            _n = 0
+        log.info("[%s] Index migrated from older build: built covering idx_prefix_cover over %s objects, "
+                 "dropped legacy idx_prefix (existing index reused, no re-crawl needed)", bucket, f"{_n:,}")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_depth ON objects(depth)")
     conn.execute("CREATE INDEX IF NOT EXISTS idx_last_modified ON objects(last_modified)")
     conn.execute("""
@@ -701,6 +721,12 @@ def _init_db(bucket, endpoint_id=None):
     # Migration: add current_crawl_gen column to existing databases
     try:
         conn.execute("ALTER TABLE crawl_status ADD COLUMN current_crawl_gen INTEGER DEFAULT 0")
+    except Exception:
+        pass  # Column already exists
+    # Migration: persist last full-crawl duration so the scheduler can classify a
+    # bucket (small vs large) immediately after a restart, without re-crawling it.
+    try:
+        conn.execute("ALTER TABLE crawl_status ADD COLUMN crawl_duration REAL DEFAULT 0")
     except Exception:
         pass  # Column already exists
     conn.execute("""
@@ -792,6 +818,7 @@ def _get_db(bucket, endpoint_id=None):
     conn = sqlite3.connect(_db_path(bucket, endpoint_id), timeout=30)
     conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA busy_timeout = 5000")       # wait up to 5s for locks
+    conn.execute("PRAGMA synchronous = NORMAL")      # safe under WAL; fewer fsyncs on the crawl write path
     conn.execute("PRAGMA cache_size = -64000")       # 64MB page cache (default 2MB)
     conn.execute("PRAGMA mmap_size = 268435456")     # 256MB memory-mapped I/O
     conn.execute("PRAGMA temp_store = MEMORY")       # temp tables in RAM
@@ -808,6 +835,16 @@ def _key_prefix(key):
 
 def _key_depth(key):
     return key.count("/")
+
+
+def _prefix_upper(prefix):
+    """Smallest string strictly greater than every string starting with `prefix`.
+
+    Lets `col >= prefix AND col < _prefix_upper(prefix)` replace the non-sargable
+    `col LIKE prefix || '%'`, so the query uses an index range scan instead of a
+    full table scan. `prefix` is non-empty (callers handle the root case).
+    """
+    return prefix[:-1] + chr(ord(prefix[-1]) + 1)
 
 
 def _update_crawl_counters(bucket, endpoint_id=None):
@@ -951,6 +988,7 @@ def _record_storage_snapshot(bucket, endpoint_id=None):
 _crawl_pool = ThreadPoolExecutor(max_workers=12, thread_name_prefix="crawler")
 _rebuild_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="rebuild")
 _crawling = {}       # crawl_key -> timestamp when crawl started
+_rebuilding = set()  # crawl_keys whose post-crawl rebuild is in progress (blocks a colliding recrawl)
 _crawl_lock = threading.Lock()
 _CRAWL_MAX_DURATION = 7200  # 2 hours — if a crawl exceeds this, force-release the lock
 
@@ -1066,6 +1104,25 @@ def _rebuild_fts_async(bucket, endpoint_id=None):
     thread.start()
 
 
+def _fts_should_rebuild(bucket, endpoint_id, keys_changed):
+    """Decide whether the (O(all-rows)) FTS trigram rebuild is actually needed.
+
+    FTS indexes only the object key, so it is stale only when keys were added or
+    removed. Rebuild when keys changed this crawl, or — as a self-heal — when the
+    FTS index is empty while objects exist (e.g. a prior rebuild failed)."""
+    if keys_changed:
+        return True
+    try:
+        with _get_db(bucket, endpoint_id) as db:
+            obj = db.execute("SELECT COUNT(*) FROM objects").fetchone()[0]
+            if obj == 0:
+                return False
+            fts = db.execute("SELECT COUNT(*) FROM objects_fts").fetchone()[0]
+            return fts == 0
+    except Exception:
+        return True  # if we can't tell, rebuild to be safe
+
+
 def _incremental_upsert(db, batch, gen):
     """Incremental recrawl: only INSERT/REPLACE objects that are new or changed.
     For unchanged objects (same key+size+etag), just bump crawl_gen.
@@ -1125,11 +1182,14 @@ def _run_crawl(bucket, endpoint_id=None):
                     (time.strftime("%Y-%m-%dT%H:%M:%SZ"),))
         db.commit()
         crawl_gen = db.execute("SELECT current_crawl_gen FROM crawl_status WHERE id=1").fetchone()[0]
+        initial_count = db.execute("SELECT COUNT(*) FROM objects").fetchone()[0]
         # Disable FTS triggers during bulk crawl for performance
         _disable_fts_triggers(db)
 
     crawl_start = time.monotonic()
     crawl_ok = False
+    fts_needs_rebuild = True  # safe default; refined below once we know what changed
+    stale_count = 0
     try:
         # Get known top-level prefixes from existing index
         known_prefixes = set()
@@ -1330,6 +1390,11 @@ def _run_crawl(bucket, endpoint_id=None):
                 "UPDATE crawl_status SET status='complete', last_crawl_end=?, total_objects=?, total_size=? WHERE id=1",
                 (time.strftime("%Y-%m-%dT%H:%M:%SZ"), total_objects, total_size))
             db.commit()
+            # FTS indexes the key only, so it is stale only when keys were ADDED or
+            # DELETED — not when size/etag changed. Skip the O(all-rows) trigram
+            # rebuild entirely when no keys changed this crawl (the common recrawl case).
+            added = total_objects - initial_count + stale_count
+            fts_needs_rebuild = (added > 0) or (stale_count > 0)
 
         elapsed = time.monotonic() - crawl_start
         msg = f"[{eid}:{bucket}] Crawl complete: {total_objects:,} objects, {total_size / (1024**3):.1f} GB in {elapsed:.1f}s"
@@ -1355,22 +1420,52 @@ def _run_crawl(bucket, endpoint_id=None):
             log.warning("Failed to write crawl error status for %s: %s", bucket, inner_e)
     finally:
         # Release crawl lock BEFORE post-crawl rebuilds so the bucket can be
-        # re-queued even if rebuilds hang or crash on very large buckets.
+        # re-queued even if rebuilds hang or crash on very large buckets. But mark
+        # the bucket as "rebuilding" so a recrawl can't start mid-rebuild and
+        # collide on the single SQLite writer (which previously aborted the
+        # rebuild with "database is locked", leaving folder_stats empty).
         with _crawl_lock:
             _crawling.pop(crawl_key, None)
+            if crawl_ok:
+                _rebuilding.add(crawl_key)
+                # Record full-crawl timing so the scheduler can decide between a
+                # cheap full recrawl (small buckets) and fast delta crawls (large).
+                m = _crawl_meta.setdefault(crawl_key, {})
+                m["last_full"] = time.time()
+                m["duration"] = time.monotonic() - crawl_start
+                try:
+                    with _get_db(bucket, eid) as _db:
+                        _db.execute("UPDATE crawl_status SET crawl_duration=? WHERE id=1", (m["duration"],))
+                        _db.commit()
+                except Exception:
+                    pass
 
     # Post-crawl rebuilds run on a SEPARATE thread pool so they don't consume
     # crawl pool capacity. This prevents large-bucket rebuilds from starving
-    # the crawl pool and blocking recrawls for other buckets.
+    # the crawl pool and blocking recrawls for other buckets. Each step runs
+    # independently so a transient failure in one doesn't skip the others.
     if crawl_ok:
         def _do_rebuilds():
             try:
-                _rebuild_fts_async(bucket, eid)
-                _record_storage_snapshot(bucket, eid)
-                _rebuild_folder_stats(bucket, eid)
-                _rebuild_prefix_children(bucket, eid)
-            except Exception as rebuild_e:
-                log.warning("[%s:%s] Post-crawl rebuild error (non-fatal): %s", eid, bucket, rebuild_e)
+                # Run the fast metadata rebuilds FIRST and grab the writer quickly.
+                # The FTS trigram rebuild can hold the single SQLite writer for tens
+                # of seconds on a large bucket; if it ran first (in its background
+                # thread) these would block past busy_timeout and fail with
+                # "database is locked", leaving folder_stats/prefix_children empty.
+                for step in (_record_storage_snapshot, _rebuild_folder_stats, _rebuild_prefix_children):
+                    try:
+                        step(bucket, eid)
+                    except Exception as step_e:
+                        log.warning("[%s:%s] Post-crawl %s failed (non-fatal): %s",
+                                    eid, bucket, step.__name__, step_e)
+                # FTS rebuild LAST, and only when keys actually changed.
+                if _fts_should_rebuild(bucket, eid, fts_needs_rebuild):
+                    _rebuild_fts_async(bucket, eid)
+                else:
+                    log.info("[%s:%s] FTS rebuild skipped — no key changes this crawl", eid, bucket)
+            finally:
+                with _crawl_lock:
+                    _rebuilding.discard(crawl_key)
         _rebuild_pool.submit(_do_rebuilds)
 
 
@@ -1652,7 +1747,178 @@ def _is_index_ready(bucket):
         return row["status"] == "complete" or (row["total_objects"] or 0) > 0
 
 
-RECRAWL_INTERVAL = int(os.environ.get("RECRAWL_INTERVAL", "120"))  # seconds, default 2 minutes
+RECRAWL_INTERVAL = int(os.environ.get("RECRAWL_INTERVAL", "120"))         # how often to check each bucket for fresh data
+FULL_CRAWL_INTERVAL = int(os.environ.get("FULL_CRAWL_INTERVAL", "3600"))  # full reconcile cadence for large buckets (deletions/cold changes)
+LARGE_BUCKET_SECONDS = int(os.environ.get("LARGE_BUCKET_SECONDS", "60"))  # if a full crawl took longer than this, keep fresh via delta crawls
+DELTA_SAMPLE = int(os.environ.get("DELTA_SAMPLE", "3000"))                # how many recent objects to sample to locate hot prefixes
+DELTA_MAX_TARGETS = int(os.environ.get("DELTA_MAX_TARGETS", "40"))        # cap on hot prefixes re-listed per delta crawl
+
+# crawl_key -> {"last_full": ts, "duration": sec, "last_delta": ts}
+_crawl_meta = {}
+
+
+def _parent_prefix(prefix):
+    """Immediate parent of a prefix: 'a/b/c/' -> 'a/b/'; 'a/' -> ''."""
+    s = prefix.rstrip("/")
+    i = s.rfind("/")
+    return s[:i + 1] if i >= 0 else ""
+
+
+def _minimal_prefixes(prefixes):
+    """Drop any prefix that is already covered by a shorter prefix in the set,
+    so we never re-list the same subtree twice in one delta crawl."""
+    kept = []
+    for p in sorted(prefixes, key=len):
+        if not any(p != k and p.startswith(k) for k in kept):
+            kept.append(p)
+    return kept
+
+
+def _hot_target_prefixes(bucket, endpoint_id, sample=None, max_targets=None):
+    """The narrow prefixes where the most recently-modified objects live (uses
+    idx_last_modified). These are exactly where new data is appended for
+    time-partitioned data, so re-listing just these is fast. Brand-new sibling
+    partitions are discovered separately in _delta_crawl via a cheap delimiter
+    scan — we deliberately do NOT broaden to parents here, since a hot prefix's
+    parent can be the entire dataset (e.g. sampling-GUID/metadata/ -> sampling-GUID/)."""
+    sample = sample or DELTA_SAMPLE
+    max_targets = max_targets or DELTA_MAX_TARGETS
+    with _get_db(bucket, endpoint_id) as db:
+        rows = db.execute(
+            "SELECT DISTINCT prefix FROM (SELECT prefix, last_modified FROM objects "
+            "WHERE prefix != '' ORDER BY last_modified DESC LIMIT ?)", (sample,)).fetchall()
+    return _minimal_prefixes({p for (p,) in rows})[:max_targets]
+
+
+def _delta_list_prefix(client, bucket, prefix):
+    """Recursively list every object under `prefix` (no delimiter). Returns raw S3 objects."""
+    objs = []
+    token = None
+    while True:
+        params = {"Bucket": bucket, "Prefix": prefix, "MaxKeys": 1000}
+        if token:
+            params["ContinuationToken"] = token
+        resp = client.list_objects_v2(**params)
+        for o in resp.get("Contents", []):
+            if o["Key"] != prefix:
+                objs.append(o)
+        if not resp.get("IsTruncated", False):
+            break
+        token = resp.get("NextContinuationToken")
+    return objs
+
+
+def _delta_crawl(bucket, endpoint_id):
+    """Fast incremental crawl: re-list ONLY the narrow hot prefixes (where new data
+    lands) plus any brand-new sibling partitions, in PARALLEL, and incremental-upsert.
+    FTS triggers stay enabled so search updates per row (no full trigram rebuild).
+    Avoids re-listing the whole bucket. Returns #new/changed objects."""
+    eid = endpoint_id or "default"
+    client = _s3_manager.get_client(eid)
+    hot = _hot_target_prefixes(bucket, eid)
+    if not hot:
+        return 0
+
+    # Surface delta activity to the UI (status + last_crawl_start). The index stays
+    # queryable throughout because _is_index_ready treats any bucket with
+    # total_objects>0 as ready. The caller resets status/last_crawl_end when done.
+    with _get_db(bucket, eid) as db:
+        db.execute("UPDATE crawl_status SET status='crawling', last_crawl_start=? WHERE id=1",
+                   (time.strftime("%Y-%m-%dT%H:%M:%SZ"),))
+        db.commit()
+
+    # Discover brand-new sibling partitions (e.g. a freshly-created hour folder):
+    # delimiter-list each hot prefix's parent and include any child prefix that has
+    # no objects in the index yet. One cheap request per distinct parent.
+    targets = set(hot)
+    parents = {_parent_prefix(p) for p in hot if _parent_prefix(p)}
+    with _get_db(bucket, eid) as db:
+        for par in parents:
+            try:
+                resp = client.list_objects_v2(Bucket=bucket, Prefix=par, Delimiter="/", MaxKeys=1000)
+                for cp in resp.get("CommonPrefixes", []):
+                    child = cp["Prefix"]
+                    seen = db.execute("SELECT 1 FROM objects WHERE prefix >= ? AND prefix < ? LIMIT 1",
+                                      (child, _prefix_upper(child))).fetchone()
+                    if not seen:
+                        targets.add(child)
+            except Exception:
+                pass
+        row = db.execute("SELECT current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
+        gen = (row[0] if row else 0) or 0
+    targets = _minimal_prefixes(targets)
+
+    # List all targets in parallel (the hot set is small; this keeps a delta fast
+    # even when several partitions are active).
+    all_objs = []
+    with ThreadPoolExecutor(max_workers=min(8, len(targets))) as ex:
+        for objs in ex.map(lambda tp: _delta_list_prefix(client, bucket, tp), targets):
+            all_objs.extend(objs)
+
+    changed = 0
+    with _get_db(bucket, eid) as db:
+        for i in range(0, len(all_objs), 5000):
+            chunk = all_objs[i:i + 5000]
+            keys = [o["Key"] for o in chunk]
+            ph = ",".join("?" * len(keys))
+            have = {r[0]: (r[1], r[2]) for r in
+                    db.execute(f"SELECT key,size,etag FROM objects WHERE key IN ({ph})", keys)}
+            batch = []
+            for o in chunk:
+                k = o["Key"]; sz = o["Size"]; et = o.get("ETag", "").strip('"')
+                prev = have.get(k)
+                if not prev or prev[0] != sz or prev[1] != et:
+                    changed += 1
+                batch.append((k, sz, o["LastModified"].isoformat(), et,
+                              _key_prefix(k), _key_depth(k), gen))
+            db.executemany(
+                "INSERT OR REPLACE INTO objects (key,size,last_modified,etag,prefix,depth,crawl_gen) "
+                "VALUES (?,?,?,?,?,?,?)", batch)
+        db.commit()
+
+    if changed:
+        # cheap metadata refreshes; FTS already maintained incrementally by triggers
+        for step in (_update_crawl_counters, _rebuild_folder_stats, _rebuild_prefix_children, _record_storage_snapshot):
+            try:
+                step(bucket, eid)
+            except Exception as e:
+                log.warning("[%s:%s] delta post-step %s failed: %s", eid, bucket, getattr(step, "__name__", step), e)
+    return changed
+
+
+def _queue_delta_crawl(bucket, endpoint_id=None):
+    """Submit a delta crawl if the bucket isn't mid full-crawl or mid-rebuild."""
+    eid = endpoint_id or "default"
+    crawl_key = f"{eid}:{bucket}"
+    with _crawl_lock:
+        if crawl_key in _rebuilding or crawl_key in _crawling:
+            return False
+        _crawling[crawl_key] = time.time()  # reuse crawl lock to block colliding full crawls
+
+    def _run():
+        t0 = time.monotonic()
+        try:
+            _s3_context.endpoint_id = eid
+            n = _delta_crawl(bucket, eid)
+            with _crawl_lock:
+                _crawl_meta.setdefault(crawl_key, {})["last_delta"] = time.time()
+            log.info("[%s:%s] Delta crawl: %d new/changed in %.1fs", eid, bucket, n, time.monotonic() - t0)
+        except Exception as e:
+            log.warning("[%s:%s] Delta crawl error: %s", eid, bucket, e)
+        finally:
+            with _crawl_lock:
+                _crawling.pop(crawl_key, None)
+            # Always return status to 'complete' and stamp last_crawl_end so the UI
+            # reflects that the index was just refreshed (even on a no-change delta).
+            try:
+                with _get_db(bucket, eid) as db:
+                    db.execute("UPDATE crawl_status SET status='complete', last_crawl_end=? WHERE id=1",
+                               (time.strftime("%Y-%m-%dT%H:%M:%SZ"),))
+                    db.commit()
+            except Exception:
+                pass
+    _crawl_pool.submit(_run)
+    return True
 
 
 def _queue_crawl(bucket, endpoint_id=None):
@@ -1661,6 +1927,11 @@ def _queue_crawl(bucket, endpoint_id=None):
     crawl_key = f"{eid}:{bucket}"
     now = time.time()
     with _crawl_lock:
+        # Don't start a crawl while this bucket's post-crawl rebuild is still
+        # running — they would contend on the single SQLite writer and the
+        # rebuild would lose, leaving folder_stats/prefix_children empty.
+        if crawl_key in _rebuilding:
+            return False
         started_at = _crawling.get(crawl_key)
         if started_at:
             # Force-release stale locks (OOM kill, thread death, etc.)
@@ -1675,18 +1946,41 @@ def _queue_crawl(bucket, endpoint_id=None):
 
 
 def _auto_recrawl():
-    """Periodically re-crawl all buckets across all endpoints to pick up new objects."""
+    """Adaptive freshness scheduler. Each cycle, per bucket:
+      • never fully crawled yet      → full crawl
+      • full crawl due (cold reconcile, every FULL_CRAWL_INTERVAL) → full crawl
+      • large bucket (slow full crawl) → DELTA crawl (re-list only hot prefixes) → fresh data fast
+      • small bucket (fast full crawl) → full recrawl every interval (already cheap & fresh)
+    This keeps high-volume buckets fresh within ~one interval without re-listing
+    the whole bucket every cycle, and avoids crawl/rebuild lock collisions."""
     while True:
         try:
             time.sleep(RECRAWL_INTERVAL)
+            now = time.time()
             for eid in _s3_manager.get_all_ids():
                 try:
                     client = _s3_manager.get_client(eid)
                     resp = client.list_buckets()
                     for b in resp.get("Buckets", []):
                         name = b["Name"]
-                        if _queue_crawl(name, eid):
-                            log.info("Auto-recrawl queued for %s:%s", eid, name)
+                        key = f"{eid}:{name}"
+                        meta = _crawl_meta.get(key)
+                        if not meta or "last_full" not in meta:
+                            if _queue_crawl(name, eid):
+                                log.info("Full crawl queued for %s (initial)", key)
+                            continue
+                        if (now - meta["last_full"]) > FULL_CRAWL_INTERVAL:
+                            if _queue_crawl(name, eid):
+                                log.info("Full recrawl queued for %s (cold reconcile)", key)
+                        elif meta.get("duration", 0) > LARGE_BUCKET_SECONDS:
+                            # Delta every tick — the loop's RECRAWL_INTERVAL sleep paces
+                            # it, and _queue_delta_crawl skips if the previous delta is
+                            # still running, so there is no overlap and no skipped ticks.
+                            if _queue_delta_crawl(name, eid):
+                                log.info("Delta crawl queued for %s (fresh data)", key)
+                        else:
+                            if (now - meta["last_full"]) >= RECRAWL_INTERVAL:
+                                _queue_crawl(name, eid)
                 except Exception as e:
                     log.error("Auto-recrawl error (endpoint=%s): %s", eid, e)
         except Exception as outer_e:
@@ -1727,8 +2021,31 @@ def startup():
                 for b in resp.get("Buckets", []):
                     name = b["Name"]
                     _init_db(name, eid)
-                    _queue_crawl(name, eid)
-                    log.info("Queued crawl for %s:%s", eid, name)
+                    # If this bucket already has a complete index from a previous run,
+                    # seed the scheduler's in-memory state from it instead of doing a
+                    # full re-crawl on every restart. The scheduler then keeps it fresh
+                    # via fast delta crawls (large buckets) or cheap full recrawls (small).
+                    seeded = False
+                    try:
+                        with _get_db(name, eid) as db:
+                            row = db.execute("SELECT status, total_objects, crawl_duration "
+                                             "FROM crawl_status WHERE id=1").fetchone()
+                        if row and row["status"] == "complete" and (row["total_objects"] or 0) > 0:
+                            # Use the persisted full-crawl duration if we have it; until a
+                            # full crawl records one, estimate large-ness from object count
+                            # so big buckets go straight to fast deltas (not a full recrawl).
+                            dur = row["crawl_duration"] or 0.0
+                            if not dur and (row["total_objects"] or 0) > 50000:
+                                dur = LARGE_BUCKET_SECONDS + 1
+                            _crawl_meta[f"{eid}:{name}"] = {"last_full": time.time(), "duration": dur}
+                            seeded = True
+                            log.info("Seeded schedule for %s:%s from existing index (%s objects); will keep fresh via scheduler",
+                                     eid, name, f"{row['total_objects']:,}")
+                    except Exception:
+                        pass
+                    if not seeded:
+                        _queue_crawl(name, eid)
+                        log.info("Queued crawl for %s:%s", eid, name)
             except Exception as e:
                 log.error("Failed to list buckets on startup (endpoint=%s): %s", eid, e)
     threading.Thread(target=_startup_crawl, daemon=True).start()
@@ -3250,15 +3567,23 @@ def delete_bucket(bucket: str, user: dict = Depends(require_admin)):
 
 # ── API: Listing ────────────────────────────────────────────────────────────
 
-def _list_from_index(bucket, prefix):
+def _list_from_index(bucket, prefix, cursor=None, limit=None):
+    """Return (folders, files, next_cursor) for `prefix` from the index.
+
+    When `limit` is set, returns one keyset page of files (key > cursor) plus a
+    `next_cursor` (None when exhausted). Folders are returned only on the first
+    page (cursor empty). When `limit` is falsy, returns every file (legacy mode).
+    """
     prefix_len = len(prefix)
     t0 = time.monotonic()
+    next_cursor = None
+    first_page = not cursor  # folders are delivered only on the first page
 
     with _get_db(bucket) as db:
         seen = set()
         folders = []
 
-        if not prefix:
+        if first_page and not prefix:
             # Root level: use discovered_prefixes (instant) instead of scanning all objects
             try:
                 dp_rows = db.execute("SELECT prefix FROM discovered_prefixes").fetchall()
@@ -3281,7 +3606,7 @@ def _list_from_index(bucket, prefix):
                             folders.append({"prefix": fp, "name": name})
             except Exception:
                 pass
-        else:
+        elif first_page:
             # Subfolder: always compute from objects table (DISTINCT scan) to avoid stale cache.
             # prefix_children is only reliably maintained for level 1 (parent="").
             t_q = time.monotonic()
@@ -3303,10 +3628,20 @@ def _list_from_index(bucket, prefix):
         folders.sort(key=lambda f: f["name"])
         t_files = time.monotonic()
 
-        file_rows = db.execute("""
-            SELECT key, size, last_modified FROM objects
-            WHERE prefix = ? ORDER BY key
-        """, (prefix,)).fetchall()
+        # Keyset pagination (O(page)) when limit is set; otherwise the legacy
+        # full-folder fetch. Both ride the covering index — already ordered by key,
+        # so no temp B-tree and no heap lookups.
+        if limit and limit > 0:
+            file_rows = db.execute(
+                "SELECT key, size, last_modified FROM objects "
+                "WHERE prefix = ? AND key > ? ORDER BY key LIMIT ?",
+                (prefix, cursor or "", limit)).fetchall()
+            if len(file_rows) == limit:
+                next_cursor = file_rows[-1]["key"]
+        else:
+            file_rows = db.execute(
+                "SELECT key, size, last_modified FROM objects WHERE prefix = ? ORDER BY key",
+                (prefix,)).fetchall()
 
         files = [
             {"key": r["key"], "name": r["key"][prefix_len:], "size": r["size"], "last_modified": r["last_modified"]}
@@ -3317,7 +3652,7 @@ def _list_from_index(bucket, prefix):
 
     log.info("[perf] _list_from_index total: %.3fs (%d folders, %d files) prefix=%s",
              time.monotonic() - t0, len(folders), len(files), prefix[:60])
-    return folders, files
+    return folders, files, next_cursor
 
 
 def _list_from_s3_streaming(bucket, prefix, endpoint_id=None):
@@ -3346,14 +3681,19 @@ def _list_from_s3_streaming(bucket, prefix, endpoint_id=None):
 
 
 @app.get("/api/buckets/{bucket}/list")
-def list_objects(bucket: str, prefix: str = "", fresh: bool = False, user: dict = Depends(get_current_user)):
+def list_objects(bucket: str, prefix: str = "", fresh: bool = False,
+                 cursor: str = "", limit: int = 0, user: dict = Depends(get_current_user)):
     """List objects at a prefix. Uses index when available (instant), falls back to S3 streaming.
-    Pass fresh=true to force a direct S3 listing bypassing the index."""
+    Pass fresh=true to force a direct S3 listing bypassing the index.
+    Pass limit>0 (with optional cursor) for keyset pagination: returns one page of
+    files plus `next_cursor`; folders are included only on the first page (empty cursor).
+    Omit limit for the legacy whole-folder response (next_cursor=null, done=true)."""
     eid = _current_endpoint_id()
     if _is_index_ready(bucket) and not fresh:
-        folders, files = _list_from_index(bucket, prefix)
+        folders, files, next_cursor = _list_from_index(bucket, prefix, cursor=cursor or None, limit=limit)
         def gen():
-            yield json.dumps({"folders": folders, "files": files, "done": True,
+            yield json.dumps({"folders": folders, "files": files,
+                              "done": next_cursor is None, "next_cursor": next_cursor,
                               "total_folders": len(folders), "total_files": len(files), "indexed": True}) + "\n"
         return StreamingResponse(gen(), media_type="application/x-ndjson")
     return StreamingResponse(_list_from_s3_streaming(bucket, prefix, endpoint_id=eid), media_type="application/x-ndjson")
@@ -3460,8 +3800,13 @@ def folder_size(bucket: str, prefix: str = "", user: dict = Depends(get_current_
         raise HTTPException(503, "Index not ready")
     with _get_db(bucket) as db:
         if prefix:
-            row = db.execute("SELECT COUNT(*) as count, COALESCE(SUM(size),0) as total_size FROM objects WHERE key LIKE ?",
-                             (prefix + "%",)).fetchone()
+            # Range scan on the covering index (prefix,key,size) — index-only, no
+            # heap fetch, no full scan. Equivalent to key LIKE prefix||'%' because
+            # every object under `prefix` has an immediate-parent prefix under it.
+            row = db.execute(
+                "SELECT COUNT(*) as count, COALESCE(SUM(size),0) as total_size "
+                "FROM objects WHERE prefix >= ? AND prefix < ?",
+                (prefix, _prefix_upper(prefix))).fetchone()
         else:
             # Fast path: use pre-computed totals from crawl_status
             row = db.execute("SELECT total_objects as count, total_size as total_size FROM crawl_status WHERE id=1").fetchone()
@@ -3512,17 +3857,25 @@ def storage_breakdown(bucket: str, prefix: str = "", user: dict = Depends(get_cu
     t_sb = time.monotonic()
     prefix_len = len(prefix)
     with _get_db(bucket) as db:
-        like_pattern = (prefix + "%") if prefix else "%"
-        rows = db.execute("""
+        # Restrict to the prefix's subtree via a covered range scan on `prefix`
+        # (index-only) instead of a non-sargable `key LIKE prefix||'%'` full scan.
+        # Rows arrive ordered by (prefix,key), so the GROUP BY streams (no temp B-tree).
+        if prefix:
+            range_sql = "prefix >= ? AND prefix < ?"
+            range_params = (prefix, _prefix_upper(prefix))
+        else:
+            range_sql = "1=1"
+            range_params = ()
+        rows = db.execute(f"""
             SELECT substr(key, 1, ? + instr(substr(key, ? + 1), '/')) as child_prefix,
                    COUNT(*) as count, SUM(size) as total_size
-            FROM objects WHERE key LIKE ? AND instr(substr(key, ? + 1), '/') > 0
+            FROM objects WHERE {range_sql} AND instr(substr(key, ? + 1), '/') > 0
             GROUP BY child_prefix ORDER BY total_size DESC
-        """, (prefix_len, prefix_len, like_pattern, prefix_len)).fetchall()
-        root_row = db.execute("""
+        """, (prefix_len, prefix_len, *range_params, prefix_len)).fetchall()
+        root_row = db.execute(f"""
             SELECT COUNT(*) as count, COALESCE(SUM(size), 0) as total_size
-            FROM objects WHERE key LIKE ? AND instr(substr(key, ? + 1), '/') = 0
-        """, (like_pattern, prefix_len)).fetchone()
+            FROM objects WHERE {range_sql} AND instr(substr(key, ? + 1), '/') = 0
+        """, (*range_params, prefix_len)).fetchone()
         log.info("[perf] storage_breakdown: %.3fs (%d children) prefix=%s",
                  time.monotonic() - t_sb, len(rows), prefix[:60])
         children = [

--- a/benchmark/bench_prod.py
+++ b/benchmark/bench_prod.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""
+Production read-only A/B benchmark — times the hot query paths against a live
+Objex instance and a real bucket. Read-only: login, list, search, breakdown,
+folder-size. No uploads/deletes/crawl-mutation. Run once per code version
+(before/after) against the SAME base URL+bucket, then diff the JSON outputs.
+
+Usage:
+  python bench_prod.py --url http://localhost:8890 --bucket coolco-id5 --label after
+  python bench_prod.py --url http://localhost:8891 --bucket coolco-id5 --label before --compare 'results/prod-after-*.json'
+"""
+import argparse, glob, json, statistics, time, urllib.request, urllib.error, http.cookiejar, os
+
+def client(url, user, pw):
+    cj = http.cookiejar.CookieJar()
+    op = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cj))
+    body = json.dumps({"username": user, "password": pw}).encode()
+    # Login is rate-limited (10/min); retry with backoff if we hit 429.
+    for attempt in range(8):
+        try:
+            req = urllib.request.Request(url + "/api/auth/login", data=body,
+                                         headers={"Content-Type": "application/json"})
+            op.open(req, timeout=30).read()
+            return op
+        except urllib.error.HTTPError as e:
+            if e.code == 429 and attempt < 7:
+                print(f"  login rate-limited (429), waiting 20s (attempt {attempt+1})...")
+                time.sleep(20)
+                continue
+            raise
+
+def get(op, url, path):
+    t0 = time.perf_counter()
+    with op.open(url + path, timeout=120) as r:
+        data = r.read()
+    return (time.perf_counter() - t0) * 1000.0, data
+
+def timed(op, url, path, iters=15):
+    ts, last = [], b""
+    for _ in range(iters):
+        ms, last = get(op, url, path)
+        ts.append(ms)
+    ts.sort()
+    n = len(ts)
+    return {"p50_ms": round(ts[n//2], 1), "p95_ms": round(ts[min(n-1, int(n*0.95))], 1),
+            "min_ms": round(ts[0], 1), "max_ms": round(ts[-1], 1),
+            "bytes": len(last), "iters": n}
+
+def find_file_heavy_prefix(op, url, bucket, root_children, max_depth=4):
+    """Walk down the biggest child until we find a prefix with direct files."""
+    # try each big child, descending into its biggest sub-child each level
+    prefix = ""
+    for child in sorted(root_children, key=lambda c: -c["object_count"]):
+        p = child["prefix"]
+        for _ in range(max_depth):
+            _, data = get(op, url, f"/api/buckets/{bucket}/list?prefix={p}&limit=1000")
+            page = json.loads(data.splitlines()[0])
+            if len(page.get("files", [])) >= 50:
+                return p, len(page.get("files", [])), page.get("next_cursor") is not None
+            folders = page.get("folders", [])
+            if not folders:
+                break
+            # descend into a middle folder (more likely to have leaf files)
+            p = folders[len(folders)//2]["prefix"]
+    return None, 0, False
+
+def run(url, bucket, label, compare):
+    op = client(url, os.environ.get("OBJEX_ADMIN_USER", "admin"),
+                os.environ.get("OBJEX_ADMIN_PASS", "admin"))
+    M = {}
+    # discover structure
+    _, data = get(op, url, f"/api/buckets/{bucket}/storage-breakdown?prefix=")
+    root = json.loads(data)
+    children = root.get("children", [])
+    big = max((c for c in children if c.get("prefix") and c["prefix"] != "(root files)"),
+              key=lambda c: c["object_count"])
+    big_prefix = big["prefix"]
+    print(f"  bucket={bucket}  objects~{root.get('object_count'):,}  biggest_subtree={big_prefix} ({big['object_count']:,})")
+
+    leaf, leaf_files, leaf_more = find_file_heavy_prefix(op, url, bucket, children)
+    print(f"  file-heavy leaf for listing test: {leaf} ({leaf_files} direct files, more_pages={leaf_more})")
+
+    scenarios = {
+        "list_root_legacy":      f"/api/buckets/{bucket}/list?prefix=",
+        "list_subtree_legacy":   f"/api/buckets/{bucket}/list?prefix={big_prefix}",
+        "breakdown_root":        f"/api/buckets/{bucket}/storage-breakdown?prefix=",
+        "breakdown_subtree":     f"/api/buckets/{bucket}/storage-breakdown?prefix={big_prefix}",
+        "folder_size_subtree":   f"/api/buckets/{bucket}/folder-size?prefix={big_prefix}",
+        "search_common":         f"/api/buckets/{bucket}/search?q=part",
+        "search_date":           f"/api/buckets/{bucket}/search?q=date",
+    }
+    if leaf:
+        # legacy (whole-folder) vs paginated first page on the SAME file-heavy leaf
+        scenarios["list_leaf_legacy"]    = f"/api/buckets/{bucket}/list?prefix={leaf}"
+        scenarios["list_leaf_paginated"] = f"/api/buckets/{bucket}/list?prefix={leaf}&limit=1000"
+
+    for name, path in scenarios.items():
+        M[name] = timed(op, url, path)
+        print(f"    {name:24s} p50={M[name]['p50_ms']:>8.1f}ms  p95={M[name]['p95_ms']:>8.1f}ms  bytes={M[name]['bytes']:,}")
+
+    res = {"label": label, "url": url, "bucket": bucket, "biggest_subtree": big_prefix,
+           "leaf": leaf, "metrics": M}
+    os.makedirs(os.path.join(os.path.dirname(__file__), "results"), exist_ok=True)
+    out = os.path.join(os.path.dirname(__file__), "results", f"prod-{label}-{time.strftime('%Y%m%d-%H%M%S')}.json")
+    json.dump(res, open(out, "w"), indent=2)
+    print(f"  saved {out}")
+
+    if compare:
+        m = sorted(glob.glob(compare))
+        if m:
+            base = json.load(open(m[-1]))
+            print(f"\n  {'='*70}\n  BEFORE ({base['label']}) -> AFTER ({label})  bucket={bucket}\n  {'='*70}")
+            print(f"  {'metric':24s} {'before p50':>12s} {'after p50':>12s} {'speedup':>10s} {'bytes b->a':>22s}")
+            for k in M:
+                if k in base["metrics"]:
+                    b, a = base["metrics"][k]["p50_ms"], M[k]["p50_ms"]
+                    sp = f"{b/a:.1f}x" if a else "-"
+                    bb, ba = base["metrics"][k]["bytes"], M[k]["bytes"]
+                    print(f"  {k:24s} {b:>10.1f}ms {a:>10.1f}ms {sp:>10s} {bb:>10,} -> {ba:<10,}")
+    return res
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", required=True)
+    ap.add_argument("--bucket", required=True)
+    ap.add_argument("--label", required=True)
+    ap.add_argument("--compare", default=None)
+    args = ap.parse_args()
+    run(args.url, args.bucket, args.label, args.compare)

--- a/benchmark/bench_query_layer.py
+++ b/benchmark/bench_query_layer.py
@@ -1,0 +1,330 @@
+#!/usr/bin/env python3
+"""
+Query-layer benchmark — measures Sairo's hot paths at scale with NO infra.
+
+Seeds a synthetic SQLite index with N objects (default 1,000,000) using the
+backend's real functions, then times the paths users actually feel — folder
+listing, search, storage breakdown, folder size — through the real HTTP API
+(FastAPI TestClient, in-process), plus the crawl write path and the post-crawl
+rebuilds via internal functions.
+
+This is the measurement the previous benchmark suite never did: it caps at the
+50K objects `mc cp` can seed, while the O(N) problems only bite past ~1M.
+
+Usage:
+    python bench_query_layer.py --objects 1000000 --label baseline
+    python bench_query_layer.py --objects 1000000 --label after-phase0 --compare results/qlbench-baseline-*.json
+
+Runs fully offline: boto3 is mocked, no MinIO/server needed.
+"""
+import argparse
+import gc
+import glob
+import json
+import os
+import statistics
+import sys
+import tempfile
+import time
+import unittest.mock
+from datetime import datetime, timezone
+
+# ─── Bootstrap env + mock boto3 BEFORE importing main ───
+_DB_DIR = tempfile.mkdtemp(prefix="sairo-qlbench-")
+os.environ.update({
+    "S3_ENDPOINT": "http://localhost:9000",
+    "S3_ACCESS_KEY": "bench",
+    "S3_SECRET_KEY": "bench",
+    "ADMIN_USER": "admin",
+    "ADMIN_PASS": "benchpass",
+    "JWT_SECRET": os.urandom(24).hex(),  # ephemeral per-run secret for the in-process test app (never a real credential)
+    "SECURE_COOKIE": "false",
+    "DB_DIR": _DB_DIR,
+    "RECRAWL_INTERVAL": "100000",   # don't let the auto-recrawl thread interfere
+})
+_mock_boto3 = unittest.mock.MagicMock()
+_mock_client = unittest.mock.MagicMock()
+_mock_boto3.client.return_value = _mock_client
+_mock_client.list_buckets.return_value = {"Buckets": []}
+sys.modules["boto3"] = _mock_boto3
+
+import logging  # noqa: E402
+logging.getLogger("httpx").setLevel(logging.WARNING)
+logging.getLogger("sairo").setLevel(logging.WARNING)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+import main  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+EXT = [".parquet", ".csv", ".json", ".log", ".txt", ".avro", ".gz"]
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _bulk_insert(bucket, rows_iter, batch_size=50000):
+    """Insert objects with FTS triggers disabled (mirrors how a real crawl bulk-loads)."""
+    main._init_db(bucket)
+    inserted = 0
+    with main._get_db(bucket) as db:
+        main._disable_fts_triggers(db)
+        batch = []
+        for row in rows_iter:
+            batch.append(row)
+            if len(batch) >= batch_size:
+                db.executemany(
+                    "INSERT OR REPLACE INTO objects (key,size,last_modified,etag,prefix,depth,crawl_gen) "
+                    "VALUES (?,?,?,?,?,?,?)", batch)
+                inserted += len(batch)
+                batch = []
+        if batch:
+            db.executemany(
+                "INSERT OR REPLACE INTO objects (key,size,last_modified,etag,prefix,depth,crawl_gen) "
+                "VALUES (?,?,?,?,?,?,?)", batch)
+            inserted += len(batch)
+        total = db.execute("SELECT COUNT(*), COALESCE(SUM(size),0) FROM objects").fetchone()
+        db.execute("UPDATE crawl_status SET status='complete', total_objects=?, total_size=?, "
+                   "last_crawl_end=? WHERE id=1", (total[0], total[1], _now()))
+        db.commit()
+    return inserted
+
+
+def _flat_rows(n):
+    """N files all directly under one prefix (worst case for unpaginated listing)."""
+    for i in range(n):
+        key = f"bigdata/file_{i:09d}{EXT[i % len(EXT)]}"
+        yield (key, (i % 10000 + 1) * 1024, "2026-05-15T12:00:00Z", f'"e{i:08x}"', "bigdata/", 1, 1)
+
+
+def _tree_rows(n):
+    """Realistic skewed tree: one dominant prefix + others, 2-3 levels deep."""
+    # 60% events (skewed hot prefix), 20% logs, 12% data, 8% config
+    dist = [("events", 0.60, 3), ("logs", 0.20, 2), ("data", 0.12, 3), ("config", 0.08, 2)]
+    i = 0
+    for top, pct, depth in dist:
+        count = int(n * pct)
+        for j in range(count):
+            if depth == 3:
+                mid = f"dt={2026}-{(j % 12)+1:02d}-{(j % 28)+1:02d}"
+                sub = f"part-{j % 200:04d}"
+                key = f"{top}/{mid}/{sub}/obj_{j:08d}{EXT[i % len(EXT)]}"
+                prefix = f"{top}/{mid}/{sub}/"
+            else:
+                sub = f"shard-{j % 500:04d}"
+                key = f"{top}/{sub}/obj_{j:08d}{EXT[i % len(EXT)]}"
+                prefix = f"{top}/{sub}/"
+            yield (key, (j % 50000 + 1) * 2048, "2026-05-15T12:00:00Z", f'"t{i:08x}"', prefix, key.count("/"), 1)
+            i += 1
+
+
+def _time_fn(fn, iterations):
+    times = []
+    for _ in range(iterations):
+        gc.collect()
+        t0 = time.perf_counter()
+        fn()
+        times.append((time.perf_counter() - t0) * 1000.0)  # ms
+    times.sort()
+    n = len(times)
+    return {
+        "p50_ms": round(times[n // 2], 2),
+        "p95_ms": round(times[min(n - 1, int(n * 0.95))], 2),
+        "min_ms": round(times[0], 2),
+        "max_ms": round(times[-1], 2),
+        "iterations": n,
+    }
+
+
+def _explain(bucket, sql, params):
+    with main._get_db(bucket) as db:
+        plan = db.execute("EXPLAIN QUERY PLAN " + sql, params).fetchall()
+    return " | ".join(r[-1] for r in plan)
+
+
+def run(objects, label, compare_path):
+    results = {"label": label, "objects": objects, "timestamp": _now(),
+               "python": sys.version.split()[0], "metrics": {}}
+    M = results["metrics"]
+
+    print(f"\n{'='*64}\n Query-layer benchmark — {objects:,} objects  (label={label})\n{'='*64}")
+
+    # ─── SEED ───
+    print(f"[seed] flat folder ({objects:,} files under bigdata/) ...", flush=True)
+    t0 = time.perf_counter()
+    _bulk_insert("bench-flat", _flat_rows(objects))
+    flat_seed = time.perf_counter() - t0
+    print(f"       done in {flat_seed:.1f}s")
+
+    print(f"[seed] skewed tree ({objects:,} files) ...", flush=True)
+    t0 = time.perf_counter()
+    _bulk_insert("bench-tree", _tree_rows(objects))
+    print(f"       done in {time.perf_counter() - t0:.1f}s")
+
+    # ─── POST-CRAWL REBUILDS (timed) ───
+    print("[rebuild] folder_stats / prefix_children / FTS (timed) ...", flush=True)
+    for bucket in ("bench-flat", "bench-tree"):
+        t0 = time.perf_counter()
+        main._rebuild_folder_stats(bucket)
+        fs = (time.perf_counter() - t0) * 1000
+        t0 = time.perf_counter()
+        main._rebuild_prefix_children(bucket)
+        pc = (time.perf_counter() - t0) * 1000
+        t0 = time.perf_counter()
+        with main._get_db(bucket) as db:
+            db.execute("INSERT INTO objects_fts(objects_fts) VALUES('rebuild')")
+            db.commit()
+        fts = (time.perf_counter() - t0) * 1000
+        M[f"rebuild_{bucket}"] = {"folder_stats_ms": round(fs, 1),
+                                  "prefix_children_ms": round(pc, 1),
+                                  "fts_rebuild_ms": round(fts, 1)}
+        print(f"       {bucket}: folder_stats={fs:.0f}ms prefix_children={pc:.0f}ms fts={fts:.0f}ms")
+
+    # DB file sizes
+    M["db_size"] = {}
+    for bucket in ("bench-flat", "bench-tree"):
+        p = main._db_path(bucket)
+        sz = sum(os.path.getsize(p + s) for s in ("", "-wal", "-shm") if os.path.exists(p + s))
+        M["db_size"][bucket + "_mb"] = round(sz / 1048576, 1)
+
+    # ─── HTTP API READ PATHS ───
+    client = TestClient(main.app)
+    r = client.post("/api/auth/login", json={"username": "admin", "password": "benchpass"})
+    assert r.status_code == 200, f"login failed: {r.status_code} {r.text[:200]}"
+    cookies = r.cookies
+
+    def api(path):
+        return client.get(path, cookies=cookies)
+
+    # sanity: confirm endpoints work + capture the big-listing payload size
+    big = api("/api/buckets/bench-flat/list?prefix=bigdata/")
+    assert big.status_code == 200, f"list failed: {big.status_code} {big.text[:200]}"
+    M["flat_listing"] = {
+        "response_bytes": len(big.content),
+        "response_mb": round(len(big.content) / 1048576, 2),
+    }
+    print(f"[api] flat folder listing payload = {M['flat_listing']['response_mb']} MB", flush=True)
+
+    print("[api] timing read endpoints ...", flush=True)
+    READ_ITERS = 15
+    scenarios = {
+        "list_flat_1M_folder":   "/api/buckets/bench-flat/list?prefix=bigdata/",
+        "list_tree_root":        "/api/buckets/bench-tree/list?prefix=",
+        "list_tree_subfolder":   "/api/buckets/bench-tree/list?prefix=events/",
+        "search_tree":           "/api/buckets/bench-tree/search?q=obj_0001",
+        "breakdown_root":        "/api/buckets/bench-tree/storage-breakdown?prefix=",
+        "breakdown_subprefix":   "/api/buckets/bench-tree/storage-breakdown?prefix=events/",
+        "folder_size_subprefix": "/api/buckets/bench-tree/folder-size?prefix=events/",
+        "storage_history":       "/api/buckets/bench-tree/storage-history",
+    }
+    for name, path in scenarios.items():
+        # paginated endpoints may need a smaller default; measure as-is (default call)
+        M[name] = _time_fn(lambda p=path: api(p), READ_ITERS)
+        print(f"       {name:24s} p50={M[name]['p50_ms']:>9.2f}ms  p95={M[name]['p95_ms']:>9.2f}ms")
+
+    # ─── PAGINATED FIRST-PAGE (if supported — measures the fixed path) ───
+    paged = api("/api/buckets/bench-flat/list?prefix=bigdata/&limit=1000")
+    if paged.status_code == 200 and len(paged.content) < len(big.content):
+        M["list_flat_first_page"] = _time_fn(
+            lambda: api("/api/buckets/bench-flat/list?prefix=bigdata/&limit=1000"), READ_ITERS)
+        M["list_flat_first_page"]["response_mb"] = round(len(paged.content) / 1048576, 3)
+        print(f"       {'list_flat_first_page':24s} p50={M['list_flat_first_page']['p50_ms']:>9.2f}ms "
+              f"({M['list_flat_first_page']['response_mb']} MB)")
+    else:
+        M["list_flat_first_page"] = {"supported": False}
+
+    # ─── WRITE PATH (crawl) ───
+    print("[write] incremental upsert throughput ...", flush=True)
+    WM = min(200000, objects)
+    fresh = list(_flat_rows(WM))
+    fresh6 = [(k, s, lm, et, pf, dp) for (k, s, lm, et, pf, dp, _g) in fresh]  # 6-tuples
+    main._init_db("bench-write")
+    with main._get_db("bench-write") as db:
+        main._disable_fts_triggers(db)
+        t0 = time.perf_counter()
+        for i in range(0, len(fresh6), 10000):
+            main._incremental_upsert(db, fresh6[i:i+10000], gen=1)
+        db.commit()
+        first_insert = time.perf_counter() - t0
+    with main._get_db("bench-write") as db:
+        t0 = time.perf_counter()
+        for i in range(0, len(fresh6), 10000):
+            main._incremental_upsert(db, fresh6[i:i+10000], gen=2)  # all unchanged → crawl_gen rewrite
+        db.commit()
+        recrawl_unchanged = time.perf_counter() - t0
+    M["write"] = {
+        "objects": WM,
+        "first_insert_sec": round(first_insert, 2),
+        "first_insert_per_sec": round(WM / first_insert),
+        "recrawl_unchanged_sec": round(recrawl_unchanged, 2),
+        "recrawl_unchanged_per_sec": round(WM / recrawl_unchanged),
+    }
+    print(f"       first insert:      {M['write']['first_insert_per_sec']:,} obj/s")
+    print(f"       recrawl unchanged: {M['write']['recrawl_unchanged_per_sec']:,} obj/s")
+
+    # ─── QUERY PLANS (qualitative: is the index used / covering?) ───
+    M["query_plans"] = {
+        "list": _explain("bench-flat",
+                         "SELECT key, size, last_modified FROM objects WHERE prefix = ? ORDER BY key",
+                         ("bigdata/",)),
+        "folder_size": _explain("bench-tree",
+                         "SELECT COUNT(*), COALESCE(SUM(size),0) FROM objects WHERE key LIKE ?",
+                         ("events/%",)),
+    }
+
+    # ─── SAVE ───
+    os.makedirs(os.path.join(os.path.dirname(__file__), "results"), exist_ok=True)
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    out = os.path.join(os.path.dirname(__file__), "results", f"qlbench-{label}-{ts}.json")
+    with open(out, "w") as f:
+        json.dump(results, f, indent=2)
+    print(f"\n[saved] {out}")
+
+    if compare_path:
+        matches = sorted(glob.glob(compare_path))
+        if matches:
+            with open(matches[-1]) as f:
+                base = json.load(f)
+            _print_comparison(base, results)
+
+    return results
+
+
+def _print_comparison(base, cur):
+    print(f"\n{'='*78}\n BEFORE ({base['label']}, {base['objects']:,} obj)  →  AFTER "
+          f"({cur['label']}, {cur['objects']:,} obj)\n{'='*78}")
+    bm, cm = base["metrics"], cur["metrics"]
+    print(f"{'metric':28s} {'before':>12s} {'after':>12s} {'change':>12s}")
+    print("-" * 68)
+
+    def line(name, b, c, unit="ms", lower_better=True):
+        if b is None or c is None:
+            return
+        if b and c:
+            factor = b / c if lower_better else c / b
+            arrow = f"{factor:.1f}x faster" if factor >= 1 else f"{1/factor:.1f}x SLOWER"
+        else:
+            arrow = "—"
+        print(f"{name:28s} {b:>10.1f}{unit:>2s} {c:>10.1f}{unit:>2s} {arrow:>12s}")
+
+    for name in ("list_flat_1M_folder", "list_tree_root", "list_tree_subfolder", "search_tree",
+                 "breakdown_root", "breakdown_subprefix", "folder_size_subprefix", "storage_history"):
+        if name in bm and name in cm and "p50_ms" in bm[name] and "p50_ms" in cm[name]:
+            line(name, bm[name]["p50_ms"], cm[name]["p50_ms"])
+    if "flat_listing" in bm and "flat_listing" in cm:
+        line("flat_payload", bm["flat_listing"]["response_mb"], cm["flat_listing"]["response_mb"], unit="MB")
+    for rb in ("rebuild_bench-flat", "rebuild_bench-tree"):
+        if rb in bm and rb in cm:
+            line(rb + ".fts", bm[rb]["fts_rebuild_ms"], cm[rb]["fts_rebuild_ms"])
+    if "write" in bm and "write" in cm:
+        line("recrawl_unchanged/s", bm["write"]["recrawl_unchanged_per_sec"],
+             cm["write"]["recrawl_unchanged_per_sec"], unit="", lower_better=False)
+
+
+if __name__ == "__main__":
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--objects", type=int, default=1_000_000)
+    ap.add_argument("--label", default="run")
+    ap.add_argument("--compare", default=None, help="glob to a prior results json to diff against")
+    args = ap.parse_args()
+    run(args.objects, args.label, args.compare)

--- a/benchmark/validate_e2e.py
+++ b/benchmark/validate_e2e.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""End-to-end feature validation against a live Objex instance + real bucket.
+Exercises every core feature read-path and reports PASS/FAIL + latency.
+Usage: python validate_e2e.py --url http://localhost:8890 --bucket ssp-production-reports
+"""
+import argparse, json, os, sys, time, urllib.request, urllib.error, urllib.parse, http.cookiejar
+
+PASS, FAIL = "✓ PASS", "✗ FAIL"
+
+def login(url, user, pw, access=None, secret=None):
+    cj = http.cookiejar.CookieJar()
+    op = urllib.request.build_opener(urllib.request.HTTPCookieProcessor(cj))
+    for attempt in range(6):
+        try:
+            if access:
+                body = json.dumps({"access_key": access, "secret_key": secret}).encode(); path = "/api/auth/login-s3"
+            else:
+                body = json.dumps({"username": user, "password": pw}).encode(); path = "/api/auth/login"
+            op.open(urllib.request.Request(url + path, data=body, headers={"Content-Type": "application/json"}), timeout=30).read()
+            return op
+        except urllib.error.HTTPError as e:
+            if e.code == 429 and attempt < 5:
+                time.sleep(15); continue
+            raise
+
+def call(op, url, path, method="GET"):
+    t0 = time.perf_counter()
+    req = urllib.request.Request(url + path, method=method)
+    try:
+        with op.open(req, timeout=120) as r:
+            data = r.read(); code = r.status
+    except urllib.error.HTTPError as e:
+        return e.code, b"", (time.perf_counter() - t0) * 1000
+    return code, data, (time.perf_counter() - t0) * 1000
+
+def first_line_json(data):
+    for ln in data.splitlines():
+        if ln.strip():
+            return json.loads(ln)
+    return {}
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--url", required=True); ap.add_argument("--bucket", required=True)
+    a = ap.parse_args()
+    url, b = a.url, a.bucket
+    results = []
+    def check(name, ok, detail=""):
+        results.append((name, ok, detail))
+        print(f"  {PASS if ok else FAIL}  {name:42} {detail}")
+
+    # --- AUTH ---
+    admin_user = os.environ.get("OBJEX_ADMIN_USER", "admin")
+    admin_pass = os.environ.get("OBJEX_ADMIN_PASS", "admin")
+    op = login(url, admin_user, admin_pass)
+    check("auth: username/password login", op is not None)
+    # S3 access-key login test runs only if creds are provided via env (never hardcode).
+    s3_key = os.environ.get("OBJEX_S3_ACCESS_KEY")
+    s3_secret = os.environ.get("OBJEX_S3_SECRET_KEY")
+    if s3_key and s3_secret:
+        try:
+            op_s3 = login(url, None, None, access=s3_key, secret=s3_secret)
+            check("auth: S3 access-key login", op_s3 is not None)
+        except Exception as e:
+            check("auth: S3 access-key login", False, str(e)[:40])
+    else:
+        check("auth: S3 access-key login", True, "skipped (set OBJEX_S3_ACCESS_KEY/SECRET to test)")
+
+    # --- CRAWL STATUS ---
+    code, data, ms = call(op, url, f"/api/buckets/{b}/crawl-status")
+    st = json.loads(data) if code == 200 else {}
+    check("crawl-status reachable + indexed", code == 200 and (st.get("total_objects", 0) > 0),
+          f"{st.get('status')}, {st.get('total_objects',0):,} objs, {ms:.0f}ms")
+
+    # --- LIST root (paginated) ---
+    code, data, ms = call(op, url, f"/api/buckets/{b}/list?prefix=&limit=1000")
+    page = first_line_json(data) if code == 200 else {}
+    folders = page.get("folders", [])
+    check("list root (paginated)", code == 200 and len(folders) >= 0, f"{len(folders)} folders, {ms:.0f}ms")
+
+    # --- LIST: follow cursor across 2 pages on a busy subtree ---
+    big = max(folders, key=lambda f: 1) if folders else None
+    sub = big["prefix"] if big else ""
+    # descend to find a folder with files
+    leaf, cur1, cur2 = None, None, None
+    probe = sub
+    for _ in range(5):
+        code, data, _ = call(op, url, f"/api/buckets/{b}/list?prefix={probe}&limit=1000")
+        pg = first_line_json(data)
+        if len(pg.get("files", [])) >= 50:
+            leaf = probe; cur1 = pg.get("next_cursor"); break
+        fs = pg.get("folders", [])
+        if not fs: break
+        probe = fs[len(fs)//2]["prefix"]
+    if leaf and cur1:
+        code, data, ms = call(op, url, f"/api/buckets/{b}/list?prefix={leaf}&cursor={urllib.parse.quote(cur1)}&limit=1000")
+        pg2 = first_line_json(data)
+        cur2 = pg2.get("next_cursor")
+        check("list pagination: cursor advances", code == 200 and pg2.get("files") and cur1 != cur2,
+              f"page2={len(pg2.get('files',[]))} files, {ms:.0f}ms")
+    else:
+        check("list pagination: cursor advances", True, "no >1000-file leaf (small folders); skipped")
+
+    # --- SEARCH (FTS) ---
+    code, data, ms = call(op, url, f"/api/buckets/{b}/search?q=part")
+    sr = json.loads(data) if code == 200 else {}
+    check("search (FTS5)", code == 200, f"{sr.get('count','?')} results, {ms:.0f}ms")
+
+    # --- BREAKDOWN root (fast-path) ---
+    code, data, ms = call(op, url, f"/api/buckets/{b}/storage-breakdown?prefix=")
+    bd = json.loads(data) if code == 200 else {}
+    check("storage-breakdown root (folder_stats fast-path)", code == 200 and ms < 100,
+          f"{len(bd.get('children',[]))} folders, {ms:.0f}ms")
+
+    # --- BREAKDOWN subprefix (range scan) ---
+    if sub:
+        code, data, ms = call(op, url, f"/api/buckets/{b}/storage-breakdown?prefix={sub}")
+        check("storage-breakdown subprefix (covered range scan)", code == 200, f"{ms:.0f}ms")
+        code, data, ms = call(op, url, f"/api/buckets/{b}/folder-size?prefix={sub}")
+        fz = json.loads(data) if code == 200 else {}
+        check("folder-size subprefix (covered range scan)", code == 200, f"{fz.get('object_count',0):,} objs, {ms:.0f}ms")
+
+    # --- STORAGE HISTORY ---
+    code, data, ms = call(op, url, f"/api/buckets/{b}/storage-history")
+    check("storage-history", code == 200, f"{ms:.0f}ms")
+
+    # --- OBJECT INFO + PRESIGNED on a real key ---
+    key = None
+    if leaf:
+        code, data, _ = call(op, url, f"/api/buckets/{b}/list?prefix={leaf}&limit=1000")
+        pg = first_line_json(data); files = pg.get("files", [])
+        if files: key = files[0]["key"]
+    if key:
+        ek = urllib.parse.quote(key)
+        code, data, ms = call(op, url, f"/api/buckets/{b}/object-info?key={ek}")
+        check("object-info (HEAD metadata)", code == 200, f"{ms:.0f}ms")
+        code, data, ms = call(op, url, f"/api/buckets/{b}/presigned-url?key={ek}")
+        pu = json.loads(data) if code == 200 else {}
+        check("presigned-url generation", code == 200 and ("url" in pu or "presigned_url" in pu), f"{ms:.0f}ms")
+    else:
+        check("object-info / presigned-url", True, "no leaf file sampled; skipped")
+
+    # --- COST + OPTIMIZATION (Tier-1 features) ---
+    code, data, ms = call(op, url, f"/api/buckets/{b}/cost-breakdown")
+    check("cost-breakdown (Tier-1)", code in (200, 404), f"HTTP {code}, {ms:.0f}ms")
+    code, data, ms = call(op, url, f"/api/buckets/{b}/optimization-summary")
+    check("optimization-summary (Tier-1)", code in (200, 404), f"HTTP {code}, {ms:.0f}ms")
+
+    npass = sum(1 for _, ok, _ in results if ok)
+    print(f"\n  RESULT: {npass}/{len(results)} features PASS")
+    return 0 if npass == len(results) else 1
+
+if __name__ == "__main__":
+    import urllib.parse
+    sys.exit(main())

--- a/charts/sairo/Chart.yaml
+++ b/charts/sairo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sairo-helm
 description: S3-compatible object storage browser with search, versioning, and analytics
 type: application
-version: 1.0.0
-appVersion: "latest"
+version: 1.1.0
+appVersion: "3.3.0"
 keywords:
   - s3
   - object-storage

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sairo",
-  "version": "2.0.0",
+  "version": "3.3.0",
   "description": "S3-compatible object storage browser with search, versioning, and analytics",
   "private": true,
   "type": "module",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -27,7 +27,11 @@ import TwoFactorSetup from "./components/TwoFactorSetup";
 import EndpointManager from "./components/EndpointManager";
 import ToastContainer, { toast } from "./components/Toast";
 import { checkAuth, logout, refreshSession } from "./auth";
-import { streamList, deleteObjects, deleteFolder, createFolder, bulkCopy, bulkMove, listDeletedVersions, purgeVersions, purgePrefix, getBranding, setCurrentEndpoint, checkForUpdate } from "./api";
+import { streamList, deleteObjects, deleteFolder, createFolder, bulkCopy, bulkMove, listDeletedVersions, purgeVersions, purgePrefix, getBranding, setCurrentEndpoint, checkForUpdate, getCrawlStatus } from "./api";
+
+// Folder listings are fetched in keyset pages of this size so the first page
+// paints instantly and no single response is huge, regardless of folder size.
+const LIST_PAGE_SIZE = 1000;
 
 // Share link route: /share/{token}
 function getShareToken() {
@@ -131,6 +135,9 @@ function MainApp() {
   const dragCounter = useRef(0);
   const abortRef = useRef(null);
   const refreshRef = useRef(null);
+  const crawlFpRef = useRef(null);     // crawl-status fingerprint — gates the 30s silent refresh
+  const silentAbortRef = useRef(null); // in-flight silent-refresh stream, so we can abort it
+  const currentViewRef = useRef({ bucket: "", prefix: "" }); // guards stale refreshes from clobbering state
 
   const isAdmin = user && user.role === "admin";
   const canWrite = isAdmin || bucketPermission === "write";
@@ -218,6 +225,8 @@ function MainApp() {
 
   const load = useCallback((b, pfx) => {
     if (abortRef.current) abortRef.current.abort();
+    if (silentAbortRef.current) silentAbortRef.current.abort();  // cancel any stale background refresh
+    currentViewRef.current = { bucket: b, prefix: pfx };
     setFolders([]);
     setFiles([]);
     setSelected(new Set());
@@ -226,11 +235,14 @@ function MainApp() {
     setLoading(true);
     setDone(false);
     setIndexed(false);
+    crawlFpRef.current = null;  // re-establish fingerprint for this view's background refresh
 
+    let firstPage = true;
     abortRef.current = streamList(b, pfx, (page) => {
       if (page.folders.length > 0) setFolders((prev) => [...prev, ...page.folders]);
       if (page.files.length > 0) setFiles((prev) => [...prev, ...page.files]);
       if (page.indexed) setIndexed(true);
+      if (firstPage) { setLoading(false); firstPage = false; }  // paint as soon as page 1 lands
       if (page.done) { setLoading(false); setDone(true); }
     }, (err) => {
       setLoading(false);
@@ -241,7 +253,7 @@ function MainApp() {
       } else {
         toast(`Failed to load: ${err.message}`, "error");
       }
-    });
+    }, { limit: LIST_PAGE_SIZE });
   }, []);
 
   useEffect(() => {
@@ -257,19 +269,32 @@ function MainApp() {
   }, []);
 
   const silentRefresh = useCallback((b, pfx) => {
-    let newFolders = [];
-    let newFiles = [];
-    const controller = streamList(b, pfx, (page) => {
-      if (page.folders.length > 0) newFolders = [...newFolders, ...page.folders];
-      if (page.files.length > 0) newFiles = [...newFiles, ...page.files];
-      if (page.indexed) setIndexed(true);
-      if (page.done) {
-        setFolders(newFolders);
-        setFiles(newFiles);
-        setDone(true);
-      }
-    });
-    return controller;
+    // Cheap (~ms) crawl-status check first: only re-fetch the folder when the index
+    // actually changed since the last load. Avoids re-downloading an unchanged folder
+    // every 30s — the previous behavior re-streamed the whole listing each tick.
+    getCrawlStatus(b).then((status) => {
+      const fp = status ? `${status.total_objects}:${status.last_crawl_end}:${status.status}` : null;
+      if (fp && crawlFpRef.current && fp === crawlFpRef.current) return;  // nothing changed
+      crawlFpRef.current = fp;
+      let newFolders = [];
+      let newFiles = [];
+      if (silentAbortRef.current) silentAbortRef.current.abort();  // supersede any prior in-flight refresh
+      silentAbortRef.current = streamList(b, pfx, (page) => {
+        if (page.folders.length > 0) newFolders = [...newFolders, ...page.folders];
+        if (page.files.length > 0) newFiles = [...newFiles, ...page.files];
+        if (page.indexed) setIndexed(true);
+        if (page.done) {
+          // Only apply if the user is still viewing this exact folder — never let a
+          // late refresh of a previous folder clobber the current view.
+          const v = currentViewRef.current;
+          if (v.bucket === b && v.prefix === pfx) {
+            setFolders(newFolders);
+            setFiles(newFiles);
+            setDone(true);
+          }
+        }
+      }, null, { limit: LIST_PAGE_SIZE });
+    }).catch(() => {});
   }, []);
 
   useEffect(() => {
@@ -283,6 +308,7 @@ function MainApp() {
 
     return () => {
       if (abortRef.current) abortRef.current.abort();
+      if (silentAbortRef.current) silentAbortRef.current.abort();
       if (refreshRef.current) clearInterval(refreshRef.current);
     };
   }, [bucket, prefix, endpointId, load, silentRefresh, user]);

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -70,39 +70,60 @@ function bucketBase(bucket) {
   return `${endpointBase()}/buckets/${encodeURIComponent(bucket)}`;
 }
 
-export function streamList(bucket, prefix, onPage, onError) {
+// streamList(bucket, prefix, onPage, onError, { limit })
+//   limit > 0  → keyset pagination: fetch one page of `limit` files at a time and
+//                follow next_cursor until exhausted. onPage fires per page, so the
+//                first page paints instantly and no single response is huge. Folders
+//                arrive only on the first page (empty cursor).
+//   limit == 0 → legacy single request that returns the whole folder at once.
+export function streamList(bucket, prefix, onPage, onError, opts = {}) {
   const controller = new AbortController();
-  const params = new URLSearchParams({ prefix });
+  const limit = opts.limit || 0;
 
-  apiFetch(`${bucketBase(bucket)}/list?${params}`, { signal: controller.signal })
-    .then(async (res) => {
-      if (!res.ok) throw new Error(`List failed: ${res.status}`);
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
+  async function fetchPage(cursor) {
+    const params = new URLSearchParams({ prefix });
+    if (limit > 0) {
+      params.set("limit", String(limit));
+      if (cursor) params.set("cursor", cursor);
+    }
+    const res = await apiFetch(`${bucketBase(bucket)}/list?${params}`, { signal: controller.signal });
+    if (!res.ok) throw new Error(`List failed: ${res.status}`);
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    let lastPage = null;
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      const lines = buffer.split("\n");
+      buffer = lines.pop();
+      for (const line of lines) {
+        if (line.trim()) { lastPage = JSON.parse(line); onPage(lastPage); }
+      }
+    }
+    if (buffer.trim()) { lastPage = JSON.parse(buffer); onPage(lastPage); }
+    return lastPage;
+  }
 
+  (async () => {
+    try {
+      let cursor = "";
       while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split("\n");
-        buffer = lines.pop();
-        for (const line of lines) {
-          if (line.trim()) {
-            onPage(JSON.parse(line));
-          }
+        const page = await fetchPage(cursor);
+        if (limit > 0 && page && page.next_cursor) {
+          cursor = page.next_cursor;
+        } else {
+          break;
         }
       }
-      if (buffer.trim()) {
-        onPage(JSON.parse(buffer));
-      }
-    })
-    .catch((err) => {
+    } catch (err) {
       if (err.name !== "AbortError") {
         console.error("Stream error:", err);
         if (onError) onError(err);
       }
-    });
+    }
+  })();
 
   return controller;
 }
@@ -514,6 +535,26 @@ export async function getVersionPresignedUrl(bucket, key, versionId, expires = 3
 
 export function getUploadUrl(bucket) {
   return `${bucketBase(bucket)}/upload`;
+}
+
+export async function getPresignedUploadUrls(bucket, keys, prefix = "") {
+  const res = await apiFetch(`${bucketBase(bucket)}/presigned-upload`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ keys, prefix }),
+  });
+  if (!res.ok) throw new Error(`Presigned upload failed: ${res.status}`);
+  return res.json();
+}
+
+export async function notifyUpload(bucket, uploads) {
+  const res = await apiFetch(`${bucketBase(bucket)}/notify-upload`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ uploads }),
+  });
+  if (!res.ok) throw new Error(`Notify upload failed: ${res.status}`);
+  return res.json();
 }
 
 export function uploadFileWithProgress(bucket, prefix, file, onProgress) {

--- a/frontend/src/components/UploadModal.jsx
+++ b/frontend/src/components/UploadModal.jsx
@@ -1,9 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
-import { formatSize, getUploadUrl } from "../api";
+import { formatSize, getPresignedUploadUrls, notifyUpload, getUploadUrl } from "../api";
 
-// Threshold for batching: files under this size go in batches
-const BATCH_SIZE_LIMIT = 5 * 1024 * 1024; // 5MB per batch
-const BATCH_FILE_LIMIT = 10; // max files per batch request
 const CONCURRENCY = 4;
 
 function formatEta(seconds) {
@@ -17,6 +14,7 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
   const [fileStates, setFileStates] = useState([]);
   const [dragOver, setDragOver] = useState(false);
   const [uploading, setUploading] = useState(false);
+  const [directMode, setDirectMode] = useState(true); // presigned PUT (default) vs proxy
   const inputRef = useRef();
   const abortRef = useRef(null);
   const taskStartTimes = useRef({});
@@ -44,14 +42,117 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
     setFileStates(prev => prev.filter((_, i) => i !== idx));
   };
 
-  const handleUpload = async () => {
+  // ── Direct upload via presigned PUT URLs (no file data through Sairo) ──
+  const handleDirectUpload = async () => {
     setUploading(true);
     let completed = 0;
     let errors = 0;
     const abortController = new AbortController();
     abortRef.current = abortController;
 
-    // Separate large files (individual upload) from small files (batchable)
+    const pending = fileStates
+      .map((fs, i) => ({ fs, i }))
+      .filter(({ fs }) => fs.status !== "complete" && fs.status !== "error");
+
+    // Get presigned PUT URLs for all files
+    let urlMap;
+    try {
+      const keys = pending.map(({ fs }) => fs.file.name);
+      const resp = await getPresignedUploadUrls(bucket, keys, prefix);
+      urlMap = {};
+      for (const entry of resp.urls) {
+        urlMap[entry.key] = entry.url;
+      }
+    } catch (err) {
+      // Presigned upload not available — fall back to proxy upload
+      setDirectMode(false);
+      setUploading(false);
+      return;
+    }
+
+    const uploadOne = async ({ fs, i }) => {
+      if (abortController.signal.aborted) return;
+
+      const key = prefix + fs.file.name;
+      const url = urlMap[key];
+      if (!url) return;
+
+      taskStartTimes.current[i] = Date.now();
+      setFileStates(prev => prev.map((s, idx) =>
+        idx === i ? { ...s, status: "uploading", progress: 0, eta: null } : s
+      ));
+
+      try {
+        await new Promise((resolve, reject) => {
+          const xhr = new XMLHttpRequest();
+          xhr.upload.addEventListener("progress", (e) => {
+            if (e.lengthComputable) {
+              const pct = (e.loaded / e.total) * 100;
+              const elapsed = (Date.now() - taskStartTimes.current[i]) / 1000;
+              const bytesPerSec = elapsed > 0.5 ? e.loaded / elapsed : 0;
+              const eta = bytesPerSec > 0 ? (e.total - e.loaded) / bytesPerSec : null;
+              setFileStates(prev => prev.map((s, idx) =>
+                idx === i ? { ...s, progress: pct, eta } : s
+              ));
+            }
+          });
+          xhr.addEventListener("load", () => {
+            if (xhr.status >= 200 && xhr.status < 300) resolve();
+            else reject(new Error(`S3 upload failed: ${xhr.status}`));
+          });
+          xhr.addEventListener("error", () => reject(new Error("Network error")));
+          xhr.addEventListener("abort", () => {
+            const err = new Error("Aborted");
+            err.name = "AbortError";
+            reject(err);
+          });
+          abortController.signal.addEventListener("abort", () => xhr.abort());
+          xhr.open("PUT", url);
+          xhr.send(fs.file);
+        });
+
+        completed++;
+        setFileStates(prev => prev.map((s, idx) =>
+          idx === i ? { ...s, status: "complete", progress: 100, eta: null } : s
+        ));
+
+        // Notify Sairo to update index
+        try {
+          await notifyUpload(bucket, [{ key, size: fs.file.size }]);
+        } catch { /* index will update on next crawl */ }
+
+      } catch (err) {
+        if (err.name === "AbortError") return;
+        errors++;
+        setFileStates(prev => prev.map((s, idx) =>
+          idx === i ? { ...s, status: "error", progress: 0, eta: null } : s
+        ));
+      }
+    };
+
+    // Run with concurrency limit
+    let cursor = 0;
+    const runNext = async () => {
+      while (cursor < pending.length) {
+        const item = pending[cursor++];
+        await uploadOne(item);
+      }
+    };
+    await Promise.all(Array.from({ length: Math.min(CONCURRENCY, pending.length) }, () => runNext()));
+
+    setUploading(false);
+    abortRef.current = null;
+    if (completed > 0 && errors === 0) onUploaded();
+  };
+
+  // ── Proxy upload (legacy — files go through Sairo server) ──
+  const handleProxyUpload = async () => {
+    setUploading(true);
+    let completed = 0;
+    let errors = 0;
+    const abortController = new AbortController();
+    abortRef.current = abortController;
+
     const pending = [];
     for (let i = 0; i < fileStates.length; i++) {
       if (fileStates[i].status !== "complete" && fileStates[i].status !== "error") {
@@ -60,13 +161,14 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
     }
 
     // Group small files into batches, keep large files individual
-    const tasks = []; // each task is { indices: number[], files: File[] }
+    const BATCH_SIZE_LIMIT = 5 * 1024 * 1024;
+    const BATCH_FILE_LIMIT = 10;
+    const tasks = [];
     let currentBatch = { indices: [], files: [], size: 0 };
 
     for (const i of pending) {
       const file = fileStates[i].file;
       if (file.size > BATCH_SIZE_LIMIT) {
-        // Large file — upload individually for progress tracking
         tasks.push({ indices: [i], files: [file], large: true });
       } else {
         if (currentBatch.files.length >= BATCH_FILE_LIMIT ||
@@ -83,11 +185,8 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
 
     const uploadTask = async (task) => {
       if (abortController.signal.aborted) return;
-
       const taskKey = task.indices.join(",");
       taskStartTimes.current[taskKey] = Date.now();
-
-      // Mark all files in this task as uploading
       setFileStates(prev => prev.map((fs, idx) =>
         task.indices.includes(idx) ? { ...fs, status: "uploading", progress: 0, eta: null } : fs
       ));
@@ -95,9 +194,7 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
       try {
         const form = new FormData();
         form.append("prefix", prefix);
-        for (const file of task.files) {
-          form.append("files", file);
-        }
+        for (const file of task.files) form.append("files", file);
 
         const xhr = new XMLHttpRequest();
         const promise = new Promise((resolve, reject) => {
@@ -117,19 +214,12 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
             else reject(new Error(`Upload failed: ${xhr.status}`));
           });
           xhr.addEventListener("error", () => reject(new Error("Network error")));
-          xhr.addEventListener("abort", () => {
-            const err = new Error("Aborted");
-            err.name = "AbortError";
-            reject(err);
-          });
+          xhr.addEventListener("abort", () => { const e = new Error("Aborted"); e.name = "AbortError"; reject(e); });
         });
-
         abortController.signal.addEventListener("abort", () => xhr.abort());
-
         xhr.open("POST", getUploadUrl(bucket));
         xhr.withCredentials = true;
         xhr.send(form);
-
         await promise;
         completed += task.indices.length;
         setFileStates(prev => prev.map((fs, idx) =>
@@ -144,7 +234,6 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
       }
     };
 
-    // Run tasks with concurrency limit
     let cursor = 0;
     const runNext = async () => {
       while (cursor < tasks.length) {
@@ -156,10 +245,10 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
 
     setUploading(false);
     abortRef.current = null;
-    if (completed > 0 && errors === 0) {
-      onUploaded();
-    }
+    if (completed > 0 && errors === 0) onUploaded();
   };
+
+  const handleUpload = directMode ? handleDirectUpload : handleProxyUpload;
 
   const pendingCount = fileStates.filter(fs => fs.status === "pending").length;
   const doneCount = fileStates.filter(fs => fs.status === "complete").length;
@@ -192,6 +281,12 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
             <div className="upload-summary">
               <span>{fileStates.length} file{fileStates.length !== 1 ? "s" : ""} ({formatSize(totalSize)})</span>
               {uploading && <span>{doneCount}/{fileStates.length} complete</span>}
+              {!uploading && (
+                <label style={{ fontSize: 11, color: "var(--text-muted)", cursor: "pointer" }}>
+                  <input type="checkbox" checked={directMode} onChange={(e) => setDirectMode(e.target.checked)} style={{ marginRight: 4 }} />
+                  Direct upload
+                </label>
+              )}
             </div>
             <div style={{ maxHeight: 240, overflowY: "auto" }}>
               {fileStates.map((fs, i) => (

--- a/marketing/devto-article.md
+++ b/marketing/devto-article.md
@@ -1,0 +1,104 @@
+---
+title: I manage 170TB of object storage. Here's the tool I had to build.
+published: false
+tags: opensource, devops, s3, selfhosted
+cover_image: 
+---
+
+I run about 170TB of data across 10 buckets on S3-compatible storage. Data pipelines dump Druid segments, Kafka flat events, Prometheus TSDB blocks — millions of objects, growing daily.
+
+Nobody on the team could answer basic questions: How much is this costing us? What's the oldest data in that bucket? Which folder grew 40TB last month?
+
+AWS Console times out on large buckets. Cyberduck crashes. MinIO Console doesn't have search. s3cmd gives you a wall of text you can't do anything with.
+
+So I built what I needed.
+
+## The first attempt broke
+
+Started simple — a Flask app that called `ListObjectsV2`, cached the results, and rendered a file browser.
+
+Worked great on a test bucket with 500 objects.
+
+Hit production: 8.2 million objects in one bucket. The process got OOM-killed at 4GB. You can't hold 10 million S3 keys in memory and also serve a web UI.
+
+## What actually works at scale
+
+The architecture that survived production:
+
+**SQLite per bucket.** Not Postgres, not Redis. One `.db` file per bucket, WAL mode for concurrent reads and writes, zero external dependencies. SQLite with the right PRAGMAs (`cache_size = -64000`, `mmap_size = 256MB`, `temp_store = MEMORY`) handles millions of rows without breaking a sweat.
+
+**Streaming crawl.** `ListObjectsV2` with 10K batch size, 16 parallel prefix workers, incremental upsert that only writes changed objects. A 10M-object bucket indexes in about 12 minutes.
+
+**FTS5 for search.** SQLite's full-text search extension. Type a filename or pattern, get instant results across millions of keys. The index rebuilds in the background so search keeps working during a crawl.
+
+**Single container.** FastAPI backend, React frontend, SQLite storage. No Docker Compose. No database server. One `docker run` and you're in.
+
+## The hard parts
+
+### Indexing 10M objects without dying
+
+The naive approach — load all keys, insert one by one — dies around 2 million objects. The fix: 10K batch inserts with `INSERT OR REPLACE`, crawl generation tracking to detect deleted objects, and 2K-chunk updates for unchanged keys. After the crawl, any object with a stale generation gets purged.
+
+### "Database is locked" at 3am
+
+16 crawl threads writing to SQLite while API threads read from it. Classic contention.
+
+`journal_mode = WAL` lets readers and a single writer coexist. But that's not enough when you have 16 threads competing for the write lock. Adding `busy_timeout = 5000` makes the writer wait 5 seconds instead of failing immediately. The "database is locked" error went from appearing every crawl cycle to zero.
+
+### Flat-key buckets are a nightmare
+
+One of our Druid buckets stores segments like `druid/datasource/2024-01-01/.../segment_id`. That's 8.2 million objects under essentially one prefix.
+
+When you call `ListObjectsV2` with `Delimiter=/`, S3 returns one "folder" with everything in it. You're back to scanning millions of objects sequentially.
+
+The fix: sub-prefix splitting. If a prefix has more than 500K objects and 3 or fewer children, recursively expand it by listing sub-prefixes with `Delimiter=/`. That turns one sequential 8.2M scan into 200 parallel 40K scans.
+
+### Making the storage chart not lie
+
+I take a storage snapshot after every crawl and aggregate to daily for the trend chart. The original query used `MAX(object_count)` per day — simple, fast.
+
+But if you delete objects mid-day and crawl again, `MAX()` picks the peak value, not the current state. The chart shows growth when storage actually shrank.
+
+Fixed it with a self-join that picks the row with the latest timestamp per day instead of the highest value. Small change, but data accuracy matters when you're making cost decisions.
+
+### Cost estimation across 13 providers
+
+Every S3-compatible provider has different pricing. AWS has 6+ storage classes with region multipliers. Cloudflare R2 has no egress fees. Wasabi has minimum storage duration charges.
+
+Built a pricing engine with static data for 13 providers (AWS, Cloudflare R2, Backblaze B2, Wasabi, MinIO, Ceph, DigitalOcean, Hetzner, Scaleway, OVH, IDrive, Storj, Leaseweb) plus live AWS pricing from their bulk API with 24h caching.
+
+The result: per-folder cost breakdown. "Your `logs/` folder costs $847/month, and 60% of it is data older than 90 days." Then it calculates how much you'd save by moving cold data to a cheaper storage class.
+
+## What it looks like today
+
+**Object browser** — streaming load that shows results as they arrive, not after a 30-second wait. File preview for images, PDFs, CSV, JSON, and Parquet/ORC schemas.
+
+**Full-text search** — type a query, get results instantly across all indexed objects.
+
+**Insights dashboard** — storage breakdown by folder with size bars, growth trends over time, estimated monthly and annual costs with provider-specific pricing.
+
+**Optimization engine** — detects cold data (files untouched for 30+ days), recommends storage class tiering with savings estimates, flags versioned buckets with no cleanup rules, finds stale multipart uploads wasting space.
+
+**Multi-endpoint** — connect to AWS, MinIO, Ceph, R2, and any S3-compatible backend from one UI. Switch between endpoints without re-deploying.
+
+**Access control** — role-based access with bucket-level permissions, API tokens, shareable file links, two-factor authentication, LDAP and OAuth support.
+
+**MCP server** — plug into AI assistants for conversational storage analysis. Ask questions about your buckets, costs, and optimization opportunities.
+
+## Try it
+
+```bash
+docker run -d -p 8888:8888 \
+  -e S3_ENDPOINT=https://s3.amazonaws.com \
+  -e S3_ACCESS_KEY=YOUR_KEY \
+  -e S3_SECRET_KEY=YOUR_SECRET \
+  -v sairo-data:/data \
+  ghcr.io/ashwathstephen/sairo:latest
+```
+
+Open `localhost:8888`. Check Docker logs for the generated admin password.
+
+Works on ARM and x86. Tested at 170TB with 10M+ objects.
+
+**GitHub:** https://github.com/ashwathstephen/sairo
+**Docs:** https://sairo.dev


### PR DESCRIPTION
Performance & freshness release, validated end-to-end against a **1M-object / 241 TB** production bucket. 72 unit tests pass.

## Highlights (measured, old vs new on the same live 1M-object bucket)
| Area | Before | After |
|---|---|---|
| List a folder's first page (1M-file folder) | ~1.4 s / 122 MB | **~73 ms / 0.12 MB** |
| Top-level breakdown (`breakdown_root`) | ~1,000 ms | **~2.5 ms** |
| Folder-size / sub-prefix breakdown (602K subtree) | 199 ms / 747 ms | **90 ms / 497 ms** |
| Keep a 1M-object bucket fresh | full re-list every cycle (~7 min) | **delta crawl ~30 s** |

## What's in it
**Added**
- Keyset pagination on `/list` (`cursor`+`limit`, `next_cursor`); first page paints instantly. Legacy whole-folder response preserved when `limit` is omitted.
- Adaptive crawl scheduler with fast parallel **delta crawls** (re-list only where new data lands) + periodic full reconcile; new tunables `FULL_CRAWL_INTERVAL`, `LARGE_BUCKET_SECONDS`, `DELTA_SAMPLE`, `DELTA_MAX_TARGETS`.
- Restart seeds the schedule from the existing index (no full re-crawl of every bucket on startup).
- Direct presigned-PUT uploads by default.

**Changed**
- Covering index `(prefix,key,size,last_modified)` → index-only listings/breakdowns; **auto-migrated in place** on first start (existing index reused, no re-crawl).
- Storage breakdown / folder-size use covered prefix-range scans instead of `LIKE` full scans.
- FTS trigram rebuild gated on key adds/deletes.
- SQLite tuning (page size, mmap, `synchronous=NORMAL`, WAL autocheckpoint).

**Fixed**
- Empty `folder_stats` after large-bucket crawls (rebuild/writer contention) → top-level breakdown no longer falls back to a ~1 s scan.
- Stale folder shown after navigation (background-refresh overwrite race).
- Background refresh now updates crawl status + last-crawl timestamp.

## Upgrade / migration
Drop-in. On first start the index migrates in place (covering index built, `crawl_duration` column added) — existing index is reused, **no re-crawl required**, and an operator log line records the migration per bucket. Requires persistent `/data` (already the case with the Helm PVC).

## Note for review
The **direct presigned-PUT upload** changes (`UploadModal.jsx` + `getPresignedUploadUrls`/`notifyUpload` in `api.js`) were pre-existing in the working tree and are included here; the build passes but the upload flow itself was not part of the perf validation — worth a manual check before release.