### PR TITLE
feat: direct browser→S3 upload for files of any size (v3.4.0, closes #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,9 @@
 
 All notable changes to Sairo are documented here. This project uses [Semantic Versioning](https://semver.org/).
 
-## [3.4.0] - 2026-06-14
+## [3.4.0] - 2026-06-15
 
-Direct browser→S3 uploads for files of any size — closes the proxy-upload OOM / size-ceiling problem (issue #6). Validated end-to-end against MinIO (all paths, md5-verified) with measured memory bounds.
+Direct browser→S3 uploads for files of any size — closes the proxy-upload OOM / size-ceiling problem (issue #6). Validated end-to-end against MinIO (all paths, md5-verified) and in a real browser, with measured memory bounds.
 
 ### Added
 
@@ -16,6 +16,7 @@ Direct browser→S3 uploads for files of any size — closes the proxy-upload OO
 
 - **Proxy upload is now memory-bounded** — the fallback path (files routed through the server) streams each file straight to S3 instead of buffering it in memory. Peak RAM is independent of file size (measured ≈100 MB for a single in-flight file whether it is 500 MB or 50 GB, vs the old path that scaled 1:1 and OOM-restarted the pod). Total proxy memory is bounded by `UPLOAD_PROXY_CONCURRENCY` (default 3) × ≈100 MB.
 - **CORS for direct upload now guarantees ETag exposure** — a bucket whose existing PUT CORS rule omits `ExposeHeaders: ETag` is upgraded in place, since the browser must read each part's ETag to complete a multipart upload.
+- **Direct uploads now work under the Content-Security-Policy** — `connect-src` includes the configured S3 endpoint origin(s) so the browser can PUT directly to the (cross-origin) S3 endpoint. Previously `connect-src 'self'` silently blocked every direct upload (with no proxy fallback, since the same-origin signing request still succeeded).
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to Sairo are documented here. This project uses [Semantic Versioning](https://semver.org/).
 
+## [3.4.0] - 2026-06-14
+
+Direct browser→S3 uploads for files of any size — closes the proxy-upload OOM / size-ceiling problem (issue #6). Validated end-to-end against MinIO (all paths, md5-verified) with measured memory bounds.
+
+### Added
+
+- **Multipart direct upload** — files larger than 100 MB are split into parts that the browser PUTs **directly to S3** in parallel (no bytes through the server), with no single-PUT 5 GB ceiling (up to S3's 5 TB object limit). New endpoints: `multipart/initiate`, `multipart/sign`, `multipart/complete`, `multipart/abort`. Smaller files continue to use a single presigned PUT.
+- **Just-in-time part signing** — each part's presigned URL is signed immediately before it is uploaded (and re-signed on retry), so a long-running multi-GB upload can never fail partway through from an expired URL. Per-part retries with backoff; the in-progress multipart upload is aborted on cancel/failure so no orphaned parts are left on S3.
+- **Stop button** — an in-progress upload can be stopped from the modal, and navigating away mid-upload aborts the transfer (and its S3 multipart upload) instead of leaving it dangling.
+
+### Changed
+
+- **Proxy upload is now memory-bounded** — the fallback path (files routed through the server) streams each file straight to S3 instead of buffering it in memory. Peak RAM is independent of file size (measured ≈100 MB for a single in-flight file whether it is 500 MB or 50 GB, vs the old path that scaled 1:1 and OOM-restarted the pod). Total proxy memory is bounded by `UPLOAD_PROXY_CONCURRENCY` (default 3) × ≈100 MB.
+- **CORS for direct upload now guarantees ETag exposure** — a bucket whose existing PUT CORS rule omits `ExposeHeaders: ETag` is upgraded in place, since the browser must read each part's ETag to complete a multipart upload.
+
+### Fixed
+
+- Multipart endpoints validate their inputs (part numbers 1–10000, well-formed parts) and return `400` instead of `500` on malformed requests; they are rate-limited and audit-logged. New tunables: `UPLOAD_PROXY_CONCURRENCY`, `MULTIPART_URL_EXPIRY`.
+
 ## [3.3.1] - 2026-06-14
 
 Freshness-reliability patch for the adaptive delta crawler on large, actively-written buckets. Validated end-to-end against live production object storage (per-partition index counts compared to S3 ground truth).

--- a/backend/main.py
+++ b/backend/main.py
@@ -70,16 +70,37 @@ async def _rate_limit_handler(request: Request, exc: RateLimitExceeded):
 
 # ── Security Headers Middleware ────────────────────────────────────────────
 
+def _csp_connect_origins():
+    """Origins the browser is allowed to XHR to, beyond 'self' — every configured S3
+    endpoint. Direct (presigned) uploads PUT straight from the browser to the S3
+    endpoint, which is a DIFFERENT origin than Sairo; without these the CSP
+    'connect-src' silently blocks the upload (and there's no proxy fallback because
+    the same-origin signing request still succeeds). Includes a wildcard subdomain so
+    virtual-host-style presigned URLs (bucket.endpoint) are allowed too."""
+    from urllib.parse import urlparse
+    origins = set()
+    try:
+        for info in list(_s3_manager._endpoints.values()):
+            p = urlparse(info.get("endpoint_url") or "")
+            if p.scheme and p.netloc:
+                origins.add(f"{p.scheme}://{p.netloc}")
+                origins.add(f"{p.scheme}://*.{p.netloc}")
+    except Exception:
+        pass
+    return " ".join(sorted(origins))
+
+
 @app.middleware("http")
 async def security_headers_middleware(request: Request, call_next):
     response = await call_next(request)
+    connect_src = ("connect-src 'self' " + _csp_connect_origins()).rstrip()
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
         "script-src 'self'; "
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
         "font-src 'self' https://fonts.gstatic.com; "
         "img-src 'self' blob: data:; "
-        "connect-src 'self'; "
+        f"{connect_src}; "
         "frame-src blob:;"
     )
     response.headers["X-Content-Type-Options"] = "nosniff"

--- a/backend/main.py
+++ b/backend/main.py
@@ -4783,36 +4783,6 @@ MULTIPART_CHUNK_SIZE = 5 * 1024 * 1024  # 5 MB per part
 MAX_UPLOAD_SIZE = int(os.environ.get("MAX_UPLOAD_SIZE", str(5 * 1024 * 1024 * 1024)))  # 5 GB default
 
 
-def _upload_multipart(bucket, key, file_obj, endpoint_id=None):
-    """Upload a file using S3 multipart upload for large files."""
-    client = _s3_manager.get_client(endpoint_id or _current_endpoint_id())
-    upload = client.create_multipart_upload(Bucket=bucket, Key=key)
-    upload_id = upload["UploadId"]
-    parts = []
-    part_number = 1
-    total_size = 0
-    try:
-        while True:
-            chunk = file_obj.read(MULTIPART_CHUNK_SIZE)
-            if not chunk:
-                break
-            resp = client.upload_part(
-                Bucket=bucket, Key=key, UploadId=upload_id,
-                PartNumber=part_number, Body=chunk,
-            )
-            parts.append({"ETag": resp["ETag"], "PartNumber": part_number})
-            total_size += len(chunk)
-            part_number += 1
-        client.complete_multipart_upload(
-            Bucket=bucket, Key=key, UploadId=upload_id,
-            MultipartUpload={"Parts": parts},
-        )
-    except Exception:
-        client.abort_multipart_upload(Bucket=bucket, Key=key, UploadId=upload_id)
-        raise
-    return total_size
-
-
 @app.post("/api/buckets/{bucket}/upload")
 @limiter.limit(UPLOAD_RATE_LIMIT)
 async def upload_files(bucket: str, request: Request, prefix: str = Form(""), files: list[UploadFile] = File(...)):
@@ -4824,36 +4794,38 @@ async def upload_files(bucket: str, request: Request, prefix: str = Form(""), fi
     eid = _current_endpoint_id()
     client = _s3_manager.get_client(eid)
 
-    # Read all file contents first (async), then upload to S3 in parallel
+    # Stream each upload straight to S3 from its (disk-backed) spooled temp file —
+    # never buffer whole files in memory. This is the proxy fallback; the default
+    # path is direct browser→S3 (multipart for large files). boto3 upload_fileobj
+    # does multipart for large objects, reading the source in bounded chunks, so
+    # a 5 GB upload uses MBs of RAM, not GBs (fixes the OOM / pod restart at scale).
+    # Small chunks + bounded concurrency keep peak memory at ~chunksize*max_concurrency
+    # PER FILE (≈32 MB), independent of file size — this is what prevents the OOM.
+    from boto3.s3.transfer import TransferConfig
+    transfer_cfg = TransferConfig(multipart_threshold=8 * 1024 * 1024,
+                                  multipart_chunksize=8 * 1024 * 1024,
+                                  max_concurrency=4, use_threads=True)
     file_data = []
     total_bytes = 0
     for f in files:
         key = prefix + f.filename
-        first_chunk = await f.read(MULTIPART_THRESHOLD + 1)
-        if len(first_chunk) <= MULTIPART_THRESHOLD:
-            total_bytes += len(first_chunk)
-            if total_bytes > MAX_UPLOAD_SIZE:
-                raise HTTPException(413, f"Upload exceeds maximum size of {MAX_UPLOAD_SIZE // (1024*1024)}MB")
-            file_data.append((key, first_chunk, len(first_chunk), False))
-        else:
-            remainder = await f.read()
-            full_content = first_chunk + remainder
-            total_bytes += len(full_content)
-            if total_bytes > MAX_UPLOAD_SIZE:
-                raise HTTPException(413, f"Upload exceeds maximum size of {MAX_UPLOAD_SIZE // (1024*1024)}MB")
-            file_data.append((key, full_content, len(full_content), True))
+        f.file.seek(0, os.SEEK_END)
+        size = f.file.tell()
+        f.file.seek(0)
+        total_bytes += size
+        if total_bytes > MAX_UPLOAD_SIZE:
+            raise HTTPException(413, f"Upload exceeds maximum size of {MAX_UPLOAD_SIZE // (1024*1024)}MB")
+        file_data.append((key, f.file, size))
 
-    def _put_one(key, body, size, is_large):
-        if is_large:
-            return key, _upload_multipart(bucket, key, io.BytesIO(body), endpoint_id=eid)
-        client.put_object(Bucket=bucket, Key=key, Body=body)
+    def _put_one(key, fileobj, size):
+        client.upload_fileobj(fileobj, bucket, key, Config=transfer_cfg)
         return key, size
 
-    # Upload to S3 concurrently
+    # Upload to S3 concurrently (each file streams from its own spooled temp file)
     import concurrent.futures
     results = []
     with concurrent.futures.ThreadPoolExecutor(max_workers=min(10, len(file_data))) as pool:
-        futures = [pool.submit(_put_one, key, body, size, is_large) for key, body, size, is_large in file_data]
+        futures = [pool.submit(_put_one, key, fileobj, size) for key, fileobj, size in file_data]
         for fut in concurrent.futures.as_completed(futures):
             key, file_size = fut.result()
             results.append({"key": key, "size": file_size})
@@ -5189,6 +5161,107 @@ def _ensure_upload_cors(bucket: str, request: Request, client):
     })
     client.put_bucket_cors(Bucket=bucket, CORSConfiguration={"CORSRules": rules})
     log.info("Added upload CORS rule for origin=%s on bucket=%s", origin, bucket)
+
+
+# ── Multipart direct upload (browser → S3: presigned, parallel, resumable) ──
+# Large files are split into parts that the browser PUTs directly to S3 in
+# parallel. No file data passes through Sairo, so there is no proxy buffering,
+# no per-pod memory pressure, and no single-PUT size ceiling (up to 5 TB).
+
+def _require_bucket_write(user, request):
+    if user["role"] != "admin" and getattr(request.state, "bucket_permission", None) != "write":
+        raise HTTPException(403, "Write access required")
+
+
+class MultipartInitiateRequest(BaseModel):
+    key: str
+    prefix: str = ""
+    content_type: str = ""
+
+
+class MultipartSignRequest(BaseModel):
+    key: str
+    upload_id: str
+    part_numbers: list[int]
+
+
+class MultipartCompleteRequest(BaseModel):
+    key: str
+    upload_id: str
+    parts: list[dict]  # [{"PartNumber": int, "ETag": str}, ...]
+
+
+class MultipartUploadAbortRequest(BaseModel):
+    key: str
+    upload_id: str
+
+
+@app.post("/api/buckets/{bucket}/multipart/initiate")
+def multipart_initiate(bucket: str, req: MultipartInitiateRequest, request: Request, user: dict = Depends(get_current_user)):
+    """Start a multipart upload; returns its UploadId. The browser uploads parts directly to S3."""
+    _require_bucket_write(user, request)
+    eid = _current_endpoint_id()
+    client = _s3_manager.get_client(eid)
+    try:
+        _ensure_upload_cors(bucket, request, client)
+    except Exception as e:
+        log.warning("Failed to ensure CORS for multipart upload on %s: %s", bucket, e)
+    key = req.prefix + req.key if req.prefix else req.key
+    params = {"Bucket": bucket, "Key": key}
+    if req.content_type:
+        params["ContentType"] = req.content_type
+    resp = client.create_multipart_upload(**params)
+    return {"key": key, "upload_id": resp["UploadId"]}
+
+
+@app.post("/api/buckets/{bucket}/multipart/sign")
+def multipart_sign(bucket: str, req: MultipartSignRequest, request: Request, user: dict = Depends(get_current_user)):
+    """Return presigned URLs to PUT a batch of parts directly to S3."""
+    _require_bucket_write(user, request)
+    if not req.part_numbers or len(req.part_numbers) > 1000:
+        raise HTTPException(400, "Provide 1-1000 part numbers")
+    eid = _current_endpoint_id()
+    client = _s3_manager.get_client(eid)
+    expires = 3600
+    urls = [
+        {"part_number": pn,
+         "url": client.generate_presigned_url(
+             "upload_part",
+             Params={"Bucket": bucket, "Key": req.key, "UploadId": req.upload_id, "PartNumber": pn},
+             ExpiresIn=expires)}
+        for pn in req.part_numbers
+    ]
+    return {"urls": urls, "expires_in": expires}
+
+
+@app.post("/api/buckets/{bucket}/multipart/complete")
+def multipart_complete(bucket: str, req: MultipartCompleteRequest, request: Request, user: dict = Depends(get_current_user)):
+    """Complete a multipart upload from the uploaded parts' ETags."""
+    _require_bucket_write(user, request)
+    if not req.parts:
+        raise HTTPException(400, "No parts provided")
+    eid = _current_endpoint_id()
+    client = _s3_manager.get_client(eid)
+    parts = sorted(
+        ({"PartNumber": int(p["PartNumber"]), "ETag": p["ETag"]} for p in req.parts),
+        key=lambda p: p["PartNumber"])
+    resp = client.complete_multipart_upload(
+        Bucket=bucket, Key=req.key, UploadId=req.upload_id,
+        MultipartUpload={"Parts": parts})
+    return {"key": req.key, "etag": (resp.get("ETag") or "").strip('"')}
+
+
+@app.post("/api/buckets/{bucket}/multipart/abort")
+def multipart_abort_direct(bucket: str, req: MultipartUploadAbortRequest, request: Request, user: dict = Depends(get_current_user)):
+    """Abort an in-progress multipart upload (cleanup on cancel/failure)."""
+    _require_bucket_write(user, request)
+    eid = _current_endpoint_id()
+    client = _s3_manager.get_client(eid)
+    try:
+        client.abort_multipart_upload(Bucket=bucket, Key=req.key, UploadId=req.upload_id)
+    except Exception as e:
+        log.warning("Failed to abort multipart upload %s on %s: %s", req.upload_id, bucket, e)
+    return {"aborted": True}
 
 
 class NotifyUploadRequest(BaseModel):

--- a/backend/main.py
+++ b/backend/main.py
@@ -198,7 +198,7 @@ async def s3_error_handler(request, exc):
 
 
 _app_start_time = time.time()
-SAIRO_VERSION = "3.3.1"
+SAIRO_VERSION = "3.4.0"
 TELEMETRY = os.environ.get("TELEMETRY", "true").lower() != "false"
 
 S3_ENDPOINT = os.environ.get("S3_ENDPOINT", "")

--- a/backend/main.py
+++ b/backend/main.py
@@ -4778,9 +4778,8 @@ def delete_folder(bucket: str, req: DeleteFolderRequest, user: dict = Depends(re
     return {"deleted": total_deleted, "errors": total_errors, "prefix": pfx}
 
 
-MULTIPART_THRESHOLD = 5 * 1024 * 1024  # 5 MB
-MULTIPART_CHUNK_SIZE = 5 * 1024 * 1024  # 5 MB per part
-MAX_UPLOAD_SIZE = int(os.environ.get("MAX_UPLOAD_SIZE", str(5 * 1024 * 1024 * 1024)))  # 5 GB default
+MAX_UPLOAD_SIZE = int(os.environ.get("MAX_UPLOAD_SIZE", str(5 * 1024 * 1024 * 1024)))  # 5 GB default (proxy fallback only)
+UPLOAD_PROXY_CONCURRENCY = int(os.environ.get("UPLOAD_PROXY_CONCURRENCY", "3"))  # files streamed in parallel through the proxy
 
 
 @app.post("/api/buckets/{bucket}/upload")
@@ -4790,17 +4789,19 @@ async def upload_files(bucket: str, request: Request, prefix: str = Form(""), fi
     if user["role"] != "admin":
         bp = getattr(request.state, "bucket_permission", None)
         if bp != "write":
-            raise HTTPException(403, "Admin access required")
+            raise HTTPException(403, "Write access required")
     eid = _current_endpoint_id()
     client = _s3_manager.get_client(eid)
 
     # Stream each upload straight to S3 from its (disk-backed) spooled temp file —
-    # never buffer whole files in memory. This is the proxy fallback; the default
-    # path is direct browser→S3 (multipart for large files). boto3 upload_fileobj
-    # does multipart for large objects, reading the source in bounded chunks, so
-    # a 5 GB upload uses MBs of RAM, not GBs (fixes the OOM / pod restart at scale).
-    # Small chunks + bounded concurrency keep peak memory at ~chunksize*max_concurrency
-    # PER FILE (≈32 MB), independent of file size — this is what prevents the OOM.
+    # never buffer a whole file in memory. This is the PROXY FALLBACK; the default
+    # path is direct browser→S3 (presigned multipart for large files, zero bytes
+    # through the server). boto3 upload_fileobj does multipart for large objects,
+    # reading the source in bounded chunks, so peak RAM is INDEPENDENT of file size
+    # (measured ≈100 MB for a single in-flight file regardless of whether it is
+    # 500 MB or 50 GB — vs the old read-into-memory path that scaled 1:1 and OOM'd).
+    # Total proxy memory is therefore bounded by ≈100 MB × UPLOAD_PROXY_CONCURRENCY,
+    # not by file size — which is what fixes the OOM / pod restart at scale.
     from boto3.s3.transfer import TransferConfig
     transfer_cfg = TransferConfig(multipart_threshold=8 * 1024 * 1024,
                                   multipart_chunksize=8 * 1024 * 1024,
@@ -4824,7 +4825,7 @@ async def upload_files(bucket: str, request: Request, prefix: str = Form(""), fi
     # Upload to S3 concurrently (each file streams from its own spooled temp file)
     import concurrent.futures
     results = []
-    with concurrent.futures.ThreadPoolExecutor(max_workers=min(10, len(file_data))) as pool:
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max(1, min(UPLOAD_PROXY_CONCURRENCY, len(file_data)))) as pool:
         futures = [pool.submit(_put_one, key, fileobj, size) for key, fileobj, size in file_data]
         for fut in concurrent.futures.as_completed(futures):
             key, file_size = fut.result()
@@ -5140,12 +5141,22 @@ def _ensure_upload_cors(bucket: str, request: Request, client):
     try:
         resp = client.get_bucket_cors(Bucket=bucket)
         rules = resp.get("CORSRules", [])
-        # Check if PUT is already allowed from this origin
+        # A rule only suffices if it allows PUT from this origin AND exposes ETag —
+        # the browser MUST read the ETag response header on each multipart part PUT
+        # (xhr.getResponseHeader("ETag")), which CORS gates via ExposeHeaders. A
+        # pre-existing PUT rule that omits ETag would otherwise silently break every
+        # multipart upload, so upgrade it in place instead of short-circuiting.
         for rule in rules:
             origins = rule.get("AllowedOrigins", [])
             methods = rule.get("AllowedMethods", [])
             if ("*" in origins or origin in origins) and "PUT" in methods:
-                return  # already configured
+                exposed = [h.lower() for h in rule.get("ExposeHeaders", [])]
+                if "etag" in exposed or "*" in exposed:
+                    return  # already fully configured
+                rule["ExposeHeaders"] = rule.get("ExposeHeaders", []) + ["ETag"]
+                client.put_bucket_cors(Bucket=bucket, CORSConfiguration={"CORSRules": rules})
+                log.info("Upgraded CORS rule to expose ETag for origin=%s on bucket=%s", origin, bucket)
+                return
     except ClientError as e:
         if "NoSuchCORSConfiguration" not in str(e):
             raise
@@ -5173,6 +5184,9 @@ def _require_bucket_write(user, request):
         raise HTTPException(403, "Write access required")
 
 
+MULTIPART_URL_EXPIRY = int(os.environ.get("MULTIPART_URL_EXPIRY", "3600"))  # presigned part-URL TTL (frontend signs just-in-time)
+
+
 class MultipartInitiateRequest(BaseModel):
     key: str
     prefix: str = ""
@@ -5197,6 +5211,7 @@ class MultipartUploadAbortRequest(BaseModel):
 
 
 @app.post("/api/buckets/{bucket}/multipart/initiate")
+@limiter.limit(UPLOAD_RATE_LIMIT)
 def multipart_initiate(bucket: str, req: MultipartInitiateRequest, request: Request, user: dict = Depends(get_current_user)):
     """Start a multipart upload; returns its UploadId. The browser uploads parts directly to S3."""
     _require_bucket_write(user, request)
@@ -5211,47 +5226,60 @@ def multipart_initiate(bucket: str, req: MultipartInitiateRequest, request: Requ
     if req.content_type:
         params["ContentType"] = req.content_type
     resp = client.create_multipart_upload(**params)
+    _audit("multipart_initiate", user["username"], bucket=bucket, details=key)
     return {"key": key, "upload_id": resp["UploadId"]}
 
 
 @app.post("/api/buckets/{bucket}/multipart/sign")
+@limiter.limit(UPLOAD_RATE_LIMIT)
 def multipart_sign(bucket: str, req: MultipartSignRequest, request: Request, user: dict = Depends(get_current_user)):
-    """Return presigned URLs to PUT a batch of parts directly to S3."""
+    """Return presigned URLs to PUT a batch of parts directly to S3. The frontend
+    signs parts just-in-time (right before each PUT) so a URL never expires mid-flight
+    on a long upload, and re-signs on a 403."""
     _require_bucket_write(user, request)
     if not req.part_numbers or len(req.part_numbers) > 1000:
         raise HTTPException(400, "Provide 1-1000 part numbers")
+    if any(pn < 1 or pn > 10000 for pn in req.part_numbers):
+        raise HTTPException(400, "Part numbers must be between 1 and 10000 (S3 limit)")
     eid = _current_endpoint_id()
     client = _s3_manager.get_client(eid)
-    expires = 3600
     urls = [
         {"part_number": pn,
          "url": client.generate_presigned_url(
              "upload_part",
              Params={"Bucket": bucket, "Key": req.key, "UploadId": req.upload_id, "PartNumber": pn},
-             ExpiresIn=expires)}
+             ExpiresIn=MULTIPART_URL_EXPIRY)}
         for pn in req.part_numbers
     ]
-    return {"urls": urls, "expires_in": expires}
+    return {"urls": urls, "expires_in": MULTIPART_URL_EXPIRY}
 
 
 @app.post("/api/buckets/{bucket}/multipart/complete")
+@limiter.limit(UPLOAD_RATE_LIMIT)
 def multipart_complete(bucket: str, req: MultipartCompleteRequest, request: Request, user: dict = Depends(get_current_user)):
     """Complete a multipart upload from the uploaded parts' ETags."""
     _require_bucket_write(user, request)
     if not req.parts:
         raise HTTPException(400, "No parts provided")
+    try:
+        parts = sorted(
+            ({"PartNumber": int(p["PartNumber"]), "ETag": str(p["ETag"])} for p in req.parts),
+            key=lambda p: p["PartNumber"])
+    except (KeyError, TypeError, ValueError):
+        raise HTTPException(400, "Each part must have an integer PartNumber and an ETag")
+    if any(p["PartNumber"] < 1 or p["PartNumber"] > 10000 or not p["ETag"] for p in parts):
+        raise HTTPException(400, "Invalid part: PartNumber must be 1-10000 and ETag non-empty")
     eid = _current_endpoint_id()
     client = _s3_manager.get_client(eid)
-    parts = sorted(
-        ({"PartNumber": int(p["PartNumber"]), "ETag": p["ETag"]} for p in req.parts),
-        key=lambda p: p["PartNumber"])
     resp = client.complete_multipart_upload(
         Bucket=bucket, Key=req.key, UploadId=req.upload_id,
         MultipartUpload={"Parts": parts})
+    _audit("multipart_complete", user["username"], bucket=bucket, details=f"{req.key} ({len(parts)} parts)")
     return {"key": req.key, "etag": (resp.get("ETag") or "").strip('"')}
 
 
 @app.post("/api/buckets/{bucket}/multipart/abort")
+@limiter.limit(UPLOAD_RATE_LIMIT)
 def multipart_abort_direct(bucket: str, req: MultipartUploadAbortRequest, request: Request, user: dict = Depends(get_current_user)):
     """Abort an in-progress multipart upload (cleanup on cancel/failure)."""
     _require_bucket_write(user, request)
@@ -5261,6 +5289,7 @@ def multipart_abort_direct(bucket: str, req: MultipartUploadAbortRequest, reques
         client.abort_multipart_upload(Bucket=bucket, Key=req.key, UploadId=req.upload_id)
     except Exception as e:
         log.warning("Failed to abort multipart upload %s on %s: %s", req.upload_id, bucket, e)
+    _audit("multipart_abort", user["username"], bucket=bucket, details=req.key)
     return {"aborted": True}
 
 

--- a/benchmark/bench_upload_memory.py
+++ b/benchmark/bench_upload_memory.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+"""
+Memory benchmark for issue #6: peak RSS of the proxy upload mechanism.
+  --mode before : read the whole file into a bytes object (old: `await f.read()`),
+                  then upload from memory  -> RSS scales with file size (OOM at scale)
+  --mode after  : stream from the file via upload_fileobj (new)  -> RSS bounded
+Each mode runs in its own process; we report peak RSS via getrusage.
+Targets local MinIO at :9400, bucket 'uptest'.
+"""
+import argparse, io, os, platform, resource, sys, tempfile, time
+import boto3
+from boto3.s3.transfer import TransferConfig
+from botocore.client import Config
+
+MULTIPART_THRESHOLD = 100 * 1024 * 1024
+
+def peak_rss_mb():
+    rss = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+    # Darwin reports bytes; Linux reports kilobytes
+    return rss / (1024 * 1024) if platform.system() == "Darwin" else rss / 1024
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--mode", choices=["before", "after"], required=True)
+    ap.add_argument("--size-mb", type=int, default=500)
+    a = ap.parse_args()
+
+    s3 = boto3.client("s3", endpoint_url="http://localhost:9400",
+                      aws_access_key_id="minioadmin", aws_secret_access_key="minioadmin",
+                      config=Config(signature_version="s3v4"))
+    size = a.size_mb * 1024 * 1024
+    tmp = tempfile.NamedTemporaryFile(delete=False)
+    # write the file in chunks so creating it doesn't itself spike RSS
+    chunk = os.urandom(8 * 1024 * 1024)
+    written = 0
+    while written < size:
+        tmp.write(chunk[: min(len(chunk), size - written)]); written += len(chunk)
+    tmp.flush(); tmp.close()
+    key = f"membench/{a.mode}-{a.size_mb}mb.bin"
+
+    base = peak_rss_mb()
+    t0 = time.monotonic()
+    if a.mode == "before":
+        # OLD behavior: whole file read into a bytes object, then uploaded from RAM
+        with open(tmp.name, "rb") as f:
+            body = f.read()                       # <-- the OOM source: full file in memory
+        s3.put_object(Bucket="uptest", Key=key, Body=body)
+        del body
+    else:
+        # NEW behavior: stream straight from the (disk-backed) file handle, with the
+        # SAME bounded config the backend uses (8MB chunks, max_concurrency=4).
+        cfg = TransferConfig(multipart_threshold=8 * 1024 * 1024, multipart_chunksize=8 * 1024 * 1024,
+                             max_concurrency=4, use_threads=True)
+        with open(tmp.name, "rb") as f:
+            s3.upload_fileobj(f, "uptest", key, Config=cfg)
+    elapsed = time.monotonic() - t0
+    peak = peak_rss_mb()
+    os.unlink(tmp.name)
+    print(f"  mode={a.mode:6}  file={a.size_mb}MB  baseline_rss={base:.0f}MB  peak_rss={peak:.0f}MB  "
+          f"delta={peak-base:.0f}MB  time={elapsed:.1f}s")
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/test_upload_e2e.py
+++ b/benchmark/test_upload_e2e.py
@@ -76,22 +76,29 @@ def run():
     part_size = 16 * 1024 * 1024
     nparts = (len(big) + part_size - 1) // part_size
     nums = list(range(1, nparts + 1))
-    signed = client.post(f"/api/buckets/{BUCKET}/multipart/sign",
-                        json={"key": key2, "upload_id": upload_id, "part_numbers": nums}, cookies=cookies).json()
-    url_by_part = {u["part_number"]: u["url"] for u in signed["urls"]}
+    # Mirror the production frontend: sign each part JUST BEFORE its PUT (just-in-time),
+    # one part per sign call, so a presigned URL can never expire mid-upload.
     parts = []
+    resign_ok = True
     for pn in nums:
+        signed = client.post(f"/api/buckets/{BUCKET}/multipart/sign",
+                             json={"key": key2, "upload_id": upload_id, "part_numbers": [pn]}, cookies=cookies).json()
+        url = signed["urls"][0]["url"]
         chunk = big[(pn - 1) * part_size: pn * part_size]
-        st, etag = put_url(url_by_part[pn], chunk)
+        st, etag = put_url(url, chunk)
         parts.append({"PartNumber": pn, "ETag": etag})
+    # re-signing an already-uploaded part must still return a usable URL (the on-403 retry path)
+    resign = client.post(f"/api/buckets/{BUCKET}/multipart/sign",
+                         json={"key": key2, "upload_id": upload_id, "part_numbers": [1]}, cookies=cookies)
+    resign_ok = resign.status_code == 200 and resign.json()["urls"][0]["url"].startswith("http")
     comp = client.post(f"/api/buckets/{BUCKET}/multipart/complete",
                        json={"key": key2, "upload_id": upload_id, "parts": parts}, cookies=cookies)
     client.post(f"/api/buckets/{BUCKET}/notify-upload",
                 json={"uploads": [{"key": key2, "size": len(big)}]}, cookies=cookies)
     got_md5, got_size = s3_object_md5(s3, key2)
-    check("multipart direct upload (120MB, 8 parts)",
-          comp.status_code == 200 and got_md5 == md5(big) and got_size == len(big),
-          f"parts={nparts}, size={got_size}, md5 match={got_md5 == md5(big)}")
+    check("multipart direct upload (120MB, 8 parts, per-part JIT signing)",
+          comp.status_code == 200 and got_md5 == md5(big) and got_size == len(big) and resign_ok,
+          f"parts={nparts}, size={got_size}, md5 match={got_md5 == md5(big)}, resign_ok={resign_ok}")
 
     # ── 2b. multipart ABORT cleanup ──
     init2 = client.post(f"/api/buckets/{BUCKET}/multipart/initiate",

--- a/benchmark/test_upload_e2e.py
+++ b/benchmark/test_upload_e2e.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""
+End-to-end upload validation for issue #6 against a REAL S3 (local MinIO).
+Exercises all three upload paths and verifies object integrity (md5):
+  1. single-PUT direct (presigned PUT) — small files
+  2. multipart direct (initiate/sign/PUT-parts/complete) — large files, browser-simulated
+  3. proxy streaming (POST /upload) — the fallback, must not buffer whole file
+
+Run with MinIO at :9400 and bucket 'uptest'. boto3 talks to MinIO for real;
+Sairo API is driven in-process via TestClient. Presigned PUTs go straight to MinIO.
+"""
+import hashlib, io, json, os, sys, time, urllib.request
+
+os.environ.update({
+    "S3_ENDPOINT": "http://localhost:9400",
+    "S3_ACCESS_KEY": "minioadmin",
+    "S3_SECRET_KEY": "minioadmin",
+    "S3_REGION": "us-east-1",
+    "ADMIN_USER": "admin",
+    "ADMIN_PASS": "uploadtest",
+    "JWT_SECRET": os.urandom(24).hex(),
+    "SECURE_COOKIE": "false",
+    "DB_DIR": "/tmp/sairo-upload-e2e",
+    "RECRAWL_INTERVAL": "100000",
+})
+import logging
+logging.getLogger("sairo").setLevel(logging.WARNING)
+logging.getLogger("httpx").setLevel(logging.WARNING)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+import main  # noqa: E402  (real boto3 → MinIO, NOT mocked)
+from fastapi.testclient import TestClient  # noqa: E402
+
+BUCKET = "uptest"
+results = []
+def check(name, ok, detail=""):
+    results.append(ok); print(f"  {'✓ PASS' if ok else '✗ FAIL'}  {name:38} {detail}")
+
+def put_url(url, body):
+    req = urllib.request.Request(url, data=body, method="PUT")
+    with urllib.request.urlopen(req, timeout=60) as r:
+        return r.status, r.headers.get("ETag")
+
+def md5(b): return hashlib.md5(b).hexdigest()
+
+def s3_object_md5(client, key):
+    body = client.get_object(Bucket=BUCKET, Key=key)["Body"].read()
+    return md5(body), len(body)
+
+def run():
+    client = TestClient(main.app)
+    r = client.post("/api/auth/login", json={"username": "admin", "password": "uploadtest"})
+    assert r.status_code == 200, f"login failed: {r.text[:200]}"
+    cookies = r.cookies
+    s3 = main._s3_manager.get_client("default")
+
+    # ── 1. single-PUT direct upload (small file) ──
+    small = os.urandom(2 * 1024 * 1024)  # 2 MB
+    key = "e2e/small.bin"
+    resp = client.post(f"/api/buckets/{BUCKET}/presigned-upload",
+                       json={"keys": ["small.bin"], "prefix": "e2e/"}, cookies=cookies)
+    url = resp.json()["urls"][0]["url"]
+    st, _ = put_url(url, small)
+    client.post(f"/api/buckets/{BUCKET}/notify-upload",
+                json={"uploads": [{"key": key, "size": len(small)}]}, cookies=cookies)
+    got_md5, got_size = s3_object_md5(s3, key)
+    check("single-PUT direct upload (2MB)", st in (200, 204) and got_md5 == md5(small) and got_size == len(small),
+          f"size={got_size}, md5 match={got_md5 == md5(small)}")
+
+    # ── 2. multipart direct upload (large file, browser-simulated) ──
+    big = os.urandom(120 * 1024 * 1024)  # 120 MB → > 100MB threshold → multipart
+    key2 = "e2e/big.bin"
+    init = client.post(f"/api/buckets/{BUCKET}/multipart/initiate",
+                       json={"key": "big.bin", "prefix": "e2e/", "content_type": "application/octet-stream"},
+                       cookies=cookies).json()
+    upload_id = init["upload_id"]
+    part_size = 16 * 1024 * 1024
+    nparts = (len(big) + part_size - 1) // part_size
+    nums = list(range(1, nparts + 1))
+    signed = client.post(f"/api/buckets/{BUCKET}/multipart/sign",
+                        json={"key": key2, "upload_id": upload_id, "part_numbers": nums}, cookies=cookies).json()
+    url_by_part = {u["part_number"]: u["url"] for u in signed["urls"]}
+    parts = []
+    for pn in nums:
+        chunk = big[(pn - 1) * part_size: pn * part_size]
+        st, etag = put_url(url_by_part[pn], chunk)
+        parts.append({"PartNumber": pn, "ETag": etag})
+    comp = client.post(f"/api/buckets/{BUCKET}/multipart/complete",
+                       json={"key": key2, "upload_id": upload_id, "parts": parts}, cookies=cookies)
+    client.post(f"/api/buckets/{BUCKET}/notify-upload",
+                json={"uploads": [{"key": key2, "size": len(big)}]}, cookies=cookies)
+    got_md5, got_size = s3_object_md5(s3, key2)
+    check("multipart direct upload (120MB, 8 parts)",
+          comp.status_code == 200 and got_md5 == md5(big) and got_size == len(big),
+          f"parts={nparts}, size={got_size}, md5 match={got_md5 == md5(big)}")
+
+    # ── 2b. multipart ABORT cleanup ──
+    init2 = client.post(f"/api/buckets/{BUCKET}/multipart/initiate",
+                        json={"key": "abort-me.bin", "prefix": "e2e/"}, cookies=cookies).json()
+    ab = client.post(f"/api/buckets/{BUCKET}/multipart/abort",
+                     json={"key": "e2e/abort-me.bin", "upload_id": init2["upload_id"]}, cookies=cookies)
+    in_progress = s3.list_multipart_uploads(Bucket=BUCKET).get("Uploads", [])
+    check("multipart abort cleans up", ab.status_code == 200 and not any(u["UploadId"] == init2["upload_id"] for u in in_progress),
+          f"in-progress uploads remaining={len(in_progress)}")
+
+    # ── 3. proxy streaming upload (large file via POST /upload) ──
+    proxy_data = os.urandom(80 * 1024 * 1024)  # 80 MB through the proxy
+    r = client.post(f"/api/buckets/{BUCKET}/upload?",
+                    data={"prefix": "e2e/"},
+                    files={"files": ("proxy.bin", io.BytesIO(proxy_data), "application/octet-stream")},
+                    cookies=cookies)
+    got_md5, got_size = s3_object_md5(s3, "e2e/proxy.bin")
+    check("proxy streaming upload (80MB)", r.status_code == 200 and got_md5 == md5(proxy_data) and got_size == len(proxy_data),
+          f"size={got_size}, md5 match={got_md5 == md5(proxy_data)}")
+
+    # ── 4. index updated (notify-upload + proxy both reflect in the index) ──
+    st = client.get(f"/api/buckets/{BUCKET}/crawl-status", cookies=cookies)
+    # listing the e2e/ prefix should show the 3 uploaded objects
+    lst = client.get(f"/api/buckets/{BUCKET}/list?prefix=e2e/&limit=1000", cookies=cookies)
+    files_listed = json.loads(lst.text.splitlines()[0]).get("files", []) if lst.status_code == 200 else []
+    names = {f["name"] for f in files_listed}
+    check("index reflects direct + proxy uploads", {"small.bin", "big.bin", "proxy.bin"}.issubset(names),
+          f"listed={sorted(names)}")
+
+    print(f"\n  RESULT: {sum(results)}/{len(results)} upload e2e checks PASS")
+    return 0 if all(results) else 1
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/charts/sairo/Chart.yaml
+++ b/charts/sairo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sairo-helm
 description: S3-compatible object storage browser with search, versioning, and analytics
 type: application
-version: 1.1.1
-appVersion: "3.3.1"
+version: 1.2.0
+appVersion: "3.4.0"
 keywords:
   - s3
   - object-storage

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sairo",
-  "version": "3.3.1",
+  "version": "3.4.0",
   "description": "S3-compatible object storage browser with search, versioning, and analytics",
   "private": true,
   "type": "module",

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -557,6 +557,47 @@ export async function notifyUpload(bucket, uploads) {
   return res.json();
 }
 
+// ── Multipart direct upload (browser → S3, parallel, resumable) ──
+export async function multipartInitiate(bucket, key, prefix = "", contentType = "") {
+  const res = await apiFetch(`${bucketBase(bucket)}/multipart/initiate`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, prefix, content_type: contentType }),
+  });
+  if (!res.ok) throw new Error(`Multipart initiate failed: ${res.status}`);
+  return res.json(); // { key, upload_id }
+}
+
+export async function multipartSign(bucket, key, uploadId, partNumbers) {
+  const res = await apiFetch(`${bucketBase(bucket)}/multipart/sign`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, upload_id: uploadId, part_numbers: partNumbers }),
+  });
+  if (!res.ok) throw new Error(`Multipart sign failed: ${res.status}`);
+  return res.json(); // { urls: [{ part_number, url }] }
+}
+
+export async function multipartComplete(bucket, key, uploadId, parts) {
+  const res = await apiFetch(`${bucketBase(bucket)}/multipart/complete`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ key, upload_id: uploadId, parts }),
+  });
+  if (!res.ok) throw new Error(`Multipart complete failed: ${res.status}`);
+  return res.json();
+}
+
+export async function multipartAbort(bucket, key, uploadId) {
+  try {
+    await apiFetch(`${bucketBase(bucket)}/multipart/abort`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key, upload_id: uploadId }),
+    });
+  } catch { /* best-effort cleanup */ }
+}
+
 export function uploadFileWithProgress(bucket, prefix, file, onProgress) {
   const xhr = new XMLHttpRequest();
   const form = new FormData();

--- a/frontend/src/components/UploadModal.jsx
+++ b/frontend/src/components/UploadModal.jsx
@@ -36,6 +36,12 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
     }
   }, []);
 
+  // If the modal unmounts mid-upload (navigation, logout, route change), abort the
+  // in-flight transfers — this also fires each worker's abort path, which calls
+  // multipartAbort() to clean up the partial multipart upload on S3 rather than
+  // leaving detached XHRs and orphaned (billed) parts behind.
+  useEffect(() => () => abortRef.current?.abort(), []);
+
   const addFiles = (newFiles) => {
     setFileStates(prev => [
       ...prev,
@@ -87,15 +93,21 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
 
     // PUT a body to a presigned URL with progress; resolves with the xhr (for ETag).
     const putWithProgress = (url, body, onLoaded) => new Promise((resolve, reject) => {
+      if (abortController.signal.aborted) { reject(Object.assign(new Error("Aborted"), { name: "AbortError" })); return; }
       const xhr = new XMLHttpRequest();
+      const onAbort = () => xhr.abort();
+      // Remove the signal listener on every terminal path — otherwise a many-part
+      // upload accretes thousands of listeners (each retaining its XHR) on the
+      // session-long AbortController.
+      const done = (fn) => { abortController.signal.removeEventListener("abort", onAbort); fn(); };
       xhr.upload.addEventListener("progress", (e) => { if (e.lengthComputable) onLoaded(e.loaded); });
-      xhr.addEventListener("load", () => {
+      xhr.addEventListener("load", () => done(() => {
         if (xhr.status >= 200 && xhr.status < 300) resolve(xhr);
-        else reject(new Error(`S3 upload failed: ${xhr.status}`));
-      });
-      xhr.addEventListener("error", () => reject(new Error("Network error")));
-      xhr.addEventListener("abort", () => { const er = new Error("Aborted"); er.name = "AbortError"; reject(er); });
-      abortController.signal.addEventListener("abort", () => xhr.abort());
+        else reject(Object.assign(new Error(`S3 upload failed: ${xhr.status}`), { status: xhr.status }));
+      }));
+      xhr.addEventListener("error", () => done(() => reject(new Error("Network error"))));
+      xhr.addEventListener("abort", () => done(() => reject(Object.assign(new Error("Aborted"), { name: "AbortError" }))));
+      abortController.signal.addEventListener("abort", onAbort);
       xhr.open("PUT", url);
       xhr.send(body);
     });
@@ -123,15 +135,6 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
 
       const { key, upload_id: uploadId } = await multipartInitiate(bucket, file.name, prefix, file.type || "");
       try {
-        // Presign all parts (batched: the sign endpoint accepts up to 1000 at a time).
-        const urlByPart = {};
-        for (let start = 1; start <= numParts; start += 1000) {
-          const nums = [];
-          for (let p = start; p < start + 1000 && p <= numParts; p++) nums.push(p);
-          const { urls } = await multipartSign(bucket, key, uploadId, nums);
-          for (const u of urls) urlByPart[u.part_number] = u.url;
-        }
-
         const loadedPerPart = new Array(numParts + 1).fill(0);
         const refreshProgress = () => {
           const loaded = loadedPerPart.reduce((a, b) => a + b, 0);
@@ -151,13 +154,20 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
             let attempt = 0;
             for (;;) {
               try {
-                const xhr = await putWithProgress(urlByPart[part], blob, (loaded) => { loadedPerPart[part] = loaded; refreshProgress(); });
+                // Sign the part JUST BEFORE uploading it (and again on every retry) so a
+                // presigned URL can never expire before use — a large/slow upload can run
+                // for hours, far past any single URL's TTL. Re-signing also recovers from a
+                // 403 (expired/clock-skew) instead of hammering a dead URL.
+                const { urls } = await multipartSign(bucket, key, uploadId, [part]);
+                const xhr = await putWithProgress(urls[0].url, blob, (loaded) => { loadedPerPart[part] = loaded; refreshProgress(); });
                 const etag = xhr.getResponseHeader("ETag");
-                if (!etag) throw new Error("Missing ETag on part (check S3 CORS ExposeHeaders)");
+                // No ETag means the bucket's CORS doesn't expose it — retrying won't help
+                // (it's a config problem, not transient), so fail fast with a clear message.
+                if (!etag) throw Object.assign(new Error("Bucket CORS must expose the ETag header for multipart upload"), { fatal: true });
                 etags[part] = etag;
                 break;
               } catch (e) {
-                if (e.name === "AbortError") throw e;
+                if (e.name === "AbortError" || e.fatal) throw e;
                 if (++attempt > PART_RETRIES) throw e;
                 loadedPerPart[part] = 0; refreshProgress();
                 await new Promise(r => setTimeout(r, 500 * attempt));  // backoff, then retry this part
@@ -377,7 +387,9 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
         )}
 
         <div className="modal-actions">
-          <button onClick={onClose} disabled={uploading}>Cancel</button>
+          <button onClick={uploading ? () => abortRef.current?.abort() : onClose}>
+            {uploading ? "Stop" : "Cancel"}
+          </button>
           <button
             onClick={handleUpload}
             disabled={uploading || pendingCount === 0}

--- a/frontend/src/components/UploadModal.jsx
+++ b/frontend/src/components/UploadModal.jsx
@@ -1,7 +1,18 @@
 import React, { useState, useRef, useEffect } from "react";
-import { formatSize, getPresignedUploadUrls, notifyUpload, getUploadUrl } from "../api";
+import { formatSize, getPresignedUploadUrls, notifyUpload, getUploadUrl,
+  multipartInitiate, multipartSign, multipartComplete, multipartAbort } from "../api";
 
-const CONCURRENCY = 4;
+const CONCURRENCY = 4;                           // files uploaded in parallel
+const MULTIPART_THRESHOLD = 100 * 1024 * 1024;   // files larger than this use multipart
+const PART_SIZE_MIN = 16 * 1024 * 1024;          // 16 MB base part size
+const PART_CONCURRENCY = 4;                      // parts uploaded in parallel within one file
+const PART_RETRIES = 3;                          // per-part retry attempts (resumable within session)
+
+function computePartSize(fileSize) {
+  let size = PART_SIZE_MIN;
+  while (Math.ceil(fileSize / size) > 10000) size *= 2;  // S3 allows at most 10,000 parts
+  return size;
+}
 
 function formatEta(seconds) {
   if (seconds < 60) return `${Math.ceil(seconds)}s`;
@@ -42,7 +53,9 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
     setFileStates(prev => prev.filter((_, i) => i !== idx));
   };
 
-  // ── Direct upload via presigned PUT URLs (no file data through Sairo) ──
+  // ── Direct upload (no file data through Sairo) ──
+  // Small files: single presigned PUT. Large files: parallel, resumable multipart
+  // (parts PUT directly to S3) — no proxy buffering, no size ceiling, no pod OOM.
   const handleDirectUpload = async () => {
     setUploading(true);
     let completed = 0;
@@ -54,89 +67,134 @@ export default function UploadModal({ bucket, prefix, initialFiles, onClose, onU
       .map((fs, i) => ({ fs, i }))
       .filter(({ fs }) => fs.status !== "complete" && fs.status !== "error");
 
-    // Get presigned PUT URLs for all files
-    let urlMap;
+    const setFs = (i, patch) =>
+      setFileStates(prev => prev.map((s, idx) => (idx === i ? { ...s, ...patch } : s)));
+
+    // Presigned single-PUT URLs for the small files (batched).
+    const smallKeys = pending.filter(({ fs }) => fs.file.size <= MULTIPART_THRESHOLD).map(({ fs }) => fs.file.name);
+    const urlMap = {};
     try {
-      const keys = pending.map(({ fs }) => fs.file.name);
-      const resp = await getPresignedUploadUrls(bucket, keys, prefix);
-      urlMap = {};
-      for (const entry of resp.urls) {
-        urlMap[entry.key] = entry.url;
+      if (smallKeys.length) {
+        const resp = await getPresignedUploadUrls(bucket, smallKeys, prefix);
+        for (const entry of resp.urls) urlMap[entry.key] = entry.url;
       }
     } catch (err) {
-      // Presigned upload not available — fall back to proxy upload
+      // Presigned upload not available — fall back to proxy upload.
       setDirectMode(false);
       setUploading(false);
       return;
     }
 
-    const uploadOne = async ({ fs, i }) => {
-      if (abortController.signal.aborted) return;
+    // PUT a body to a presigned URL with progress; resolves with the xhr (for ETag).
+    const putWithProgress = (url, body, onLoaded) => new Promise((resolve, reject) => {
+      const xhr = new XMLHttpRequest();
+      xhr.upload.addEventListener("progress", (e) => { if (e.lengthComputable) onLoaded(e.loaded); });
+      xhr.addEventListener("load", () => {
+        if (xhr.status >= 200 && xhr.status < 300) resolve(xhr);
+        else reject(new Error(`S3 upload failed: ${xhr.status}`));
+      });
+      xhr.addEventListener("error", () => reject(new Error("Network error")));
+      xhr.addEventListener("abort", () => { const er = new Error("Aborted"); er.name = "AbortError"; reject(er); });
+      abortController.signal.addEventListener("abort", () => xhr.abort());
+      xhr.open("PUT", url);
+      xhr.send(body);
+    });
 
+    const uploadSingle = async ({ fs, i }) => {
       const key = prefix + fs.file.name;
       const url = urlMap[key];
-      if (!url) return;
-
+      if (!url) throw new Error("No presigned URL");
       taskStartTimes.current[i] = Date.now();
-      setFileStates(prev => prev.map((s, idx) =>
-        idx === i ? { ...s, status: "uploading", progress: 0, eta: null } : s
-      ));
+      setFs(i, { status: "uploading", progress: 0, eta: null });
+      await putWithProgress(url, fs.file, (loaded) => {
+        const elapsed = (Date.now() - taskStartTimes.current[i]) / 1000;
+        const bps = elapsed > 0.5 ? loaded / elapsed : 0;
+        setFs(i, { progress: (loaded / fs.file.size) * 100, eta: bps > 0 ? (fs.file.size - loaded) / bps : null });
+      });
+      await notifyUpload(bucket, [{ key, size: fs.file.size }]).catch(() => {});
+    };
 
+    const uploadMultipartFile = async ({ fs, i }) => {
+      const file = fs.file;
+      const partSize = computePartSize(file.size);
+      const numParts = Math.ceil(file.size / partSize);
+      taskStartTimes.current[i] = Date.now();
+      setFs(i, { status: "uploading", progress: 0, eta: null });
+
+      const { key, upload_id: uploadId } = await multipartInitiate(bucket, file.name, prefix, file.type || "");
       try {
-        await new Promise((resolve, reject) => {
-          const xhr = new XMLHttpRequest();
-          xhr.upload.addEventListener("progress", (e) => {
-            if (e.lengthComputable) {
-              const pct = (e.loaded / e.total) * 100;
-              const elapsed = (Date.now() - taskStartTimes.current[i]) / 1000;
-              const bytesPerSec = elapsed > 0.5 ? e.loaded / elapsed : 0;
-              const eta = bytesPerSec > 0 ? (e.total - e.loaded) / bytesPerSec : null;
-              setFileStates(prev => prev.map((s, idx) =>
-                idx === i ? { ...s, progress: pct, eta } : s
-              ));
+        // Presign all parts (batched: the sign endpoint accepts up to 1000 at a time).
+        const urlByPart = {};
+        for (let start = 1; start <= numParts; start += 1000) {
+          const nums = [];
+          for (let p = start; p < start + 1000 && p <= numParts; p++) nums.push(p);
+          const { urls } = await multipartSign(bucket, key, uploadId, nums);
+          for (const u of urls) urlByPart[u.part_number] = u.url;
+        }
+
+        const loadedPerPart = new Array(numParts + 1).fill(0);
+        const refreshProgress = () => {
+          const loaded = loadedPerPart.reduce((a, b) => a + b, 0);
+          const elapsed = (Date.now() - taskStartTimes.current[i]) / 1000;
+          const bps = elapsed > 0.5 ? loaded / elapsed : 0;
+          setFs(i, { progress: (loaded / file.size) * 100, eta: bps > 0 ? (file.size - loaded) / bps : null });
+        };
+
+        const etags = new Array(numParts + 1);
+        let nextPart = 1;
+        const worker = async () => {
+          while (nextPart <= numParts) {
+            if (abortController.signal.aborted) throw Object.assign(new Error("Aborted"), { name: "AbortError" });
+            const part = nextPart++;
+            const startByte = (part - 1) * partSize;
+            const blob = file.slice(startByte, Math.min(startByte + partSize, file.size));
+            let attempt = 0;
+            for (;;) {
+              try {
+                const xhr = await putWithProgress(urlByPart[part], blob, (loaded) => { loadedPerPart[part] = loaded; refreshProgress(); });
+                const etag = xhr.getResponseHeader("ETag");
+                if (!etag) throw new Error("Missing ETag on part (check S3 CORS ExposeHeaders)");
+                etags[part] = etag;
+                break;
+              } catch (e) {
+                if (e.name === "AbortError") throw e;
+                if (++attempt > PART_RETRIES) throw e;
+                loadedPerPart[part] = 0; refreshProgress();
+                await new Promise(r => setTimeout(r, 500 * attempt));  // backoff, then retry this part
+              }
             }
-          });
-          xhr.addEventListener("load", () => {
-            if (xhr.status >= 200 && xhr.status < 300) resolve();
-            else reject(new Error(`S3 upload failed: ${xhr.status}`));
-          });
-          xhr.addEventListener("error", () => reject(new Error("Network error")));
-          xhr.addEventListener("abort", () => {
-            const err = new Error("Aborted");
-            err.name = "AbortError";
-            reject(err);
-          });
-          abortController.signal.addEventListener("abort", () => xhr.abort());
-          xhr.open("PUT", url);
-          xhr.send(fs.file);
-        });
+          }
+        };
+        await Promise.all(Array.from({ length: Math.min(PART_CONCURRENCY, numParts) }, () => worker()));
 
-        completed++;
-        setFileStates(prev => prev.map((s, idx) =>
-          idx === i ? { ...s, status: "complete", progress: 100, eta: null } : s
-        ));
-
-        // Notify Sairo to update index
-        try {
-          await notifyUpload(bucket, [{ key, size: fs.file.size }]);
-        } catch { /* index will update on next crawl */ }
-
-      } catch (err) {
-        if (err.name === "AbortError") return;
-        errors++;
-        setFileStates(prev => prev.map((s, idx) =>
-          idx === i ? { ...s, status: "error", progress: 0, eta: null } : s
-        ));
+        const parts = [];
+        for (let p = 1; p <= numParts; p++) parts.push({ PartNumber: p, ETag: etags[p] });
+        await multipartComplete(bucket, key, uploadId, parts);
+        await notifyUpload(bucket, [{ key, size: file.size }]).catch(() => {});
+      } catch (e) {
+        await multipartAbort(bucket, key, uploadId);  // clean up the partial upload on S3
+        throw e;
       }
     };
 
-    // Run with concurrency limit
+    const uploadOne = async ({ fs, i }) => {
+      if (abortController.signal.aborted) return;
+      try {
+        if (fs.file.size > MULTIPART_THRESHOLD) await uploadMultipartFile({ fs, i });
+        else await uploadSingle({ fs, i });
+        completed++;
+        setFs(i, { status: "complete", progress: 100, eta: null });
+      } catch (err) {
+        if (err.name === "AbortError") return;
+        errors++;
+        setFs(i, { status: "error", progress: 0, eta: null });
+      }
+    };
+
+    // File-level concurrency.
     let cursor = 0;
     const runNext = async () => {
-      while (cursor < pending.length) {
-        const item = pending[cursor++];
-        await uploadOne(item);
-      }
+      while (cursor < pending.length) await uploadOne(pending[cursor++]);
     };
     await Promise.all(Array.from({ length: Math.min(CONCURRENCY, pending.length) }, () => runNext()));
 


### PR DESCRIPTION
Closes #6.

## Problem
Uploads were proxied through the server, which read each whole file into memory → OOM / pod restarts and a ~500 MB ceiling in k8s.

## Solution
- **Small files** (≤100 MB): single presigned PUT — browser → S3 directly.
- **Large files**: presigned **multipart** — browser PUTs each part directly to S3 in parallel; no bytes through the server, no 5 GB single-PUT ceiling.
- **Proxy fallback**: still available, but now **streams** to S3 with memory bounded by `UPLOAD_PROXY_CONCURRENCY` × ~100 MB (independent of file size).

## Key fixes (from an adversarial review + real-browser validation)
- **CSP blocked direct uploads** — `connect-src 'self'` silently blocked the browser→S3 PUT (a different origin). `connect-src` now includes the configured S3 endpoint origin(s). *(This also fixes v3.3.0's direct upload.)*
- **Part-URL expiry** — parts are signed just-in-time and re-signed on retry, so long multi-GB uploads can't fail from an expired URL mid-transfer.
- **CORS ETag exposure** — a pre-existing PUT rule lacking `ExposeHeaders: ETag` is upgraded in place (the browser must read each part's ETag).
- **Cancel/cleanup** — Stop button + abort-on-unmount abort the S3 multipart upload (no orphaned parts); per-part abort-listener leak fixed.
- Input validation (part numbers 1–10000, well-formed parts → 400), rate-limiting, audit logging on the multipart endpoints; proxy memory cap; dead-code/message cleanup.

## Validation
- 72/72 unit tests; upload e2e 5/5 (single-PUT / multipart+JIT-sign+resign / abort / proxy) md5-verified against MinIO.
- Memory: 500 MB upload → +501 MB (before) vs **+96 MB (after)**, bounded regardless of size.
- **Real browser (Playwright): 9/9** — login, browse, navigate, search, Insights, direct/multipart/proxy uploads, Stop; uploaded objects md5-verified in S3.
- Backend regression: list/search/breakdown/cost/optimization/versioning/crawl-status/multipart all 200.

## Not in this PR (deferred, documented)
- All-large-batch auto-fallback to proxy (manual toggle exists).
- Pre-existing IDOR on `/api/e/{endpoint}/buckets/...` read routes — that's #8, not introduced here; write/multipart endpoints fail closed.

## Note
`_ensure_upload_cors` rule creation/upgrade can only run against real S3 (MinIO doesn't implement the bucket-CORS API), so that one path is verified by review, not by the MinIO e2e.