### PR TITLE
fix: scope S3-key auth to the user's own keys across endpoints (v3.4.1, closes #8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to Sairo are documented here. This project uses [Semantic Versioning](https://semver.org/).
 
+## [3.4.1] - 2026-06-27
+
+Security/correctness fix for S3-key authentication with multiple endpoints (issue #8). Previously a user who logged in with S3 access keys could see and manage **every** bucket on **every** configured endpoint, because the server used its own stored endpoint credentials (and an unconditional admin role) for all operations and discarded the user's keys.
+
+### Fixed
+
+- **S3-key sessions now act with the user's own keys** — in `AUTH_MODE=s3`, every S3 call (bucket listing, object listing/preview/download, uploads, presigned URLs) is made with the **logged-in user's** access key, so the provider's IAM scopes exactly what they can see and do. Logging in with one account's keys shows only that account's buckets, not other endpoints'. The keys are kept encrypted in the session token (Fernet, same key that protects stored endpoint credentials) so this works statelessly across replicas.
+- **The local index is no longer an access bypass** — object listings are served from Sairo's per-bucket index (built with server credentials), so S3-key requests are now independently gated by a `head_bucket` check with the user's keys (cached briefly) before any indexed data is returned.
+- **Per-bucket permission checks could be bypassed via the multi-endpoint path** — `bucket_permission_middleware` ran *before* the `/api/e/{endpoint}/...` path rewrite, so prefixing a bucket URL with `/api/e/<id>/` skipped the permission check entirely (an IDOR on read routes). The middleware now runs after the rewrite, and S3-key sessions are bound to the endpoint they authenticated against.
+- **Bucket-list cache no longer shared across users** — the 30s `/api/buckets` cache (keyed by nothing) is bypassed for S3-key sessions so one user's bucket list can't be served to another.
+
 ## [3.4.0] - 2026-06-15
 
 Direct browser→S3 uploads for files of any size — closes the proxy-upload OOM / size-ceiling problem (issue #6). Validated end-to-end against MinIO (all paths, md5-verified) and in a real browser, with measured memory bounds.

--- a/backend/main.py
+++ b/backend/main.py
@@ -109,34 +109,64 @@ async def security_headers_middleware(request: Request, call_next):
     return response
 
 
-# ── Multi-Endpoint URL Rewriting Middleware ─────────────────────────────────
+# ── S3-key session helpers (AUTH_MODE=s3) ──────────────────────────────────
 
-@app.middleware("http")
-async def endpoint_routing_middleware(request: Request, call_next):
-    """Rewrite /api/e/{endpoint_id}/... → /api/... and set endpoint context for S3 client proxy."""
-    path = request.url.path
-    endpoint_id = "default"
-    if path.startswith("/api/e/"):
-        parts = path.split("/")
-        # parts: ['', 'api', 'e', endpoint_id, ...]
-        if len(parts) >= 5:
-            endpoint_id = parts[3]
-            # Rewrite URL: remove /e/{endpoint_id} segment
-            new_path = "/api/" + "/".join(parts[4:])
-            request.scope["path"] = new_path
-    request.state.endpoint_id = endpoint_id
-    # Set context variable — propagates to sync handlers via Starlette's run_in_threadpool
-    token = _endpoint_ctx.set(endpoint_id)
+def _extract_s3_session(request: Request):
+    """For AUTH_MODE=s3 cookie sessions, decode the JWT and return the user's
+    {ak, sk, eid} (decrypted). Returns None otherwise (password mode, API tokens,
+    no/invalid cookie). API-token (Bearer) sessions intentionally keep server creds."""
+    if AUTH_MODE != "s3":
+        return None
+    token = request.cookies.get("access_token")
+    if not token:
+        return None
     try:
-        return await call_next(request)
-    finally:
-        _endpoint_ctx.reset(token)
+        p = jwt.decode(token, JWT_SECRET, algorithms=["HS256"])
+    except Exception:
+        return None
+    ak_enc = p.get("s3ak")
+    if not ak_enc:
+        return None
+    ak = _decrypt(ak_enc)
+    if not ak:
+        return None
+    return {"ak": ak, "sk": _decrypt(p.get("s3sk", "")), "eid": p.get("eid", "default")}
+
+
+_bucket_access_cache: dict = {}  # (ak_hash, eid, bucket) -> (ts, bool)
+_bucket_access_lock = threading.Lock()
+_BUCKET_ACCESS_TTL = 60
+
+
+def _s3_user_can_access(creds: dict, endpoint_id: str, bucket: str) -> bool:
+    """True if the user's S3 keys can reach this bucket (provider IAM is the source of
+    truth). head_bucket result cached briefly so it isn't called on every request."""
+    ak_hash = hashlib.sha256(creds["ak"].encode()).hexdigest()[:16]
+    key = (ak_hash, endpoint_id, bucket)
+    now = time.time()
+    with _bucket_access_lock:
+        hit = _bucket_access_cache.get(key)
+        if hit and now - hit[0] < _BUCKET_ACCESS_TTL:
+            return hit[1]
+    try:
+        _s3_manager.get_client(endpoint_id).head_bucket(Bucket=bucket)  # uses user creds (ctx set)
+        ok = True
+    except Exception:
+        ok = False
+    with _bucket_access_lock:
+        if len(_bucket_access_cache) > 2000:
+            _bucket_access_cache.clear()
+        _bucket_access_cache[key] = (now, ok)
+    return ok
+
 
 # ── Bucket Permission Middleware ────────────────────────────────────────────
+# Registered BEFORE endpoint_routing_middleware (below) so it ends up INNER: it runs
+# after the path is rewritten and after the S3-key user's creds are in context.
 
 @app.middleware("http")
 async def bucket_permission_middleware(request: Request, call_next):
-    """Check per-bucket permissions for all /api/buckets/{bucket}/... routes."""
+    """Per-bucket access control for /api/buckets/{bucket}/... routes."""
     path = request.scope.get("path", request.url.path)
     if not path.startswith("/api/buckets/"):
         return await call_next(request)
@@ -144,16 +174,25 @@ async def bucket_permission_middleware(request: Request, call_next):
     if len(parts) < 4:
         return await call_next(request)
     bucket = parts[3]
-    # Try to get user — if auth fails, let endpoint handle 401
     try:
         user = get_current_user(request)
     except HTTPException:
+        return await call_next(request)
+    # AUTH_MODE=s3: the user acts with their own keys. Object listings are served from
+    # the LOCAL index (built with server creds), so we must independently confirm the
+    # user's keys can actually reach this bucket — otherwise the index would be an
+    # access bypass. The provider's IAM (cached head_bucket) is the source of truth.
+    creds = _user_creds_ctx.get(None)
+    if creds and creds.get("ak"):
+        if not _s3_user_can_access(creds, request.state.endpoint_id, bucket):
+            return JSONResponse(status_code=403, content={"detail": "No access to this bucket"})
+        request.state.bucket_permission = "write"  # actual op authority enforced by S3 IAM
         return await call_next(request)
     # Admin bypasses everything
     if user["role"] == "admin":
         request.state.bucket_permission = "admin"
         return await call_next(request)
-    # Non-admin: lookup bucket permission
+    # Non-admin (password mode): lookup bucket permission
     with _get_users_db() as db:
         row = db.execute(
             "SELECT permission FROM bucket_permissions WHERE username=? AND bucket=?",
@@ -167,6 +206,42 @@ async def bucket_permission_middleware(request: Request, call_next):
     if request.method != "GET" and permission != "write":
         return JSONResponse(status_code=403, content={"detail": "Write access required"})
     return await call_next(request)
+
+
+# ── Multi-Endpoint URL Rewriting + S3-key session Middleware ────────────────
+# Registered LAST → OUTERMOST: runs first on the way in, so the path is rewritten and
+# the S3-key user's credentials/endpoint are bound into context BEFORE the permission
+# middleware and route handler execute.
+
+@app.middleware("http")
+async def endpoint_routing_middleware(request: Request, call_next):
+    """Rewrite /api/e/{endpoint_id}/... → /api/..., set endpoint context, and (in
+    AUTH_MODE=s3) bind the request to the logged-in user's endpoint + credentials."""
+    path = request.url.path
+    endpoint_id = "default"
+    if path.startswith("/api/e/"):
+        parts = path.split("/")
+        # parts: ['', 'api', 'e', endpoint_id, ...]
+        if len(parts) >= 5:
+            endpoint_id = parts[3]
+            request.scope["path"] = "/api/" + "/".join(parts[4:])
+    # S3-key session: carry the user's own keys + bind to the endpoint they logged into
+    # (ignore the routing endpoint, so an S3-key user can't reach another endpoint).
+    user_creds = None
+    scope_path = request.scope.get("path", path)
+    if scope_path.startswith("/api/"):
+        sess = _extract_s3_session(request)
+        if sess:
+            user_creds = {"ak": sess["ak"], "sk": sess["sk"]}
+            endpoint_id = sess["eid"]
+    request.state.endpoint_id = endpoint_id
+    t_e = _endpoint_ctx.set(endpoint_id)
+    t_u = _user_creds_ctx.set(user_creds)
+    try:
+        return await call_next(request)
+    finally:
+        _endpoint_ctx.reset(t_e)
+        _user_creds_ctx.reset(t_u)
 
 
 # ── Login Rate Limiter ──────────────────────────────────────────────────────
@@ -219,7 +294,7 @@ async def s3_error_handler(request, exc):
 
 
 _app_start_time = time.time()
-SAIRO_VERSION = "3.4.0"
+SAIRO_VERSION = "3.4.1"
 TELEMETRY = os.environ.get("TELEMETRY", "true").lower() != "false"
 
 S3_ENDPOINT = os.environ.get("S3_ENDPOINT", "")
@@ -308,6 +383,7 @@ class S3ClientManager:
         self._clients: dict = {}
         self._lock = threading.Lock()
         self._endpoints: dict = {}  # endpoint_id -> {endpoint_url, access_key, secret_key, region, path_style}
+        self._user_clients: dict = {}  # (endpoint_id, access_key_hash) -> client (AUTH_MODE=s3, per-user creds)
 
     def register(self, endpoint_id: str, endpoint_url: str, access_key: str, secret_key: str,
                  region: str = "", path_style: bool = False):
@@ -317,33 +393,62 @@ class S3ClientManager:
                 "secret_key": secret_key, "region": region, "path_style": path_style,
             }
             self._clients.pop(endpoint_id, None)  # Invalidate cached client
+            for k in [k for k in self._user_clients if k[0] == endpoint_id]:
+                self._user_clients.pop(k, None)
+
+    def _build_client(self, info: dict, access_key: str, secret_key: str):
+        cfg = _S3_CONFIG
+        if info.get("path_style"):
+            cfg = _S3_CONFIG.merge(Config(s3={"addressing_style": "path"}))
+        kwargs = {
+            "endpoint_url": info["endpoint_url"],
+            "aws_access_key_id": access_key,
+            "aws_secret_access_key": secret_key,
+            "config": cfg,
+        }
+        if info["region"]:
+            kwargs["region_name"] = info["region"]
+        return boto3.client("s3", **kwargs)
 
     def get_client(self, endpoint_id: str = "default"):
+        # AUTH_MODE=s3: when a request carries the user's own S3 keys, every S3 call
+        # uses THOSE keys (provider IAM scopes the result) against the endpoint's
+        # connection params. Background threads / password sessions have no creds in
+        # context → fall through to the shared server client below.
+        creds = _user_creds_ctx.get(None)
+        if creds and creds.get("ak"):
+            return self._get_user_client(endpoint_id, creds["ak"], creds["sk"])
         with self._lock:
             if endpoint_id in self._clients:
                 return self._clients[endpoint_id]
             info = self._endpoints.get(endpoint_id)
             if not info:
                 raise HTTPException(404, f"S3 endpoint '{endpoint_id}' not found")
-            cfg = _S3_CONFIG
-            if info.get("path_style"):
-                cfg = _S3_CONFIG.merge(Config(s3={"addressing_style": "path"}))
-            kwargs = {
-                "endpoint_url": info["endpoint_url"],
-                "aws_access_key_id": info["access_key"],
-                "aws_secret_access_key": info["secret_key"],
-                "config": cfg,
-            }
-            if info["region"]:
-                kwargs["region_name"] = info["region"]
-            client = boto3.client("s3", **kwargs)
+            client = self._build_client(info, info["access_key"], info["secret_key"])
             self._clients[endpoint_id] = client
+            return client
+
+    def _get_user_client(self, endpoint_id: str, access_key: str, secret_key: str):
+        info = self._endpoints.get(endpoint_id) or self._endpoints.get("default")
+        if not info:
+            raise HTTPException(404, f"S3 endpoint '{endpoint_id}' not found")
+        ak_hash = hashlib.sha256(access_key.encode()).hexdigest()[:16]
+        key = (endpoint_id, ak_hash)
+        with self._lock:
+            client = self._user_clients.get(key)
+            if client is None:
+                if len(self._user_clients) > 256:  # bound the cache; drop oldest insert
+                    self._user_clients.pop(next(iter(self._user_clients)), None)
+                client = self._build_client(info, access_key, secret_key)
+                self._user_clients[key] = client
             return client
 
     def invalidate(self, endpoint_id: str):
         with self._lock:
             self._clients.pop(endpoint_id, None)
             self._endpoints.pop(endpoint_id, None)
+            for k in [k for k in self._user_clients if k[0] == endpoint_id]:
+                self._user_clients.pop(k, None)
 
     def get_endpoint_info(self, endpoint_id: str):
         return self._endpoints.get(endpoint_id)
@@ -359,6 +464,12 @@ _s3_manager.register("default", S3_ENDPOINT, S3_ACCESS_KEY, S3_SECRET_KEY, _S3_R
 
 # Context variable for current endpoint — propagates across async/sync boundaries in Starlette
 _endpoint_ctx: contextvars.ContextVar[str] = contextvars.ContextVar("_endpoint_ctx", default="default")
+
+# Per-request S3 credentials for AUTH_MODE=s3 — when set, every S3 client built for
+# this request uses the LOGGED-IN USER's keys instead of the server's endpoint creds,
+# so the provider's IAM scopes exactly what the user can see/do. None for password-mode
+# sessions, API tokens, and background (crawl) threads → those keep using server creds.
+_user_creds_ctx: contextvars.ContextVar[Optional[dict]] = contextvars.ContextVar("_user_creds_ctx", default=None)
 
 # Keep thread-local as fallback for background threads that set it explicitly
 _s3_context = threading.local()
@@ -2272,6 +2383,7 @@ class LoginRequest(BaseModel):
 class LoginS3Request(BaseModel):
     access_key: str
     secret_key: str
+    endpoint_id: str = "default"  # which configured endpoint to authenticate against
 
 class CreateUserRequest(BaseModel):
     username: str
@@ -2326,28 +2438,25 @@ def auth_login_s3(req: LoginS3Request, request: Request):
     _check_login_rate(request.client.host)
     if not req.access_key or not req.secret_key:
         raise HTTPException(400, "Access key and secret key are required")
-    # Test the S3 credentials
+    # Validate the USER's keys against the chosen endpoint's connection params, then
+    # keep them (encrypted) in the session token so every later S3 call is made AS the
+    # user — the provider's IAM then scopes exactly what they can see and do.
+    eid = req.endpoint_id or "default"
+    info = _s3_manager.get_endpoint_info(eid) or _s3_manager.get_endpoint_info("default")
+    if not info:
+        raise HTTPException(400, "No S3 endpoint configured")
     try:
-        cfg = _S3_CONFIG
-        if _S3_PATH_STYLE:
-            cfg = _S3_CONFIG.merge(Config(s3={"addressing_style": "path"}))
-        test_client = boto3.client(
-            "s3",
-            endpoint_url=S3_ENDPOINT,
-            aws_access_key_id=req.access_key,
-            aws_secret_access_key=req.secret_key,
-            region_name=_S3_REGION or None,
-            config=cfg,
-        )
+        test_client = _s3_manager._build_client(info, req.access_key, req.secret_key)
         test_client.list_buckets()
     except Exception as e:
         log.warning("S3 auth failed for access_key=%s: %s", req.access_key[:6] + "...", e)
         raise HTTPException(401, "Invalid S3 credentials")
-    # Credentials valid — issue a session as admin
-    # Use a sanitized version of the access key as the username
+    # Credentials valid — issue a session as admin. Use a sanitized version of the
+    # access key as the username; carry the user's keys encrypted in the JWT.
     username = f"s3:{req.access_key[:8]}"
     token = jwt.encode(
-        {"sub": username, "role": "admin",
+        {"sub": username, "role": "admin", "eid": eid,
+         "s3ak": _encrypt(req.access_key), "s3sk": _encrypt(req.secret_key),
          "exp": datetime.now(timezone.utc) + timedelta(hours=SESSION_HOURS)},
         JWT_SECRET, algorithm="HS256")
     response = JSONResponse({"username": username, "role": "admin"})
@@ -3559,6 +3668,12 @@ def list_all_buckets(user: dict = Depends(get_current_user)):
     result = []
     with _get_users_db() as db:
         endpoints = db.execute("SELECT id, name, endpoint_url FROM s3_endpoints ORDER BY is_default DESC, created_at").fetchall()
+    # AUTH_MODE=s3: scope to the single endpoint the user authenticated against, listed
+    # with THEIR keys — so they see only their account's buckets, not every endpoint's.
+    s3_creds = _user_creds_ctx.get(None)
+    if s3_creds and s3_creds.get("ak"):
+        bound_eid = _current_endpoint_id()  # middleware bound this to the user's login endpoint
+        endpoints = [ep for ep in endpoints if ep["id"] == bound_eid] or [ep for ep in endpoints if ep["id"] == "default"]
     for ep in endpoints:
         eid = ep["id"]
         try:
@@ -3601,14 +3716,22 @@ _BUCKET_LIST_TTL = 30  # seconds
 @app.get("/api/buckets")
 def list_buckets(user: dict = Depends(get_current_user)):
     now = time.time()
-    with _bucket_list_cache_lock:
-        if _bucket_list_cache["data"] and now - _bucket_list_cache["ts"] < _BUCKET_LIST_TTL:
-            resp = _bucket_list_cache["data"]
-        else:
-            resp = s3.list_buckets()
-            _bucket_list_cache["data"] = resp
-            _bucket_list_cache["ts"] = now
-    # Non-admin: only show buckets with explicit permissions
+    s3_creds = _user_creds_ctx.get(None)
+    if s3_creds and s3_creds.get("ak"):
+        # AUTH_MODE=s3: list with the USER's keys so the provider IAM scopes the result.
+        # Never use the shared cache here — it's keyed by nothing and would leak one
+        # user's bucket list to another.
+        resp = s3.list_buckets()
+    else:
+        with _bucket_list_cache_lock:
+            if _bucket_list_cache["data"] and now - _bucket_list_cache["ts"] < _BUCKET_LIST_TTL:
+                resp = _bucket_list_cache["data"]
+            else:
+                resp = s3.list_buckets()
+                _bucket_list_cache["data"] = resp
+                _bucket_list_cache["ts"] = now
+    # Non-admin: only show buckets with explicit permissions. S3-key users are already
+    # scoped by their keys above, so no extra filter (their role is admin).
     allowed = None
     if user["role"] != "admin":
         with _get_users_db() as udb:

--- a/benchmark/test_s3_key_scoping.py
+++ b/benchmark/test_s3_key_scoping.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Issue #8: S3-key auth must scope a user to ONLY the buckets their keys can access,
+across multi-endpoint setups. Drives the real FastAPI stack (login → middleware →
+endpoints) in AUTH_MODE=s3 against a FAKE S3 that enforces per-key IAM scoping, so the
+behaviour is verified deterministically without a live MinIO/Ceph.
+
+Scenario: provider has bucket-a (only TKEYUSERA can touch) and bucket-b (only TKEYUSERB).
+A user logging in with TKEYUSERA must see/manage bucket-a only — never bucket-b, and
+never via the /api/e/ endpoint-routing path either.
+"""
+import os, sys, json
+from datetime import datetime, timezone
+
+os.environ.update({
+    "AUTH_MODE": "s3",
+    "S3_ENDPOINT": "http://fake-s3.local:9000",
+    "S3_ACCESS_KEY": "serverroot", "S3_SECRET_KEY": "serverrootsecret",
+    "S3_REGION": "us-east-1", "JWT_SECRET": "scopingtestsecretscopingtestsecret01",
+    "SECURE_COOKIE": "false", "DB_DIR": "/tmp/sairo-scoping", "RECRAWL_INTERVAL": "100000",
+})
+import shutil; shutil.rmtree("/tmp/sairo-scoping", ignore_errors=True); os.makedirs("/tmp/sairo-scoping", exist_ok=True)
+import logging; logging.getLogger("sairo").setLevel(logging.ERROR)
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "backend"))
+import main  # noqa: E402
+from botocore.exceptions import ClientError  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+# ── Fake S3 enforcing per-key scoping (stands in for MinIO/Ceph IAM) ──
+ACCESS = {  # which access key may touch which buckets
+    "TKEYUSERA": {"bucket-a"},
+    "TKEYUSERB": {"bucket-b"},
+    "serverroot": {"bucket-a", "bucket-b"},  # the server/root creds see everything
+}
+ALL_BUCKETS = ["bucket-a", "bucket-b"]
+
+class FakeS3:
+    def __init__(self, access_key):
+        self.ak = access_key
+    def _allowed(self):
+        return ACCESS.get(self.ak, set())
+    def list_buckets(self):
+        if self.ak not in ACCESS:  # unknown key = invalid credentials (real S3 raises)
+            raise ClientError({"Error": {"Code": "InvalidAccessKeyId", "Message": "bad creds"}}, "ListBuckets")
+        names = [b for b in ALL_BUCKETS if b in self._allowed()]
+        return {"Buckets": [{"Name": n, "CreationDate": datetime(2026, 1, 1, tzinfo=timezone.utc)} for n in names],
+                "Owner": {"DisplayName": self.ak}}
+    def head_bucket(self, Bucket=None, **kw):
+        if Bucket in self._allowed():
+            return {}
+        raise ClientError({"Error": {"Code": "403", "Message": "Forbidden"}}, "HeadBucket")
+    def __getattr__(self, name):  # any other call: succeed if scoped, else 403
+        def _m(*a, **k):
+            b = k.get("Bucket")
+            if b is not None and b not in self._allowed():
+                raise ClientError({"Error": {"Code": "403", "Message": "Forbidden"}}, name)
+            return {}
+        return _m
+
+# Patch the client factory so every client is a scoped FakeS3 keyed by its access key.
+main._s3_manager._build_client = lambda info, ak, sk: FakeS3(ak)
+main._s3_manager._clients.clear(); main._s3_manager._user_clients.clear()
+
+results = []
+def check(name, ok, detail=""):
+    results.append(ok); print(f"  {'✓ PASS' if ok else '✗ FAIL'}  {name:52} {detail}")
+
+def login(c, ak, sk):
+    r = c.post("/api/auth/login-s3", json={"access_key": ak, "secret_key": sk})
+    return r
+
+def names(resp_json):
+    return sorted(b["name"] for b in resp_json.get("buckets", []))
+
+def run():
+    c = TestClient(main.app)
+
+    # 1. login with USERA's keys → succeeds, and the JWT carries the encrypted keys
+    r = login(c, "TKEYUSERA", "secretuseraaaaaaaaaa")
+    import jwt as _jwt
+    tok = r.cookies.get("access_token")
+    claims = _jwt.decode(tok, os.environ["JWT_SECRET"], algorithms=["HS256"]) if tok else {}
+    ak_back = main._decrypt(claims.get("s3ak", ""))
+    check("login-s3(USERA) succeeds", r.status_code == 200, f"status={r.status_code}")
+    check("JWT carries encrypted user keys", ak_back == "TKEYUSERA" and claims.get("s3ak", "").startswith("enc::"),
+          f"decrypted_ak={ak_back}")
+
+    # 2. /api/buckets returns ONLY bucket-a (scoped by USERA's keys)
+    r = c.get("/api/buckets")
+    check("USERA sees only bucket-a", r.status_code == 200 and names(r.json()) == ["bucket-a"], f"got={names(r.json())}")
+
+    # 3. USERA may NOT touch bucket-b — even though the local index path would serve it
+    rb = c.get("/api/buckets/bucket-b/crawl-status")
+    check("USERA blocked from bucket-b (index not a bypass)", rb.status_code == 403, f"status={rb.status_code}")
+    ra = c.get("/api/buckets/bucket-a/crawl-status")
+    check("USERA allowed on bucket-a", ra.status_code == 200, f"status={ra.status_code}")
+
+    # 4. USERA cannot escape scope via the /api/e/ endpoint-routing path (IDOR)
+    re = c.get("/api/e/default/buckets/bucket-b/crawl-status")
+    check("USERA blocked from bucket-b via /api/e/ (IDOR closed)", re.status_code == 403, f"status={re.status_code}")
+
+    # 5. /api/all-buckets shows only the bound endpoint with the user's buckets
+    r = c.get("/api/all-buckets")
+    eps = r.json().get("endpoints", [])
+    all_names = sorted(b["name"] for ep in eps for b in ep.get("buckets", []))
+    check("USERA all-buckets scoped to bucket-a", r.status_code == 200 and all_names == ["bucket-a"], f"got={all_names}")
+
+    # 6. switch to USERB — must see ONLY bucket-b (no cross-user cache leak)
+    c2 = TestClient(main.app)
+    login(c2, "TKEYUSERB", "secretuserbbbbbbbbbb")
+    r = c2.get("/api/buckets")
+    check("USERB sees only bucket-b (no cache leak)", r.status_code == 200 and names(r.json()) == ["bucket-b"], f"got={names(r.json())}")
+    rb = c2.get("/api/buckets/bucket-a/crawl-status")
+    check("USERB blocked from bucket-a", rb.status_code == 403, f"status={rb.status_code}")
+
+    # 7. invalid keys are rejected
+    bad = c.post("/api/auth/login-s3", json={"access_key": "TKEYNOPE", "secret_key": "x"})
+    check("invalid keys rejected", bad.status_code == 401, f"status={bad.status_code}")
+
+    print(f"\n  RESULT: {sum(results)}/{len(results)} S3-key scoping checks PASS")
+    return 0 if all(results) else 1
+
+if __name__ == "__main__":
+    sys.exit(run())

--- a/charts/sairo/Chart.yaml
+++ b/charts/sairo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sairo-helm
 description: S3-compatible object storage browser with search, versioning, and analytics
 type: application
-version: 1.2.0
-appVersion: "3.4.0"
+version: 1.2.1
+appVersion: "3.4.1"
 keywords:
   - s3
   - object-storage

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sairo",
-  "version": "3.4.0",
+  "version": "3.4.1",
   "description": "S3-compatible object storage browser with search, versioning, and analytics",
   "private": true,
   "type": "module",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -247,7 +247,10 @@ function MainApp() {
     }, (err) => {
       setLoading(false);
       setDone(true);
-      if (err.message && err.message.includes("NoSuchBucket")) {
+      if (err.status === 403 || (err.message && err.message.includes("403"))) {
+        toast(`You don't have access to bucket "${b}"`, "error");
+        goHome();
+      } else if (err.message && err.message.includes("NoSuchBucket")) {
         toast(`Bucket "${b}" no longer exists`, "warning");
         goHome();
       } else {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -87,7 +87,7 @@ export function streamList(bucket, prefix, onPage, onError, opts = {}) {
       if (cursor) params.set("cursor", cursor);
     }
     const res = await apiFetch(`${bucketBase(bucket)}/list?${params}`, { signal: controller.signal });
-    if (!res.ok) throw new Error(`List failed: ${res.status}`);
+    if (!res.ok) { const e = new Error(`List failed: ${res.status}`); e.status = res.status; throw e; }
     const reader = res.body.getReader();
     const decoder = new TextDecoder();
     let buffer = "";


### PR DESCRIPTION
Closes #8.

## Problem
With S3-key authentication + multiple configured endpoints, logging in with one account's S3 keys showed **every bucket on every endpoint**. Root cause: the server validated the user's keys once, **discarded them**, issued an unconditional `admin` session, and ran all S3 operations with its **own** stored per-endpoint credentials.

## Fix — act as the user, scope via the provider's IAM
- **login-s3** keeps the user's keys (encrypted with the existing Fernet key) + the chosen endpoint in the JWT; validates against that endpoint.
- **`_s3_manager.get_client()`** returns a client built from the request user's keys when present (cached per user+endpoint). Centralized here, so *every* existing call site — bucket/object listing, download, upload, presigned URLs — is covered with no per-site edits. Background/crawl threads and password-mode sessions keep server creds (zero behavior change).
- **`/api/buckets` + `/api/all-buckets`** list with the user's keys and scope to the bound endpoint; the shared (unkeyed) 30s bucket-list cache is bypassed for s3-key sessions (was a cross-user leak).
- **Index isn't an access bypass** — object listings come from the local SQLite index (built with server creds), so s3-key requests are independently gated by a cached `head_bucket` with the user's keys.
- **Related IDOR fixed** — `bucket_permission_middleware` ran *before* the `/api/e/{id}/...` path rewrite, so that prefix skipped the permission check. Middlewares reordered to check the rewritten path; s3-key sessions are bound to their login endpoint.

Only `AUTH_MODE=s3` behavior changes; password mode is untouched.

## Validation
- **Full-stack scoping test** (login → middleware → endpoints) against a fake S3 enforcing per-key IAM: **10/10** — user sees only their account's buckets, blocked from others (directly and via `/api/e/`), invalid keys rejected, no cross-user cache leak. (`benchmark/test_s3_key_scoping.py`)
- 72/72 unit tests (password-mode regression incl. the middleware reorder); frontend builds (backend-only fix).

## Note on validation scope
Live MinIO/Ceph multi-user IAM e2e + browser run are **pending** — the local image registry is currently unreachable in my environment, so I couldn't spin up MinIO with scoped users. The full-stack test above simulates the provider's per-key IAM and proves Sairo uses each user's keys and gates access correctly; the remaining piece (the real provider returning the scoped result for a scoped key) is standard S3 behavior. Recommend a quick verify against your Ceph RGW before/after tagging.

## Out of scope (follow-ups)
- Per-endpoint `bucket_permissions` for password-mode users (table has no endpoint column).
- Whether s3-key users should be full Sairo admins (endpoint/user management) vs storage-only.