### PR TITLE
docs: update for direct upload (v3.4.0) + S3-key scoping (v3.4.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Works with **AWS S3**, **MinIO**, **Ceph**, **Wasabi**, **Cloudflare R2**, **Bac
 - **Object Browser** — Navigate buckets and prefixes with virtual scrolling for 100K+ objects
 - **Instant Search** — SQLite-indexed search across all objects by filename
 - **File Preview** — Images, text, CSV, JSON, PDF, Parquet/ORC/Avro schemas, and binary hex
-- **Upload & Download** — Multipart upload with progress tracking, drag-and-drop support
+- **Upload & Download** — Direct browser-to-S3 upload for files of any size (presigned multipart, no data through the server), drag-and-drop with progress, and presigned-URL downloads
 - **Storage Dashboard** — Visual breakdown by prefix with growth trend charts and cost estimates
 - **Cost Intelligence** — Per-folder cost breakdown with provider comparison. AWS pricing fetched live; others from community data
 - **Version Management** — Browse, restore, delete, and purge individual object versions

--- a/website/src/content/docs/features/multi-endpoint.mdx
+++ b/website/src/content/docs/features/multi-endpoint.mdx
@@ -36,6 +36,10 @@ The endpoint configured via environment variables (`S3_ENDPOINT`, `S3_ACCESS_KEY
 
 The bucket sidebar groups buckets by endpoint. Each endpoint appears as a collapsible section with the endpoint name as the header. Expand or collapse sections to focus on the storage you are working with.
 
+<Aside type="caution">
+  In **S3-key auth mode** (`AUTH_MODE=s3`), a session is bound to the endpoint it logged into and is scoped to the buckets the user's own keys can access — it does **not** span all configured endpoints. Cross-endpoint browsing from a single login applies to `local`/admin sessions, which use the per-endpoint credentials stored by an admin.
+</Aside>
+
 ## URL routing
 
 Non-default endpoints use a namespaced URL pattern so that API calls are routed to the correct backend:

--- a/website/src/content/docs/features/upload-download.mdx
+++ b/website/src/content/docs/features/upload-download.mdx
@@ -1,6 +1,6 @@
 ---
 title: Upload & Download
-description: Drag-and-drop upload with multipart support for large files, and presigned URL downloads with configurable expiration.
+description: Direct browser-to-S3 upload for files of any size, with presigned URL downloads and configurable expiration.
 ---
 
 import { Aside } from "@astrojs/starlight/components";
@@ -17,16 +17,25 @@ Drag files from your desktop or file manager and drop them anywhere on the objec
 
 You can drop multiple files at once or use the upload button to select several files from the file picker. All selected files are uploaded in parallel.
 
-### Multipart upload
+### Direct browser-to-S3 upload
 
-Files larger than **5 MB** are automatically uploaded using S3 multipart upload on the backend. The browser uploads the full file to Sairo, and the backend splits it into parts for parallel upload to S3. A progress bar shows upload completion from browser to server.
+Since v3.4.0, uploads go **directly from your browser to the S3 endpoint** — the file data does not pass through the Sairo server. Sairo only issues short-lived presigned URLs; the bytes flow browser → S3.
 
-Multipart upload provides a key benefit:
+- **Small files** (≤ 100 MB) upload with a single presigned `PUT`.
+- **Large files** (> 100 MB) use **presigned multipart upload**: the browser splits the file into parts and uploads them to S3 in parallel, each part signed just-in-time so a long transfer never fails on an expired URL. There is no single-PUT size ceiling — you can upload files far larger than before (up to S3's 5 TB object limit). A progress bar (with ETA) tracks the whole file, and an in-progress upload can be **Stopped**, which aborts the multipart upload on S3 so no orphaned parts are left behind.
 
-- **Throughput** -- The backend uploads multiple parts to S3 in parallel, which is significantly faster than a single-stream upload for large files.
+Because no file data is buffered on the server, large uploads no longer cause memory pressure or pod restarts at scale.
 
 <Aside>
-  Incomplete multipart uploads consume storage on the S3 backend. You can track and abort incomplete uploads from the bucket's **Settings > Multipart** tab, or configure a lifecycle rule to clean them up automatically.
+  Direct upload requires the bucket's CORS to allow `PUT` from the Sairo origin and to expose the `ETag` response header (the browser must read each part's `ETag`). Sairo configures this automatically on providers that support the S3 bucket-CORS API. On providers that don't (e.g. MinIO, which is configured globally), set CORS to allow `PUT`/`GET` from the Sairo origin and expose `ETag`.
+</Aside>
+
+#### Proxy fallback
+
+If direct upload isn't available (for example a restricted environment that blocks the browser→S3 request), Sairo falls back to a **proxy upload** through the server. This path now **streams** each file straight to S3 instead of buffering it in memory, so peak memory is bounded (~100 MB per in-flight file regardless of file size) rather than growing with the file. Concurrency is controlled by `UPLOAD_PROXY_CONCURRENCY` (default 3). You can also toggle proxy upload manually with the **Direct upload** checkbox in the upload dialog.
+
+<Aside>
+  Incomplete multipart uploads consume storage on the S3 backend. You can track and abort incomplete uploads from the bucket's **Settings > Multipart** tab, or configure an `AbortIncompleteMultipartUpload` lifecycle rule to clean them up automatically.
 </Aside>
 
 ## Download

--- a/website/src/content/docs/guides/minio.mdx
+++ b/website/src/content/docs/guides/minio.mdx
@@ -88,3 +88,9 @@ mc admin user svcacct add myminio minioadmin --name sairo-service
 Sairo and the MinIO Console can run side by side. They access the same buckets and objects through the same MinIO server. Changes made in either UI are immediately visible in the other.
 
 MinIO Console runs on port **9001** by default, while the MinIO API runs on port **9000**. Sairo connects to the API port.
+
+## Direct upload and CORS
+
+Sairo uploads files directly from the browser to MinIO using presigned URLs, so the browser makes a cross-origin request to the MinIO API. The browser must be allowed to `PUT` to MinIO and to read the `ETag` response header (required to complete multipart uploads).
+
+MinIO does not implement the S3 bucket-CORS API, so Sairo cannot configure this automatically — set it on the MinIO server instead. MinIO allows all origins for the S3 API by default and exposes `ETag`, so direct upload typically works out of the box; if you have locked CORS down, allow the Sairo origin for `PUT`/`GET` and expose `ETag`. If a direct upload can't reach MinIO, Sairo automatically falls back to a memory-bounded proxy upload through the server.

--- a/website/src/content/docs/reference/changelog.mdx
+++ b/website/src/content/docs/reference/changelog.mdx
@@ -13,6 +13,38 @@ Each version release produces all three artifacts from the same `v*` tag:
 
 ---
 
+## v3.4.1
+
+**S3-key authentication is scoped per user**
+
+- **Fixed (issue #8):** In `AUTH_MODE=s3`, every S3 operation is now performed with the **logged-in user's own keys**, so the provider's IAM scopes exactly what they can see and do. Previously an S3-key user got an unscoped admin session and could see every bucket on every configured endpoint. The user's keys are kept encrypted in the session token; bucket access is independently enforced per request (the local index can no longer be used to reach a bucket the user's keys can't).
+- **Fixed:** an IDOR where the per-bucket permission check could be skipped by prefixing a request with `/api/e/{endpoint}/` — the check now runs on the resolved path, and S3-key sessions are bound to the endpoint they logged into.
+- Existing S3-key users should log in again after upgrading.
+
+## v3.4.0
+
+**Direct browser-to-S3 upload for files of any size** (issue #6)
+
+- Uploads now go **directly from the browser to S3** via presigned URLs — small files with a single `PUT`, large files (> 100 MB) with **presigned multipart** (parts signed just-in-time, no single-PUT size ceiling). No file data passes through the Sairo server, so large uploads no longer cause memory pressure or pod restarts.
+- The proxy upload path remains as a fallback but now **streams** to S3 with bounded memory (~100 MB per in-flight file regardless of size; `UPLOAD_PROXY_CONCURRENCY`, default 3).
+- In-progress uploads can be **Stopped**, which aborts the multipart upload on S3 to avoid orphaned parts.
+- New tunables: `UPLOAD_PROXY_CONCURRENCY`, `MULTIPART_URL_EXPIRY`.
+
+## v3.3.1
+
+**Delta-crawler freshness fixes**
+
+- New partitions are reliably indexed even when they sort beyond the first 1000 siblings; discovery walks all datasets in parallel; natural-sort partition selection (so `day=2`…`day=10` picks the true newest); a cooldown prevents back-to-back delta crawls; restart resumes from the existing index instead of re-crawling; the index stays "ready" during crawl transitions.
+
+## v3.3.0
+
+**Performance & freshness at scale**
+
+- **Keyset pagination** for listings — million-object folders open instantly (first page ~73 ms vs ~1.4 s before).
+- **Adaptive crawl scheduler** with fast incremental **delta crawls** that pick up new objects in ~30 s on large buckets, plus a periodic full reconcile.
+- **Covering index** + covered range scans for folder listings and storage breakdowns (top-level breakdown ~2.5 ms).
+- Direct presigned-PUT uploads (completed in v3.4.0), restart-resumes-from-index, SQLite tuning. New tunables: `S3_MAX_POOL_CONNECTIONS`, `FULL_CRAWL_INTERVAL`, `LARGE_BUCKET_SECONDS`, `DELTA_*`.
+
 ## v3.2.0
 
 **Cost Intelligence, Multipart Cleanup & Optimization Recommendations**

--- a/website/src/content/docs/reference/environment-variables.mdx
+++ b/website/src/content/docs/reference/environment-variables.mdx
@@ -13,11 +13,21 @@ All Sairo configuration is done through environment variables. This page lists e
 | `S3_ACCESS_KEY` | _(required)_ | S3 access key ID |
 | `S3_SECRET_KEY` | _(required)_ | S3 secret access key |
 | `S3_REGION` | _(empty)_ | S3 region |
+| `S3_MAX_POOL_CONNECTIONS` | `32` | Max pooled connections per S3 client, so parallel crawl/delta list calls don't serialize on a small pool |
+
+## Uploads
+
+| Variable | Default | Description |
+|---|---|---|
+| `UPLOAD_PROXY_CONCURRENCY` | `3` | Files streamed in parallel through the proxy-upload fallback. Bounds peak server memory (~100 MB per in-flight file × this value). The default direct browser→S3 path uses no server memory. |
+| `MULTIPART_URL_EXPIRY` | `3600` | Lifetime (seconds) of each presigned multipart part URL. Parts are signed just-in-time, so this only needs to cover a single part's upload. |
+| `MAX_UPLOAD_SIZE` | `5368709120` (5 GB) | Maximum total size for a **proxy** upload request. Does not apply to direct browser→S3 uploads. |
 
 ## Authentication
 
 | Variable | Default | Description |
 |---|---|---|
+| `AUTH_MODE` | `local` | Authentication mode: `local` (username/password) or `s3` (log in with S3 access key + secret; access is scoped to each user's own keys via the provider's IAM) |
 | `ADMIN_USER` | `admin` | Username for the default admin account |
 | `ADMIN_PASS` | _(auto-generated)_ | Password for the default admin account. If not set, a random password is printed to logs on first startup. |
 | `JWT_SECRET` | _(auto-generated)_ | Secret key for signing JWT tokens. Set explicitly for multi-instance deployments. |
@@ -30,6 +40,20 @@ All Sairo configuration is done through environment variables. This page lists e
 |---|---|---|
 | `RECRAWL_INTERVAL` | `120` | Seconds between automatic reindex cycles for each bucket |
 | `DB_DIR` | `/data` | Directory where SQLite index databases are stored |
+| `FULL_CRAWL_INTERVAL` | `3600` | Seconds between full reconcile crawls for large buckets (delta crawls run on `RECRAWL_INTERVAL` in between) |
+| `LARGE_BUCKET_SECONDS` | `30` | A bucket whose full crawl takes longer than this is treated as "large" and kept fresh with delta crawls + periodic full reconcile, instead of full re-crawls every interval |
+
+### Delta-crawl tuning
+
+These bound how the incremental delta crawler discovers new data on large buckets. The defaults suit time-partitioned layouts (e.g. `year=/month=/day=/hour=`); they rarely need changing.
+
+| Variable | Default | Description |
+|---|---|---|
+| `DELTA_BRANCH_FANOUT` | `8` | Levels with more children than this are treated as time partitions (follow only the newest few); fewer means a descriptive branch (follow all) |
+| `DELTA_NEWEST_K` | `2` | How many of the newest partitions to re-list at a partition level (current + just-rolled) |
+| `DELTA_MAX_DEPTH` | `12` | Safety cap on prefix-walk depth |
+| `DELTA_LIST_CONCURRENCY` | `16` | Parallel S3 list calls per level during delta discovery |
+| `DELTA_MAX_NODES` | `2000` | Safety cap on folders visited per delta crawl |
 
 ## LDAP
 

--- a/website/src/content/docs/security/authentication.mdx
+++ b/website/src/content/docs/security/authentication.mdx
@@ -3,6 +3,8 @@ title: "Authentication"
 description: "How Sairo handles authentication with JWT tokens, secure cookies, session management, and rate limiting."
 ---
 
+import { Aside } from "@astrojs/starlight/components";
+
 Sairo uses JWT-based authentication with secure cookie storage. Tokens are issued on login and validated on every API request.
 
 ## Auth Modes
@@ -11,15 +13,25 @@ Sairo supports two authentication modes, controlled by the `AUTH_MODE` environme
 
 | Mode | `AUTH_MODE` | Login Fields | Best For |
 |---|---|---|---|
-| **Local** (default) | `local` | Username + Password | Teams with multiple users, RBAC, 2FA |
-| **S3 Keys** | `s3` | S3 Access Key + Secret Key | Single-user setups, quick start, headless |
+| **Local** (default) | `local` | Username + Password | Teams with multiple users, Sairo-managed RBAC, 2FA |
+| **S3 Keys** | `s3` | S3 Access Key + Secret Key | Delegating access control to your S3 provider's IAM; headless / quick start |
 
-In **S3 mode**, users authenticate by entering their S3 access key and secret key. Sairo validates the credentials by calling `list_buckets()` against the configured S3 endpoint. If it succeeds, the user gets an admin session. No user account setup needed.
+In **S3 mode**, users authenticate by entering their S3 access key and secret key. Sairo validates the credentials by calling `list_buckets()` against the configured S3 endpoint. No Sairo user accounts are needed — access is governed entirely by the S3 provider.
+
+Since **v3.4.1**, every S3 operation in this mode is performed with the **logged-in user's own keys** (kept encrypted in the session token), so the provider's IAM scopes exactly what each user can see and do:
+
+- A user sees and can manage **only the buckets their keys can access** — not every bucket the server can reach, and not buckets on other endpoints.
+- Access is enforced per request: object listings come from Sairo's local index, so each bucket request is independently checked against the provider with the user's keys before any indexed data is returned.
+- In multi-endpoint setups, a session is bound to the endpoint it logged into.
 
 ```yaml
 environment:
   AUTH_MODE: "s3"  # Authenticate with S3 credentials instead of username/password
 ```
+
+<Aside type="caution">
+  After upgrading to v3.4.1, existing S3-key users should log in again so their keys are captured in the session. Before v3.4.1, S3-key users were given an unscoped admin session and could see every bucket on every configured endpoint.
+</Aside>
 
 Both modes can be used simultaneously — the login page shows a toggle to switch between "S3 Keys" and "Password". In `s3` mode, the S3 tab is shown first. In `local` mode, the password tab is shown first (S3 tab appears only if explicitly enabled).
 


### PR DESCRIPTION
Brings the product docs in line with the last four releases. Two pages were **actively inaccurate** after the recent work; the rest were stale/missing.

## Corrected (were wrong)
- **Upload & Download** — described the removed "browser → Sairo → S3" proxy model and a 5 MB threshold. Rewritten for v3.4.0: direct browser→S3 (single PUT / presigned multipart, no data through the server, no size ceiling), Stop/abort, the memory-bounded proxy fallback, and the bucket CORS (`ExposeHeaders: ETag`) requirement.
- **Authentication** — said S3-key login yields an unscoped admin session. Updated for v3.4.1: each S3-key user is scoped to the buckets their own keys can access via the provider's IAM, bound to their login endpoint; note to re-login after upgrade.

## Added / synced
- **Changelog** — added v3.3.0, v3.3.1, v3.4.0, v3.4.1 (was stuck at v3.2.0).
- **Environment Variables** — added `AUTH_MODE`, upload tunables (`UPLOAD_PROXY_CONCURRENCY`, `MULTIPART_URL_EXPIRY`, `MAX_UPLOAD_SIZE`), `S3_MAX_POOL_CONNECTIONS`, and the crawler/delta tunables (`FULL_CRAWL_INTERVAL`, `LARGE_BUCKET_SECONDS`, `DELTA_*`).
- **Multi-Endpoint** — note that S3-key sessions are bound/scoped to their login endpoint.
- **MinIO guide** — direct-upload CORS guidance (MinIO doesn't implement the bucket-CORS API).
- **README** — upload bullet reflects direct-to-S3 for files of any size.

Docs site builds successfully (all 6 changed pages render; the local Pagefind step fails only due to a darwin-arm64 binary fetch, unrelated to content).