### PR TITLE
feat: telemetry v2 + docs refresh (v3.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to Sairo are documented here. This project uses [Semantic Versioning](https://semver.org/).
 
+## [3.5.0] - 2026-06-27
+
+Anonymous telemetry schema v2 — richer, still privacy-first.
+
+### Added
+
+- **Telemetry v2** — the anonymous heartbeat now also reports instance **health** (trailing-24h request + error counts, restart count, **crash count** — unclean exits like OOM/SIGKILL, counted separately from orchestrated restarts — index-disk used/total, a derived `ok`/`degraded`/`error` status), **activation milestones** (first bucket / object / API token / MCP connection timestamps), **engagement** (active-buckets-in-24h, last-write time, enabled feature slugs, update-available), and **instance validity** (`boot_count` + `id_persistence` so a durable install is distinguishable from throwaway-storage instances that mint a new id each restart). All additive; still aggregate **counts and timestamps only** — never bucket names, keys, paths, IPs, or any user content. Values are clamped before sending and the payload stays well under 4 KB. New `schema_version: "2"`. Documented at [Telemetry](https://sairo.dev/security/telemetry).
+- A single process is elected (file lock) to emit the heartbeat, so a multi-worker deployment can't send duplicate pings; the Helm chart sets `SAIRO_STORAGE_EPHEMERAL` from `persistence.enabled` so `id_persistence` is accurate on Kubernetes.
+
+### Changed
+
+- **Heartbeat cadence is now hourly** (`TELEMETRY_INTERVAL`, default `3600`s) instead of daily, so the trailing-24h health metrics stay current. Telemetry remains fully opt-out via `TELEMETRY=false` (no ping is sent when disabled).
+
 ## [3.4.1] - 2026-06-27
 
 Security/correctness fix for S3-key authentication with multiple endpoints (issue #8). Previously a user who logged in with S3 access keys could see and manage **every** bucket on **every** configured endpoint, because the server used its own stored endpoint credentials (and an unconditional admin role) for all operations and discarded the user's keys.

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Works with **AWS S3**, **MinIO**, **Ceph**, **Wasabi**, **Cloudflare R2**, **Bac
 ## Features
 
 - **Object Browser** — Navigate buckets and prefixes with virtual scrolling for 100K+ objects
-- **Instant Search** — SQLite-indexed search across all objects by filename
+- **Instant Search** — SQLite-indexed search across all objects by filename, kept fresh on large buckets by an adaptive delta crawler that re-lists only the newest prefixes
 - **File Preview** — Images, text, CSV, JSON, PDF, Parquet/ORC/Avro schemas, and binary hex
 - **Upload & Download** — Direct browser-to-S3 upload for files of any size (presigned multipart, no data through the server), drag-and-drop with progress, and presigned-URL downloads
 - **Storage Dashboard** — Visual breakdown by prefix with growth trend charts and cost estimates
@@ -40,10 +40,12 @@ Works with **AWS S3**, **MinIO**, **Ceph**, **Wasabi**, **Cloudflare R2**, **Bac
 - **Multi-Endpoint** — Connect multiple S3 backends and manage all from one dashboard
 - **Audit Log** — Full activity trail with filtering by action, user, and bucket
 - **User Management** — Role-based access control (admin / viewer) with per-bucket permissions
+- **S3-Key Auth** — Optional `AUTH_MODE=s3`: users log in with their own S3 keys and see only the buckets their provider IAM allows — access is delegated entirely to the provider
 - **Two-Factor Auth** — TOTP-based 2FA with QR setup and recovery codes
 - **OAuth & LDAP** — Google, GitHub OAuth and LDAP authentication
 - **AI-Powered Analysis (MCP)** — Connect Claude, Cursor, or any MCP client to ask natural language questions about your storage. 26 tools for analytics, cost optimization, pipeline health, and more
-- **Petabyte-Scale Performance** — Folder listings in 0.05ms on 500K+ objects. Pre-computed prefix hierarchies, 64MB SQLite page cache, 256MB memory-mapped I/O, async FTS rebuilds
+- **Petabyte-Scale Performance** — Proven on a live 269 TB / 15.5M-object deployment. Constant-time folder listing at any scale via pre-computed prefix hierarchies, 64MB SQLite page cache, 256MB memory-mapped I/O, async FTS rebuilds
+- **Anonymous Telemetry (opt-out)** — A privacy-first heartbeat reports aggregate counts, instance health, and activation timestamps only (never names, keys, paths, or content). Disable with `TELEMETRY=false`
 - **Dark Mode** — Full dark/light theme with system preference detection
 - **Keyboard Shortcuts** — 30+ shortcuts for power users
 - **Single Container** — No dependencies. No microservices. Just `docker run` and go.
@@ -109,17 +111,18 @@ Connect Claude Desktop, Cursor, or any MCP-compatible client and ask:
 
 ## Performance
 
-Benchmarked on production data (557K objects, 167 TB, NetApp StorageGRID):
+Validated read-only against a live production deployment (Leaseweb S3-compatible storage):
 
-| Operation | Speed |
-|-----------|-------|
-| Folder listing | 0.05ms (pre-computed prefix hierarchy) |
-| Object count | 1.5ms on 557K objects |
-| Full-text search | 22ms, 200 results on 139K objects |
-| Storage breakdown | 310ms on 557K objects |
-| Crawl throughput | 16 parallel prefix workers, 10K batch inserts |
+| Operation | Result |
+|-----------|--------|
+| Production scale | **15.5M objects across 14 buckets, ~269 TB** |
+| Largest single bucket | **~9.86M objects** |
+| Folder listing | **Constant-time** — lands at the network floor even on the 9.86M-object bucket (≈0ms server-side) |
+| Full-text search | Single-digit ms on 100K+ objects; tens of ms server-side at ~10M objects |
+| Upload | Direct browser→S3 multipart, up to 5 TB/object, **flat server memory** |
+| Crawl throughput | 16 parallel prefix workers, 10K batch inserts, adaptive delta crawl |
 
-**Scaling:** Tested up to 2M objects per bucket. Designed for petabyte scale with instant folder navigation at any dataset size.
+**Scaling:** Folder navigation is a constant-time index lookup, so it stays instant at any dataset size. See [Benchmarks](https://docs.sairo.dev/reference/benchmarks/) for the full methodology and server-compute microbenchmarks.
 
 ## Environment Variables
 
@@ -136,7 +139,13 @@ Benchmarked on production data (557K objects, 167 TB, NetApp StorageGRID):
 | `SESSION_HOURS` | `24` | Login session duration in hours |
 | `SECURE_COOKIE` | `true` | Set to `false` for HTTP (non-HTTPS) deployments |
 | `RECRAWL_INTERVAL` | `120` | Seconds between automatic re-index cycles |
+| `LARGE_BUCKET_SECONDS` | `60` | A bucket whose full crawl exceeds this is kept fresh via incremental delta crawls instead of full re-crawls |
+| `FULL_CRAWL_INTERVAL` | `3600` | Seconds between full reconcile crawls for large buckets (delta crawls run in between) |
 | `DB_DIR` | `/data` | Directory for SQLite databases |
+| `TELEMETRY` | `true` | Anonymous usage heartbeat (aggregate counts + health only). Set `false` to disable |
+| `TELEMETRY_INTERVAL` | `3600` | Seconds between telemetry heartbeats |
+
+> This is a summary. See the [full environment-variable reference](https://docs.sairo.dev/reference/environment-variables/) for delta-crawl tuning, uploads, LDAP/OAuth, branding, and rate limiting.
 
 ## Tech Stack
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -294,7 +294,7 @@ async def s3_error_handler(request, exc):
 
 
 _app_start_time = time.time()
-SAIRO_VERSION = "3.4.1"
+SAIRO_VERSION = "3.5.0"
 TELEMETRY = os.environ.get("TELEMETRY", "true").lower() != "false"
 
 S3_ENDPOINT = os.environ.get("S3_ENDPOINT", "")
@@ -2269,8 +2269,9 @@ def startup():
 
     # Start telemetry heartbeat
     if TELEMETRY:
+        _tel_record_boot()  # boot_count + restart history + crash detection (prev unclean exit)
         threading.Thread(target=_telemetry_loop, daemon=True).start()
-        log.info("Anonymous telemetry enabled. Set TELEMETRY=false to disable.")
+        log.info("Anonymous telemetry enabled (schema v2). Set TELEMETRY=false to disable.")
     else:
         log.info("Telemetry disabled.")
 
@@ -2278,7 +2279,177 @@ def startup():
 # ── Telemetry ─────────────────────────────────────────────────────────────
 
 TELEMETRY_URL = "https://dashboard.sairo.dev/api/v1/ping"
-TELEMETRY_INTERVAL = 86400  # 24 hours
+TELEMETRY_INTERVAL = int(os.environ.get("TELEMETRY_INTERVAL", "3600"))  # hourly (trailing-24h metrics assume regular pings)
+TELEMETRY_SCHEMA_VERSION = "2"
+
+# ── Telemetry runtime counters (Tier 1 health + Tier 3 engagement) ──────────
+# Lightweight, in-memory, and strictly FAIL-SAFE: nothing here may ever alter a
+# request/response or raise into the request path. Aggregate counts only — never
+# bucket names, keys, paths, or any user content.
+_tel_lock = threading.Lock()
+_tel_req_hours: dict = {}      # epoch_hour -> request count
+_tel_failed_hours: dict = {}   # epoch_hour -> 5xx count
+_tel_bucket_seen: dict = {}    # bucket -> last-access epoch (for active_buckets_24h; names never sent)
+_tel_last_write = [0.0]        # epoch of the last successful write operation
+
+
+def _tel_record(path: str, method: str, status: int):
+    """Account one request for the trailing-24h counters. Never raises."""
+    try:
+        now = time.time()
+        hr = int(now // 3600)
+        with _tel_lock:
+            _tel_req_hours[hr] = _tel_req_hours.get(hr, 0) + 1
+            if status >= 500:
+                _tel_failed_hours[hr] = _tel_failed_hours.get(hr, 0) + 1
+            cutoff = hr - 26  # keep ~26h of hourly buckets
+            for d in (_tel_req_hours, _tel_failed_hours):
+                for k in [k for k in d if k < cutoff]:
+                    d.pop(k, None)
+            if status < 400 and path.startswith("/api/buckets/"):
+                parts = path.split("/")
+                if len(parts) >= 4 and parts[3]:
+                    _tel_bucket_seen[parts[3]] = now
+                    if method in ("POST", "PUT", "DELETE", "PATCH"):
+                        _tel_last_write[0] = now
+                    if len(_tel_bucket_seen) > 10000:  # bound memory
+                        _tel_bucket_seen.pop(min(_tel_bucket_seen, key=_tel_bucket_seen.get), None)
+    except Exception:
+        pass
+
+
+def _tel_sum_24h(d: dict) -> int:
+    cutoff = int(time.time() // 3600) - 23
+    with _tel_lock:
+        return sum(v for k, v in d.items() if k >= cutoff)
+
+
+def _tel_active_buckets_24h() -> int:
+    cutoff = time.time() - 86400
+    with _tel_lock:
+        return sum(1 for ts in _tel_bucket_seen.values() if ts >= cutoff)
+
+
+@app.middleware("http")
+async def telemetry_counter_middleware(request: Request, call_next):
+    """Outermost middleware — counts requests for anonymous telemetry. Strictly
+    pass-through: it never modifies the request/response and never swallows the
+    handler's exception (it re-raises after recording a failure)."""
+    if not TELEMETRY:
+        return await call_next(request)
+    try:
+        response = await call_next(request)
+    except Exception:
+        try:
+            _tel_record(request.scope.get("path", request.url.path), request.method, 500)
+        except Exception:
+            pass
+        raise
+    try:
+        _tel_record(request.scope.get("path", request.url.path), request.method, response.status_code)
+    except Exception:
+        pass
+    return response
+
+
+def _meta_get(key: str, default=None):
+    try:
+        with _get_users_db() as db:
+            row = db.execute("SELECT value FROM instance_meta WHERE key=?", (key,)).fetchone()
+            return row[0] if row else default
+    except Exception:
+        return default
+
+
+def _meta_set(key: str, value: str):
+    try:
+        with _get_users_db() as db:
+            db.execute("INSERT OR REPLACE INTO instance_meta (key, value) VALUES (?, ?)", (key, str(value)))
+            db.commit()
+    except Exception:
+        pass
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _epoch_to_iso(e: float) -> str:
+    return datetime.fromtimestamp(e, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _sqlts_to_iso(s):
+    """SQLite CURRENT_TIMESTAMP ('YYYY-MM-DD HH:MM:SS', UTC) -> ISO-8601 Z. None-safe."""
+    if not s:
+        return None
+    s = str(s).strip()
+    return s.replace(" ", "T") + ("" if s.endswith("Z") else "Z")
+
+
+def _tel_record_boot():
+    """Once per process start: bump boot_count, record the restart, and detect whether the
+    PREVIOUS run exited cleanly. A missing clean-exit marker ⇒ the prior process died
+    uncleanly (crash / OOM / SIGKILL / node loss) ⇒ count a crash (distinct from an
+    orchestrated SIGTERM restart). boot_count powers the dashboard's persistent-vs-ephemeral
+    classification — an ephemeral install (state wiped each boot) is forever boot_count==1."""
+    try:
+        now = int(time.time())
+        bc = int(_meta_get("boot_count", "0") or "0") + 1
+        _meta_set("boot_count", bc)
+        rlst = [t for t in json.loads(_meta_get("restart_ts", "[]") or "[]") if now - t < 26 * 3600]
+        rlst.append(now)
+        _meta_set("restart_ts", json.dumps(rlst[-200:]))
+        if bc > 1 and _meta_get("clean_exit", "1") != "1":  # previous run did NOT shut down cleanly
+            clst = [t for t in json.loads(_meta_get("crash_ts", "[]") or "[]") if now - t < 26 * 3600]
+            clst.append(now)
+            _meta_set("crash_ts", json.dumps(clst[-200:]))
+        _meta_set("clean_exit", "0")  # mark dirty until a graceful shutdown flips it back
+    except Exception:
+        pass
+
+
+def _tel_mark_clean_exit():
+    """Graceful-shutdown hook — flips the marker so the next boot doesn't count a crash."""
+    _meta_set("clean_exit", "1")
+
+
+def _detect_storage_ephemeral():
+    """Best-effort: is DB_DIR on ephemeral storage? Returns True / False / None (unknown).
+    An explicit operator/Helm hint (SAIRO_STORAGE_EPHEMERAL) wins; else infer from the mount table."""
+    hint = os.environ.get("SAIRO_STORAGE_EPHEMERAL", "").strip().lower()
+    if hint in ("true", "1", "yes"):
+        return True
+    if hint in ("false", "0", "no"):
+        return False
+    try:
+        dbdir = os.path.realpath(DB_DIR)
+        best, fstype = "", ""
+        with open("/proc/mounts") as f:
+            for line in f:
+                p = line.split()
+                if len(p) >= 3 and (dbdir == p[1] or dbdir.startswith(p[1].rstrip("/") + "/")):
+                    if len(p[1]) >= len(best):  # most-specific (longest) matching mountpoint
+                        best, fstype = p[1], p[2]
+        if fstype in ("tmpfs", "ramfs"):
+            return True
+        if best == "/" and fstype in ("overlay", "overlayfs", "aufs"):  # container root, no dedicated volume
+            return True
+        return None  # separate non-tmpfs mount (PVC / named volume / emptyDir) — indistinguishable from here
+    except Exception:
+        return None  # non-Linux or unreadable → unknown
+
+
+def _id_persistence(boot_count) -> str:
+    """persistent (proven, or hinted) / ephemeral (hinted or tmpfs/overlay-root) / unknown."""
+    if boot_count and int(boot_count) > 1:
+        return "persistent"  # proven: local state survived at least one restart
+    eph = _detect_storage_ephemeral()
+    if eph is True:
+        return "ephemeral"
+    if eph is False:
+        return "persistent"
+    return "unknown"
+
 
 def _get_instance_id() -> str:
     """Get or create a persistent anonymous instance ID."""
@@ -2320,11 +2491,10 @@ def _collect_telemetry() -> dict:
     except Exception:
         pass
 
-    # Count users, endpoints, and API token usage (MCP/CLI indicator)
-    user_count = 0
-    endpoint_count = 0
-    api_tokens = 0
-    api_tokens_active = 0
+    # Count users, endpoints, API tokens, 2FA, share links; earliest token/usage
+    user_count = endpoint_count = api_tokens = api_tokens_active = 0
+    twofa_count = share_link_count = 0
+    first_token_at = first_mcp_at = None
     try:
         with _get_users_db() as db:
             user_count = db.execute("SELECT COUNT(*) FROM users").fetchone()[0]
@@ -2333,31 +2503,184 @@ def _collect_telemetry() -> dict:
             api_tokens_active = db.execute(
                 "SELECT COUNT(*) FROM api_tokens WHERE last_used IS NOT NULL AND last_used > datetime('now', '-7 days')"
             ).fetchone()[0]
+            try:
+                twofa_count = db.execute("SELECT COUNT(*) FROM users WHERE totp_enabled=1").fetchone()[0]
+            except Exception:
+                pass
+            try:
+                share_link_count = db.execute("SELECT COUNT(*) FROM share_links").fetchone()[0]
+            except Exception:
+                pass
+            r = db.execute("SELECT MIN(created_at), MIN(last_used) FROM api_tokens").fetchone()
+            if r:
+                first_token_at, first_mcp_at = _sqlts_to_iso(r[0]), _sqlts_to_iso(r[1])
     except Exception:
         pass
 
     provider = detect_provider(S3_ENDPOINT)
 
+    # Disk usage of the volume backing the index/data
+    disk_total = disk_used = 0
+    try:
+        import shutil
+        du = shutil.disk_usage(DB_DIR)
+        disk_total, disk_used = du.total, du.used
+    except Exception:
+        pass
+
+    # Trailing-24h request counters + restart history
+    requests_24h = _tel_sum_24h(_tel_req_hours)
+    requests_failed_24h = min(_tel_sum_24h(_tel_failed_hours), requests_24h)
+    restart_count_24h = crash_count_24h = boot_count = 0
+    try:
+        _now = time.time()
+        restart_count_24h = sum(1 for t in json.loads(_meta_get("restart_ts", "[]") or "[]") if _now - t < 86400)
+        crash_count_24h = sum(1 for t in json.loads(_meta_get("crash_ts", "[]") or "[]") if _now - t < 86400)
+        boot_count = int(_meta_get("boot_count", "0") or "0")
+    except Exception:
+        pass
+    id_persistence = _id_persistence(boot_count)
+
+    # active_buckets_24h — persist across restarts: merge in-memory with stored, prune to 24h.
+    # Bucket names stay LOCAL in instance_meta; only the COUNT is ever sent in the ping.
+    active_buckets_24h = 0
+    try:
+        _now = time.time()
+        persisted = json.loads(_meta_get("active_buckets", "{}") or "{}")
+        with _tel_lock:
+            for b, ts in _tel_bucket_seen.items():
+                if ts > persisted.get(b, 0):
+                    persisted[b] = ts
+        persisted = {b: ts for b, ts in persisted.items() if _now - ts < 86400}
+        if len(persisted) > 10000:
+            persisted = dict(sorted(persisted.items(), key=lambda kv: kv[1])[-10000:])
+        _meta_set("active_buckets", json.dumps(persisted))
+        active_buckets_24h = len(persisted)
+    except Exception:
+        active_buckets_24h = _tel_active_buckets_24h()
+
+    # Activation milestones (record-once, idempotent — never overwritten)
+    if bucket_count > 0 and not _meta_get("first_bucket_at"):
+        _meta_set("first_bucket_at", _iso_now())
+    if total_objects > 0 and not _meta_get("first_object_at"):
+        _meta_set("first_object_at", _iso_now())
+    first_bucket_at = _meta_get("first_bucket_at")
+    first_object_at = _meta_get("first_object_at")
+
+    # last_write_at: max(in-memory since boot, persisted) so it survives restarts
+    last_write_at = _meta_get("last_write_at")
+    if _tel_last_write[0] > 0:
+        cand = _epoch_to_iso(_tel_last_write[0])
+        if not last_write_at or cand > last_write_at:
+            _meta_set("last_write_at", cand)
+            last_write_at = cand
+
+    # features_enabled — config/DB-derived Sairo capabilities (stable lowercase slugs)
+    feats = []
+    if AUTH_MODE == "s3":
+        feats.append("s3_auth")
+    if os.environ.get("LDAP_ENABLED", "false").lower() == "true":
+        feats.append("ldap")
+    if os.environ.get("OAUTH_GOOGLE_CLIENT_ID") or os.environ.get("OAUTH_GITHUB_CLIENT_ID"):
+        feats.append("oauth")
+    if endpoint_count > 1:
+        feats.append("multi_endpoint")
+    if api_tokens > 0:
+        feats.append("api_tokens")
+    if twofa_count > 0:
+        feats.append("twofa")
+    if share_link_count > 0:
+        feats.append("share_links")
+    if os.environ.get("APP_NAME", "Sairo") != "Sairo" or os.environ.get("APP_LOGO"):
+        feats.append("custom_branding")
+    feats = feats[:32]
+
+    # update_available — read the cached check only; never triggers a network call here
+    _latest = _update_cache.get("latest")
+    update_available = bool(_latest and _latest != SAIRO_VERSION and _latest > SAIRO_VERSION)
+
+    # health rollup
+    err_rate = (requests_failed_24h / requests_24h) if requests_24h else 0.0
+    disk_pct = (disk_used / disk_total) if disk_total else 0.0
+    if disk_pct > 0.95 or err_rate > 0.25 or crash_count_24h >= 3:
+        health = "error"
+    elif disk_pct > 0.85 or crash_count_24h >= 1 or restart_count_24h > 5:
+        health = "degraded"
+    else:
+        health = "ok"
+
+    def _ci(v, hi):  # clamp to a non-negative int within bounds
+        try:
+            return max(0, min(int(v), hi))
+        except Exception:
+            return 0
+
+    bucket_count = _ci(bucket_count, 10000)
     return {
+        # ── existing baseline (unchanged) ──
         "instance_id": instance_id,
         "version": SAIRO_VERSION,
         "buckets": bucket_count,
-        "total_objects": total_objects,
-        "total_size": total_size,
+        "total_objects": _ci(total_objects, 10**12),
+        "total_size": _ci(total_size, 10**18),
         "provider": provider,
         "uptime_hours": uptime_hours,
         "os": f"{platform.system().lower()}/{platform.machine()}",
-        "endpoints": endpoint_count,
-        "users": user_count,
+        "endpoints": _ci(endpoint_count, 10000),
+        "users": _ci(user_count, 10**6),
         "auth_mode": AUTH_MODE,
-        "api_tokens": api_tokens,
-        "api_tokens_active": api_tokens_active,
+        "api_tokens": _ci(api_tokens, 10**6),
+        "api_tokens_active": _ci(api_tokens_active, 10**6),
+        # ── v2: schema + Tier 1 health ──
+        "schema_version": TELEMETRY_SCHEMA_VERSION,
+        "requests_24h": _ci(requests_24h, 10**12),
+        "requests_failed_24h": _ci(requests_failed_24h, 10**12),
+        "restart_count_24h": _ci(restart_count_24h, 10000),
+        "crash_count_24h": _ci(crash_count_24h, 10000),
+        "disk_total_bytes": _ci(disk_total, 10**18),
+        "disk_used_bytes": _ci(disk_used, 10**18),
+        "health": health,
+        # ── v2: id validity (persistent vs ephemeral / reincarnation) ──
+        "id_persistence": id_persistence,
+        "boot_count": _ci(boot_count, 10**9),
+        # ── v2: Tier 2 activation milestones ──
+        "first_bucket_at": first_bucket_at,
+        "first_object_at": first_object_at,
+        "first_api_token_at": first_token_at,
+        "first_mcp_connect_at": first_mcp_at,
+        # ── v2: Tier 3 engagement + adoption ──
+        "active_buckets_24h": min(_ci(active_buckets_24h, 10000), bucket_count),
+        "last_write_at": last_write_at,
+        "features_enabled": feats,
+        "update_available": update_available,
     }
 
+@app.on_event("shutdown")
+def _telemetry_shutdown():
+    """Record a clean shutdown so the next boot doesn't mis-count this as a crash."""
+    if TELEMETRY:
+        _tel_mark_clean_exit()
+
+
+_telemetry_lockfile = None  # held for the process lifetime by the elected pinger
+
+
 def _telemetry_loop():
-    """Background thread: send anonymous heartbeat every 24 hours."""
+    """Background thread: send the anonymous heartbeat every TELEMETRY_INTERVAL seconds (hourly by
+    default). Only ONE process per host pings — a non-blocking file lock elects a single leader so a
+    multi-worker deployment can't emit duplicate pings or split counters."""
+    global _telemetry_lockfile
     import urllib.request
     import json as _json
+    try:
+        import fcntl
+        _telemetry_lockfile = open(os.path.join(DB_DIR, ".telemetry.lock"), "w")
+        fcntl.flock(_telemetry_lockfile, fcntl.LOCK_EX | fcntl.LOCK_NB)  # raises if another worker holds it
+    except ImportError:
+        pass  # no fcntl (non-POSIX) → assume single process
+    except OSError:
+        log.info("Telemetry: another worker holds the ping lock; this worker will not ping.")
+        return
     time.sleep(60)  # wait 1 min after startup before first ping
     while True:
         try:

--- a/backend/main.py
+++ b/backend/main.py
@@ -2278,7 +2278,7 @@ def startup():
 
 # ── Telemetry ─────────────────────────────────────────────────────────────
 
-TELEMETRY_URL = "https://dashboard.sairo.dev/api/v1/ping"
+TELEMETRY_URL = os.environ.get("TELEMETRY_URL", "https://dashboard.sairo.dev/api/v1/ping")
 TELEMETRY_INTERVAL = int(os.environ.get("TELEMETRY_INTERVAL", "3600"))  # hourly (trailing-24h metrics assume regular pings)
 TELEMETRY_SCHEMA_VERSION = "2"
 

--- a/charts/sairo/Chart.yaml
+++ b/charts/sairo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sairo-helm
 description: S3-compatible object storage browser with search, versioning, and analytics
 type: application
-version: 1.2.1
-appVersion: "3.4.1"
+version: 1.3.0
+appVersion: "3.5.0"
 keywords:
   - s3
   - object-storage

--- a/charts/sairo/templates/deployment.yaml
+++ b/charts/sairo/templates/deployment.yaml
@@ -83,6 +83,10 @@ spec:
             # ── Crawler ──
             - name: RECRAWL_INTERVAL
               value: {{ .Values.crawler.recrawlInterval | quote }}
+            # ── Telemetry: tell the app whether its storage is ephemeral, so anonymous
+            #    telemetry can report id_persistence accurately (emptyDir → ephemeral). ──
+            - name: SAIRO_STORAGE_EPHEMERAL
+              value: {{ not .Values.persistence.enabled | quote }}
             # ── Rate Limiting ──
             {{- if .Values.rateLimit }}
             {{- if .Values.rateLimit.default }}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sairo",
-  "version": "3.4.1",
+  "version": "3.5.0",
   "description": "S3-compatible object storage browser with search, versioning, and analytics",
   "private": true,
   "type": "module",

--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -60,6 +60,7 @@ export default defineConfig({
 						{ slug: 'security/api-tokens' },
 						{ slug: 'security/oauth-ldap' },
 						{ slug: 'security/audit-log' },
+						{ slug: 'security/telemetry' },
 					],
 				},
 				{

--- a/website/src/content/docs/cli/quickstart.mdx
+++ b/website/src/content/docs/cli/quickstart.mdx
@@ -207,6 +207,6 @@ The CLI queries Sairo's indexed backend, not S3 directly. On a production bucket
 
 ## Next Steps
 
-- [Command Reference](/cli/commands/) — All 24 commands with flags and examples
+- [Command Reference](/cli/commands/) — every command with flags and examples
 - [Benchmarks](/reference/benchmarks/) — Full performance data
 - [API Reference](/reference/api/) — The REST API the CLI talks to

--- a/website/src/content/docs/features/object-browser.mdx
+++ b/website/src/content/docs/features/object-browser.mdx
@@ -54,3 +54,7 @@ A filter input above the table narrows the visible objects to those whose name m
 ## NDJSON streaming
 
 When you open a folder, Sairo's backend streams object metadata to the browser as newline-delimited JSON (NDJSON). The frontend appends rows to the table as each chunk arrives rather than waiting for the full response. This gives you progressive rendering -- you see the first results immediately, even if the folder contains millions of objects.
+
+## Keyset pagination
+
+For very large folders, the backend pages through objects using **keyset (cursor-based) pagination** rather than offset pagination. Each page is fetched by seeking to the last key seen, so page latency and payload size stay constant no matter how deep into the folder you scroll — a folder with a million objects in a single prefix opens just as quickly as the first page. This is what keeps memory and response sizes bounded on the largest buckets.

--- a/website/src/content/docs/features/search.mdx
+++ b/website/src/content/docs/features/search.mdx
@@ -38,7 +38,7 @@ Click any search result to navigate directly to that object's location in the br
 
 ## Background indexing
 
-Sairo's crawler runs on a continuous loop (default: every 2 minutes, configurable via `RECRAWL_INTERVAL`). Each crawl updates the SQLite database and its FTS5 index, so newly uploaded or deleted objects appear in search results shortly after the next crawl completes.
+Sairo's crawler runs on a continuous loop (default: every 2 minutes, configurable via `RECRAWL_INTERVAL`). Each crawl updates the SQLite database and its FTS5 index, so newly uploaded or deleted objects appear in search results shortly after the next crawl completes. Large buckets are kept fresh by an **adaptive delta crawler** that re-lists only the newest prefixes each cycle (with periodic full reconciles), so search stays current at multi-million-object scale without re-walking the whole bucket — see [Architecture](/reference/architecture/).
 
 <Aside>
   Search results reflect the state of the local index, not a live listing from S3. If you need to search for an object that was just uploaded, trigger a manual re-index from the bucket's **Settings > Index** tab.

--- a/website/src/content/docs/getting-started/concepts.mdx
+++ b/website/src/content/docs/getting-started/concepts.mdx
@@ -76,7 +76,7 @@ Sairo's background crawler keeps the local index in sync with your S3 storage.
 
 2. **Parallel indexing**
 
-   The crawler processes **4 prefix threads per bucket** simultaneously. For buckets with deep prefix hierarchies, this dramatically reduces indexing time compared to a single-threaded approach.
+   The crawler processes **16 concurrent prefix threads per bucket**. For buckets with deep prefix hierarchies, this dramatically reduces indexing time compared to a single-threaded approach. See [Architecture](/reference/architecture/) for the full crawl model.
 
 3. **Metadata stored**
 
@@ -88,12 +88,16 @@ Sairo's background crawler keeps the local index in sync with your S3 storage.
 
 4. **Auto-recrawl loop**
 
-   After the initial crawl completes, Sairo waits `RECRAWL_INTERVAL` seconds (default: **120**) and then starts another crawl. This loop repeats indefinitely, keeping the index reasonably fresh.
+   After the initial crawl completes, Sairo waits `RECRAWL_INTERVAL` seconds (default: **120**) and then refreshes the index. This loop repeats indefinitely, keeping the index fresh.
+
+5. **Adaptive delta crawling for large buckets**
+
+   A small bucket is cheap to re-crawl in full, so it is. But re-walking a multi-million-object bucket every two minutes would be slow and expensive. So once a bucket's full crawl takes longer than `LARGE_BUCKET_SECONDS` (default: **60**), Sairo switches it to **incremental delta crawls**: each cycle re-lists only the newest/"hot" prefixes (e.g. today's partition in a `year=/month=/day=` layout) to pick up new objects in seconds, and runs a full reconcile every `FULL_CRAWL_INTERVAL` (default: **3600s**) to catch deletions and cold changes. This keeps huge buckets current without re-listing the whole bucket each cycle.
 
 </Steps>
 
-<Aside type="tip" title="Tuning the recrawl interval">
-  The recrawl interval is a tradeoff between index freshness and S3 API costs. For buckets with millions of objects, consider increasing `RECRAWL_INTERVAL` to reduce `ListObjectsV2` calls. For rapidly changing buckets, decrease it. See [Configuration](/installation/configuration/).
+<Aside type="tip" title="Tuning crawl freshness vs. cost">
+  Crawl frequency is a tradeoff between index freshness and S3 API costs. For large buckets, delta crawling handles freshness automatically; tune `RECRAWL_INTERVAL`, `LARGE_BUCKET_SECONDS`, and `FULL_CRAWL_INTERVAL` to balance the two. See [Configuration](/installation/configuration/) and the [delta-crawl tuning reference](/reference/environment-variables/).
 </Aside>
 
 ## Authentication model

--- a/website/src/content/docs/reference/architecture.mdx
+++ b/website/src/content/docs/reference/architecture.mdx
@@ -60,6 +60,27 @@ Configuration:
 
 This approach scales to petabyte-level buckets with tens of millions of objects.
 
+## Adaptive Delta Crawling
+
+Re-crawling a small bucket in full every cycle is cheap. Re-walking a multi-million-object bucket every couple of minutes is not. So Sairo adapts per bucket:
+
+- A bucket whose **full crawl takes longer than `LARGE_BUCKET_SECONDS`** (default 60s) is flagged "large" and switched to **incremental delta crawls** instead of full re-crawls.
+- A delta crawl samples the most recently-indexed objects (`DELTA_SAMPLE`) to locate the **"hot" prefixes** that are actually receiving writes, then re-lists only those — capped at `DELTA_MAX_TARGETS`. In a time-partitioned layout (`year=/month=/day=/hour=`) this means re-listing today's partition and the one that just rolled over, not the entire history.
+- Partition vs. descriptive levels are distinguished by fan-out: a level with more than `DELTA_BRANCH_FANOUT` children is treated as a time partition (follow only the newest `DELTA_NEWEST_K`); a level with fewer is a descriptive branch (follow all).
+- A full reconcile runs every `FULL_CRAWL_INTERVAL` (default 3600s) to catch deletions and cold changes that a delta pass would miss.
+
+The result: new objects on a huge bucket show up in seconds, at a tiny fraction of the API cost of a full re-crawl. All delta parameters are tunable — see [Environment Variables](/reference/environment-variables/).
+
+## Upload Path (Browser → S3)
+
+Uploads do **not** stream through the Sairo server. The browser uploads object bytes **directly to the S3 endpoint** using presigned URLs that the server signs on demand:
+
+- **Small files** use a single presigned `PUT`.
+- **Large files** use **presigned multipart**: the browser splits the file into parts and uploads them in parallel, each part URL signed just-in-time so a long transfer never fails on an expired URL. There is no single-PUT size ceiling — objects can be as large as S3 allows (up to 5 TB). An in-progress upload can be stopped, which aborts the multipart upload on S3 so no orphaned parts remain.
+- Because no file data is buffered in the server process, **server memory stays flat regardless of file size** — large uploads no longer cause memory pressure or pod restarts at scale.
+
+A server-proxied streaming path remains as a fallback (bounded by `UPLOAD_PROXY_CONCURRENCY`) for environments where direct browser→S3 access is blocked.
+
 ## SQLite Performance Tuning
 
 Sairo applies aggressive PRAGMA tuning for maximum query performance:
@@ -86,7 +107,7 @@ SELECT * FROM prefix_children WHERE parent_prefix = '';
 SELECT DISTINCT SUBSTR(key, ...) FROM objects WHERE ...
 ```
 
-This works at any scale — tested up to 2M objects per bucket.
+This works at any scale — validated read-only on a live deployment of 15.5M objects across 14 buckets (~269 TB), where folder listing on the largest (~9.86M-object) bucket still returns at the network round-trip floor. See [Benchmarks](/reference/benchmarks/).
 
 ## NDJSON Streaming
 

--- a/website/src/content/docs/reference/benchmarks.mdx
+++ b/website/src/content/docs/reference/benchmarks.mdx
@@ -1,74 +1,118 @@
 ---
 title: "Benchmarks"
-description: "Performance benchmarks for search, indexing, uploads, and API response times — with reproduction scripts."
+description: "Performance benchmarks for search, indexing, uploads, and API response times — server-compute microbenchmarks plus validation on a live multi-hundred-terabyte deployment."
 ---
 
 import { Aside } from "@astrojs/starlight/components";
 
-Sairo ships with a benchmark suite you can run against your own deployment. All numbers on the landing page are derived from these reproducible tests.
+Sairo ships with a benchmark suite you can run against your own deployment. The numbers below come from two complementary contexts, kept deliberately separate so they are never conflated:
 
-## Test Environment
+1. **Server-compute microbenchmarks** — single Uvicorn process in Docker against local MinIO. These isolate Sairo's own latency (index lookups, FTS5, SQL aggregation) with negligible network overhead.
+2. **Production validation** — a live, read-only run against a real multi-hundred-terabyte deployment, to confirm the architecture holds at scale.
+
+<Aside type="tip">
+  Production deployments on dedicated Linux hardware with NVMe storage will yield better server-compute numbers than these Docker Desktop results.
+</Aside>
+
+## Production Validation (live deployment)
+
+Measured read-only against a live production instance on Leaseweb S3-compatible object storage:
+
+| Parameter | Value |
+|---|---|
+| **Total indexed** | **15.5M objects across 14 buckets, ~269 TB** |
+| **Largest single bucket** | **~9.86M objects** |
+| **Access path** | Public internet, behind a CDN/TLS edge |
+
+Because this run crosses the public internet, every request carries a fixed transport round-trip (RTT) floor. We measured that floor against a zero-compute endpoint and subtract it to isolate Sairo's server-side cost:
+
+| Operation (on the ~9.86M-object bucket) | End-to-end p50 | Server compute (end-to-end − RTT floor) |
+|---|---|---|
+| `/healthz` (zero-compute reference) | 284ms | — *(this is the RTT floor)* |
+| **Folder listing** | 281ms | **≈ 0ms — at the network floor** |
+| Search (200 results) | 305ms | **~20–35ms** |
+| Storage breakdown (root) | 304ms | **~20–35ms** |
+
+The headline result: **folder listing on a ~9.86M-object bucket lands at the network floor** — Sairo adds no measurable server-side latency, because the listing is a single indexed lookup against a pre-computed prefix hierarchy regardless of folder size. Search and storage breakdown stay in the tens of milliseconds server-side at ~10M objects.
+
+<Aside type="note">
+  These end-to-end figures are dominated by transport, not Sairo. They are included to show real at-scale behavior over a real network — for clean millisecond-level server latency, see the localhost microbenchmarks below.
+</Aside>
+
+## Test Environment (microbenchmarks)
 
 | Parameter | Value |
 |---|---|
 | **Runtime** | Docker container, single Uvicorn process |
 | **Host** | macOS, Apple Silicon (Docker Desktop) |
-| **Local S3** | MinIO (localhost:9000) |
-| **Production S3** | Remote S3-compatible object storage |
-| **Production dataset** | 134,707 objects, 38.25 TB |
-| **Methodology** | 30 iterations per measurement, percentile reporting |
+| **Storage** | Local MinIO, plus a local Sairo pointed at production S3 indexes |
+| **Methodology** | 15–30 iterations per measurement, percentile reporting |
 
-<Aside type="tip">
-  Production deployments on dedicated Linux hardware with NVMe storage will yield better numbers than these Docker Desktop results.
-</Aside>
+## Search Latency (server-compute)
 
-## Search Latency
+FTS5 trigram search, measured locally to isolate server cost:
 
-FTS5 trigram search against the production bucket (134,707 objects, 38.25 TB):
+| Dataset | Query | Results | p50 | p95 |
+|---|---|---|---|---|
+| 134K-object index | typical (limit=200) | 200 | **2.2–3.1ms** | 3–22ms |
+| 134K-object index | broad match, limit=500 | 500 | **40ms** | 43ms |
+| ~10M-object bucket (live, minus RTT) | 200 results | 200 | **~20–35ms** | — |
 
-| Query | Results | p50 | p95 |
+Typical queries return in **single-digit milliseconds** on hundreds of thousands of objects, and in **tens of milliseconds** on ~10M-object buckets. Larger result sets (500+ rows) cost more because of row serialization, not search.
+
+## Object Listing & Pagination
+
+Listing is served from the SQLite index, never a live S3 `LIST`. Folder navigation uses a pre-computed `prefix_children` hierarchy, so it is a constant-time index lookup at any folder size.
+
+| Scenario | Before | After | Notes |
 |---|---|---|---|
-| `parquet` (limit=100) | 100 | **3.1ms** | 4.8ms |
-| `events` | 200 | **2.4ms** | 16.2ms |
-| `tracking` | 200 | **2.3ms** | 3.0ms |
-| `analytics` | 200 | **2.5ms** | 3.4ms |
-| `ingest` | 200 | **2.4ms** | 5.5ms |
-| `metadata` | 200 | **2.4ms** | 4.3ms |
-| `2026` | 200 | **2.2ms** | 22.0ms |
+| Folder listing, 557K-object bucket | 114ms | **0.048ms** | pre-computed prefix hierarchy |
+| Folder listing, >1M-object bucket | OOM (disabled) | **constant-time** | previously turned off above 1M objects; now lands at the network floor on a live 9.86M-object bucket |
+| Leaf listing (large folder), paginated | 8.7ms, ~1 MB payload | **4.8ms, ~238 KB payload** | pagination (v3.3.0) caps payload + latency |
+| Flat folder with 1,000,000 objects in one prefix | — | **~1.3s** | worst case: a single non-hierarchical folder of 1M keys |
 
-Fastest observed: **1.7ms**. Typical queries return in **2-3ms p50** against 134K objects.
+The flat-1M-folder case is the deliberate stress test — a single prefix holding a million keys with no sub-structure. Even then it returns in ~1.3s; any normally-partitioned layout lists in low single-digit milliseconds.
 
 ## Indexing Throughput
 
-| Bucket | Objects | Duration | Throughput |
-|---|---|---|---|
-| bench-small | 1,000 | 1.08s | **926 obj/s** |
-| bench-mixed | 2,416 | 1.08s | **1,348 obj/s** |
-| production-bucket | 134,707 | completed | Production-scale crawl |
-
-Indexing rate: **1,000–1,350 objects/second** on local MinIO.
-
-## Upload Throughput
-
-| File Size | p50 | Throughput |
+| Bucket | Objects | Throughput |
 |---|---|---|
-| 1 KB | 44.9ms | — |
-| 1 MB | 51.9ms | 19.3 MB/s |
-| 10 MB | 130.7ms | 76.5 MB/s |
-| 50 MB | 436.2ms | **114.6 MB/s** |
+| bench-small | 1,000 | **926 obj/s** |
+| bench-mixed | 2,416 | **1,348 obj/s** |
+| production buckets | 15.5M (live) | crawled + kept fresh via adaptive delta crawler |
 
-## API Response Times
+Indexing rate: **1,000–1,350 objects/second** on local MinIO. At production scale, large buckets are kept current by an **adaptive delta crawler** that re-lists only the newest partitions instead of re-walking the whole bucket each cycle, with periodic full reconciles.
+
+## Uploads (direct browser → S3)
+
+Since v3.4.0, uploads go **directly from the browser to the S3 endpoint** — file bytes never pass through the Sairo server. Small files use a single presigned `PUT`; large files use **presigned multipart**, splitting the file into parts uploaded in parallel, each part signed just-in-time.
+
+| Property | Behavior |
+|---|---|
+| **Server memory during upload** | **Flat, independent of file size** — no buffering, so no OOM or pod restarts at scale |
+| **Maximum object size** | Up to S3's **5 TB** per-object limit (no single-PUT ceiling) |
+| **Large-file transfer** | Parallel multipart parts; an in-progress upload can be stopped and is cleanly aborted on S3 |
+| **Throughput** | Bounded by the client's bandwidth to S3, not by Sairo |
+
+<Aside type="note">
+  Earlier versions streamed uploads through the server (a ~114 MB/s proxy path, capped by server memory). That path remains only as a fallback; the default direct path removes the server as a bottleneck entirely, which is the meaningful win at scale.
+</Aside>
+
+## API Response Times (server-compute)
 
 | Endpoint | p50 | p95 |
 |---|---|---|
 | `/healthz` | **2.1ms** | 3.6ms |
 | `/api/buckets` | **4.3ms** | 5.8ms |
-| Object listing (production) | **2.4ms** | 4.6ms |
+| Object listing | **2.4ms** | 4.6ms |
+| Storage breakdown (root) | **2.4–3.9ms** | 5–6ms |
 | Presigned URL generation | **3.1ms** | 5.6ms |
+
+Sub-5ms p50 for standard endpoints on local hardware.
 
 ## Concurrent Load
 
-Production S3, concurrent search queries:
+Concurrent search queries, single Uvicorn process:
 
 | Concurrent Users | Requests/sec |
 |---|---|
@@ -76,51 +120,28 @@ Production S3, concurrent search queries:
 | 10 | **333** |
 | 25 | **528** |
 
-## Scaling Performance (v3.0)
+Throughput scales with worker count; these are single-process numbers.
 
-Benchmarked on production data running in Docker against Leaseweb StorageGRID:
+## SQLite PRAGMA Tuning
 
-### Folder Listing (the user-facing speedup)
-
-| Bucket | Objects | Before (v2.0) | After (v3.0) | Speedup |
-|---|---|---|---|---|
-| ssp-production-reports | 557K | 114ms | **0.048ms** | **2,378x** |
-| ds-mletl-data | 139K | 27ms | **0.056ms** | **486x** |
-| druid-lw-prod | 2M (was >1M, disabled) | 312ms (DISTINCT fallback) | **0.002ms** | **191,231x** |
-
-Folder listing uses pre-computed `prefix_children` via SQL-only aggregation. Previously disabled for buckets >1M objects due to OOM — now works at any scale.
-
-### SQLite PRAGMA Tuning Impact
+The index database is opened with: `cache_size=-64000` (64 MB), `mmap_size=268435456` (256 MB memory-mapped I/O), `temp_store=MEMORY`. Impact at scale:
 
 | Query | Before | After | Dataset |
 |---|---|---|---|
-| COUNT(*) | 2.0ms | 1.5ms | 557K objects |
-| COUNT(*) | 11.3ms | 7.3ms | 2M objects |
-| SUM(size) | 40ms | 62ms | 557K objects |
-| Folder stats rebuild | 63ms | 56ms | 139K objects |
+| `COUNT(*)` | 11.3ms | **7.3ms** | 2M objects |
+| `COUNT(*)` | 2.0ms | **1.5ms** | 557K objects |
+| Folder stats rebuild | 63ms | **56ms** | 139K objects |
 
-PRAGMAs applied: `cache_size=-64000` (64MB), `mmap_size=268435456` (256MB), `temp_store=MEMORY`.
+## Crawl Architecture
 
-### Crawl Performance
-
-| Setting | Before | After |
-|---|---|---|
-| Crawl workers | 6 | **12** |
-| Prefix workers | 4 | **16** |
-| Batch size | 2,000 | **10,000** |
-| Update chunks | 500 | **2,000** |
-| FTS rebuild | Blocks 15+ min | **Background thread** |
-| Sub-prefix splitting | None | **Auto for buckets with few prefixes** |
-
-### At 1PB Scale (Projected)
-
-| Operation | Expected Performance |
+| Setting | Value |
 |---|---|
-| Folder listing | < 1ms (constant time, index lookup) |
-| Search | ~1ms (FTS5, always available) |
-| Storage breakdown | ~500ms (full scan with PRAGMA tuning) |
-| Crawl (50M objects) | ~25 min (with sub-prefix splitting) |
-| FTS rebuild (50M objects) | ~83 min (background, non-blocking) |
+| Crawl workers | **12** |
+| Prefix workers | **16** |
+| Batch insert size | **10,000** |
+| FTS rebuild | **Background thread** (never blocks listing/search) |
+| Large buckets | **Adaptive delta crawl** + periodic full reconcile |
+| Sub-prefix splitting | **Automatic** for buckets with few top-level prefixes |
 
 ## Running the Benchmarks
 
@@ -136,8 +157,6 @@ cd benchmark
 ./seed-data.sh large        # Seeds bench-large (50K objects)
 ```
 
-The seeder creates four buckets with realistic file structures:
-
 | Bucket | Objects | Pattern |
 |---|---|---|
 | `bench-small` | 1,000 | 5 dirs × 10 months × 20 files |
@@ -148,37 +167,25 @@ The seeder creates four buckets with realistic file structures:
 ### 2. Run benchmarks
 
 ```bash
-# Run all benchmarks
-./run-benchmarks.sh
-
-# Run specific benchmark categories
-./run-benchmarks.sh search          # Search latency only
-./run-benchmarks.sh crawl           # Crawl/indexing only
-./run-benchmarks.sh crawl listing   # Crawl + listing
+./run-benchmarks.sh                 # all categories
+./run-benchmarks.sh search          # search latency only
+./run-benchmarks.sh crawl listing   # crawl + listing
 ```
 
-### Prerequisites
-
-- Sairo running on `localhost:8000` (or set `SAIRO_URL`)
-- MinIO running on `localhost:9000`
-- Test buckets seeded via `seed-data.sh`
-- Default admin credentials (`admin`/`password`) or set `ADMIN_USER`/`ADMIN_PASS`
+Prerequisites: Sairo on `localhost:8000` (or set `SAIRO_URL`), MinIO on `localhost:9000`, test buckets seeded, and admin credentials.
 
 ### 3. Results
 
-Results are saved to `benchmark/results/`:
-
-- **JSON** — machine-readable per-run results (`benchmark-YYYYMMDD-HHMMSS.json`)
-- **Markdown** — human-readable summary (`LATEST-RESULTS.md`)
+Results are saved to `benchmark/results/` as machine-readable JSON and a human-readable `LATEST-RESULTS.md`.
 
 ## Landing Page Claims
 
-Every number on the landing page maps to a specific benchmark result:
-
 | Landing Page Claim | Benchmark Evidence |
 |---|---|
-| "Single-digit millisecond search" | Production p50 = 2.2–3.1ms on 134K objects |
+| "Proven at 269 TB / 15.5M objects" | Live deployment, 14 buckets, largest ~9.86M objects |
+| "Constant-time folder listing at any scale" | Listing lands at the network floor on a ~9.86M-object bucket |
+| "Single-digit millisecond search" | p50 = 2.2–3.1ms on 134K objects (tens of ms at ~10M) |
 | "1,300+ obj/sec indexing" | 1,348 obj/s measured on bench-mixed |
 | "Sub-5ms API responses" | healthz p50 = 2.1ms, most endpoints < 5ms |
-| "500+ requests/second" | 528 req/s at 25 concurrent users (production) |
-| "114 MB/s upload" | 50 MB file upload sustained throughput |
+| "500+ requests/second" | 528 req/s at 25 concurrent users |
+| "Uploads of any size, zero server memory" | Direct browser→S3 multipart up to 5 TB; flat server memory |

--- a/website/src/content/docs/reference/changelog.mdx
+++ b/website/src/content/docs/reference/changelog.mdx
@@ -13,6 +13,13 @@ Each version release produces all three artifacts from the same `v*` tag:
 
 ---
 
+## v3.5.0
+
+**Anonymous telemetry schema v2** — richer, still privacy-first
+
+- The heartbeat now also reports instance **health** (trailing-24h requests/errors, restarts, disk used/total, derived status), **activation milestones**, and **engagement** (active buckets, last write, enabled features, update-available). Still **aggregate counts + timestamps only** — never names, keys, paths, IPs, or content; clamped and < 4 KB.
+- Cadence is now **hourly** (`TELEMETRY_INTERVAL`, default 3600s). Fully opt-out via `TELEMETRY=false`. See [Telemetry](/security/telemetry).
+
 ## v3.4.1
 
 **S3-key authentication is scoped per user**

--- a/website/src/content/docs/reference/environment-variables.mdx
+++ b/website/src/content/docs/reference/environment-variables.mdx
@@ -97,6 +97,14 @@ These bound how the incremental delta crawler discovers new data on large bucket
 
 Login attempts are rate-limited with two layers: **10 per minute** via slowapi and **10 per 5 minutes per IP** via a hardcoded window. Neither is independently configurable.
 
+## Telemetry
+
+| Variable | Default | Description |
+|---|---|---|
+| `TELEMETRY` | `true` | Send an anonymous usage heartbeat (aggregate counts + timestamps only — never names, keys, paths, or content). Set to `false` to disable entirely. See [Telemetry](/security/telemetry). |
+| `TELEMETRY_INTERVAL` | `3600` | Seconds between heartbeats. |
+| `SAIRO_STORAGE_EPHEMERAL` | _(auto)_ | Optional hint for the telemetry `id_persistence` field: `true` if `DB_DIR` is ephemeral (e.g. `emptyDir`), `false` if durable. The Helm chart sets it from `persistence.enabled`; otherwise Sairo infers it from the mount table. |
+
 ## Example: Full Configuration
 
 ```yaml

--- a/website/src/content/docs/reference/environment-variables.mdx
+++ b/website/src/content/docs/reference/environment-variables.mdx
@@ -41,7 +41,7 @@ All Sairo configuration is done through environment variables. This page lists e
 | `RECRAWL_INTERVAL` | `120` | Seconds between automatic reindex cycles for each bucket |
 | `DB_DIR` | `/data` | Directory where SQLite index databases are stored |
 | `FULL_CRAWL_INTERVAL` | `3600` | Seconds between full reconcile crawls for large buckets (delta crawls run on `RECRAWL_INTERVAL` in between) |
-| `LARGE_BUCKET_SECONDS` | `30` | A bucket whose full crawl takes longer than this is treated as "large" and kept fresh with delta crawls + periodic full reconcile, instead of full re-crawls every interval |
+| `LARGE_BUCKET_SECONDS` | `60` | A bucket whose full crawl takes longer than this is treated as "large" and kept fresh with delta crawls + periodic full reconcile, instead of full re-crawls every interval |
 
 ### Delta-crawl tuning
 
@@ -49,6 +49,8 @@ These bound how the incremental delta crawler discovers new data on large bucket
 
 | Variable | Default | Description |
 |---|---|---|
+| `DELTA_SAMPLE` | `3000` | How many of the most recently-indexed objects to sample to locate the "hot" prefixes a delta crawl should re-list |
+| `DELTA_MAX_TARGETS` | `40` | Cap on the number of hot prefixes re-listed per delta crawl |
 | `DELTA_BRANCH_FANOUT` | `8` | Levels with more children than this are treated as time partitions (follow only the newest few); fewer means a descriptive branch (follow all) |
 | `DELTA_NEWEST_K` | `2` | How many of the newest partitions to re-list at a partition level (current + just-rolled) |
 | `DELTA_MAX_DEPTH` | `12` | Safety cap on prefix-walk depth |
@@ -101,7 +103,7 @@ Login attempts are rate-limited with two layers: **10 per minute** via slowapi a
 
 | Variable | Default | Description |
 |---|---|---|
-| `TELEMETRY` | `true` | Send an anonymous usage heartbeat (aggregate counts + timestamps only — never names, keys, paths, or content). Set to `false` to disable entirely. See [Telemetry](/security/telemetry). |
+| `TELEMETRY` | `true` | Send an anonymous usage heartbeat (schema v2: aggregate counts, instance health, and activation timestamps only — never names, keys, paths, or content). Set to `false` to disable entirely. See [Telemetry](/security/telemetry). |
 | `TELEMETRY_INTERVAL` | `3600` | Seconds between heartbeats. |
 | `TELEMETRY_URL` | `https://dashboard.sairo.dev/api/v1/ping` | Endpoint the heartbeat is POSTed to. Override to point at your own collector (or leave unset to disable by setting `TELEMETRY=false`). |
 | `SAIRO_STORAGE_EPHEMERAL` | _(auto)_ | Optional hint for the telemetry `id_persistence` field: `true` if `DB_DIR` is ephemeral (e.g. `emptyDir`), `false` if durable. The Helm chart sets it from `persistence.enabled`; otherwise Sairo infers it from the mount table. |

--- a/website/src/content/docs/reference/environment-variables.mdx
+++ b/website/src/content/docs/reference/environment-variables.mdx
@@ -103,6 +103,7 @@ Login attempts are rate-limited with two layers: **10 per minute** via slowapi a
 |---|---|---|
 | `TELEMETRY` | `true` | Send an anonymous usage heartbeat (aggregate counts + timestamps only — never names, keys, paths, or content). Set to `false` to disable entirely. See [Telemetry](/security/telemetry). |
 | `TELEMETRY_INTERVAL` | `3600` | Seconds between heartbeats. |
+| `TELEMETRY_URL` | `https://dashboard.sairo.dev/api/v1/ping` | Endpoint the heartbeat is POSTed to. Override to point at your own collector (or leave unset to disable by setting `TELEMETRY=false`). |
 | `SAIRO_STORAGE_EPHEMERAL` | _(auto)_ | Optional hint for the telemetry `id_persistence` field: `true` if `DB_DIR` is ephemeral (e.g. `emptyDir`), `false` if durable. The Helm chart sets it from `persistence.enabled`; otherwise Sairo infers it from the mount table. |
 
 ## Example: Full Configuration

--- a/website/src/content/docs/security/telemetry.mdx
+++ b/website/src/content/docs/security/telemetry.mdx
@@ -1,0 +1,54 @@
+---
+title: "Telemetry"
+description: "What anonymous usage data Sairo reports, why, and how to turn it off."
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+Sairo sends a small, anonymous heartbeat so the maintainers can understand fleet health and adoption (which versions and providers are in use, whether instances are healthy). It is **aggregate counts and timestamps only** — never your data.
+
+<Aside type="tip">
+  To disable telemetry completely, set `TELEMETRY=false`. No ping is sent at all when it's off.
+</Aside>
+
+## What is sent
+
+The heartbeat (schema v2) is a single small JSON POST (well under 4 KB) to `https://dashboard.sairo.dev/api/v1/ping`, by default once per hour. It contains:
+
+- **Identity / build:** a random anonymous `instance_id` (generated locally, not tied to you), the Sairo `version`, `os`, and detected storage `provider`.
+- **Scale (aggregate counts):** number of buckets, total objects, total size, endpoints, users, API tokens.
+- **Health:** trailing-24h request count, error count, **process restart count and crash count** (crashes = unclean exits like OOM/SIGKILL, counted separately from orchestrated restarts), index-volume disk total/used bytes, and a derived `ok | degraded | error` status.
+- **Activation timestamps:** when this instance first created a bucket, first stored an object, first minted an API token, first saw an MCP/CLI connection.
+- **Engagement:** count of buckets active in the last 24h, last-write timestamp, which Sairo features are enabled (e.g. `oauth`, `ldap`, `twofa`, `multi_endpoint`), and whether a newer version is available.
+- **Instance validity:** `boot_count` (how many times this install has started) and `id_persistence` (`persistent` / `ephemeral` / `unknown`) — so the dashboard can tell a long-lived install from one on throwaway storage that gets a new id on every restart. No identifying data; just counts and a label.
+
+<Aside>
+  The disk figures are for **Sairo's own index volume** (`DB_DIR`), not your S3 object storage — they're a health signal (a full index disk degrades crawling), not a measure of how much data you store.
+</Aside>
+
+## What is never sent
+
+Sairo deliberately collects **none** of the following:
+
+- Bucket names, object keys, file names, or any paths
+- Any object content or metadata values
+- Usernames, emails, or any user-identifying information
+- IP addresses or request bodies
+- Free-text of any kind
+
+Counts and timestamps cannot be reversed into your content. The collector also clamps values on arrival as a second line of defense.
+
+## Controlling it
+
+| Variable | Default | Effect |
+|---|---|---|
+| `TELEMETRY` | `true` | Set to `false` to disable all telemetry (no ping is sent). |
+| `TELEMETRY_INTERVAL` | `3600` | Seconds between pings. |
+| `SAIRO_STORAGE_EPHEMERAL` | _(auto)_ | Optional hint for `id_persistence`: `true` if `DB_DIR` is throwaway storage, `false` if durable. The Helm chart sets it automatically from `persistence.enabled`; otherwise Sairo infers it. |
+
+```yaml
+environment:
+  TELEMETRY: "false"   # opt out entirely
+```
+
+The startup log line states whether telemetry is enabled, so you can confirm your setting took effect.

--- a/website/src/content/docs/security/user-management.mdx
+++ b/website/src/content/docs/security/user-management.mdx
@@ -5,6 +5,20 @@ description: "Managing users, roles, and per-bucket permissions in Sairo."
 
 Sairo has a built-in user system with two roles and granular per-bucket permissions for viewers.
 
+:::note[This page describes local auth mode]
+Everything below — roles, the admin/viewer model, and per-bucket permissions — applies when `AUTH_MODE=local` (the default). If you run Sairo in **S3-key auth mode** (`AUTH_MODE=s3`), authorization works differently — see [S3-key auth mode](#s3-key-auth-mode) below.
+:::
+
+## S3-key auth mode
+
+When `AUTH_MODE=s3`, users log in with their **own S3 access key and secret**, and Sairo performs every storage operation using *those* credentials — not a shared server key. As a result, **bucket visibility and permissions are governed entirely by your S3 provider's IAM**, not by Sairo's role system:
+
+- Each user sees and can act on **only the buckets their own keys are allowed to access**. A user whose keys are scoped to two buckets sees exactly those two — the rest of the account is invisible to them, even via direct URL.
+- The admin/viewer roles and the per-bucket permission grants described below **do not apply** in this mode. Authorization is delegated to the provider (AWS IAM, MinIO policies, Ceph caps, etc.).
+- This makes Sairo safe to expose to a team whose access is already managed by IAM: you grant and revoke access at the provider, and Sairo reflects it automatically.
+
+Use local auth mode (below) when you want Sairo itself to manage users and per-bucket access against a single set of storage credentials.
+
 ## Roles
 
 | Role | Capabilities |


### PR DESCRIPTION
## Telemetry v2 (v3.5.0)
Extends the anonymous heartbeat to schema v2 — health, activation, engagement, and instance-validity signals. Additive, privacy-first (aggregate counts + timestamps only; opt-out via \`TELEMETRY=false\`), fail-safe and isolated from the request path. \`TELEMETRY_URL\` is configurable for self-hosted collectors.

Validated end-to-end on real containers: real ping over the wire, crash/restart lifecycle (boot_count + crash detection), multi-worker leader-lock (single pinger), ephemeral-storage classification (tmpfs / overlay-root / emptyDir-hint → ephemeral; reincarnation = new id + boot=1), and a full scoping/IDOR regression (no core-functionality impact). Dashboard ingestion contract confirmed.

## Docs refresh (same release window)
- **Performance:** benchmarks now lead with live production validation (15.5M objects / 14 buckets / ~269 TB; folder listing at the network floor on a ~9.86M-object bucket). Uploads rewritten around direct browser→S3 multipart. Provider/scale corrected; bucket names anonymized.
- **Accuracy fixes:** \`LARGE_BUCKET_SECONDS\` 30→60 to match code; documented \`DELTA_SAMPLE\`/\`DELTA_MAX_TARGETS\`; crawler threads 4→16 in concepts.
- **Newly documented capabilities:** S3-key auth scoping (provider IAM), adaptive delta crawler, direct upload path, keyset pagination, telemetry opt-out.