### PR TITLE
feat: more clickable update banner + numeric version compare

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -295,6 +295,22 @@ async def s3_error_handler(request, exc):
 
 _app_start_time = time.time()
 SAIRO_VERSION = "3.5.0"
+
+
+def _version_gt(a: str, b: str) -> bool:
+    """True if version `a` is newer than `b`, compared numerically (not lexically,
+    so 3.10.0 > 3.9.0). Non-numeric/missing parts degrade gracefully to 0."""
+    def parts(v):
+        out = []
+        for p in (v or "").lstrip("vV").split("."):
+            num = "".join(c for c in p if c.isdigit())
+            out.append(int(num) if num else 0)
+        return out
+    pa, pb = parts(a), parts(b)
+    n = max(len(pa), len(pb))
+    pa += [0] * (n - len(pa))
+    pb += [0] * (n - len(pb))
+    return pa > pb
 TELEMETRY = os.environ.get("TELEMETRY", "true").lower() != "false"
 
 S3_ENDPOINT = os.environ.get("S3_ENDPOINT", "")
@@ -2597,7 +2613,7 @@ def _collect_telemetry() -> dict:
 
     # update_available — read the cached check only; never triggers a network call here
     _latest = _update_cache.get("latest")
-    update_available = bool(_latest and _latest != SAIRO_VERSION and _latest > SAIRO_VERSION)
+    update_available = bool(_latest and _version_gt(_latest, SAIRO_VERSION))
 
     # health rollup
     err_rate = (requests_failed_24h / requests_24h) if requests_24h else 0.0
@@ -3346,7 +3362,7 @@ def get_version(user: dict = Depends(get_current_user)):
             _update_cache["checked_at"] = now
         except Exception:
             latest = _update_cache.get("latest") or SAIRO_VERSION
-    update_available = latest and latest != SAIRO_VERSION and latest > SAIRO_VERSION
+    update_available = bool(latest and _version_gt(latest, SAIRO_VERSION))
     return {
         "current": SAIRO_VERSION,
         "latest": latest,

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,6 +33,16 @@ import { streamList, deleteObjects, deleteFolder, createFolder, bulkCopy, bulkMo
 // paints instantly and no single response is huge, regardless of folder size.
 const LIST_PAGE_SIZE = 1000;
 
+// Update banner: the headline wins users get by upgrading. Refresh these to the
+// latest release's user-facing highlights when cutting a new version.
+const UPDATE_HIGHLIGHTS = [
+  "Direct uploads, any size",
+  "Million-object folders open instantly",
+  "Per-user S3-key access",
+  "Faster crawling",
+];
+const UPGRADE_CMD = "docker compose pull && docker compose up -d";
+
 // Share link route: /share/{token}
 function getShareToken() {
   const path = window.location.pathname;
@@ -131,6 +141,8 @@ function MainApp() {
   const [showEndpointManager, setShowEndpointManager] = useState(false);
   const [branding, setBranding] = useState({ app_name: "Sairo" });
   const [updateInfo, setUpdateInfo] = useState(null);
+  const [showUpgradeCmd, setShowUpgradeCmd] = useState(false);
+  const [upgradeCmdCopied, setUpgradeCmdCopied] = useState(false);
   const [bucketPermission, setBucketPermission] = useState(null);
   const dragCounter = useRef(0);
   const abortRef = useRef(null);
@@ -610,14 +622,32 @@ function MainApp() {
           </div>
         </header>
         {updateInfo && updateInfo.update_available && (
-          <div style={{ padding: "8px 16px", background: "rgba(59, 130, 246, 0.1)", border: "1px solid rgba(59, 130, 246, 0.2)", borderRadius: 8, margin: "0 16px 12px", display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-            <span style={{ fontSize: 13, color: "var(--text, #e4e4e7)" }}>
-              Sairo <strong>v{updateInfo.latest}</strong> is available. You are on v{updateInfo.current}.
+          <div className="update-banner">
+            <span className="ub-icon" aria-hidden="true">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.2" strokeLinecap="round" strokeLinejoin="round"><path d="M12 19V5M5 12l7-7 7 7" /></svg>
             </span>
-            <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-              <a href="https://github.com/AshwathStephen/sairo/releases" target="_blank" rel="noopener noreferrer" style={{ fontSize: 12, color: "#3b82f6", textDecoration: "none", fontWeight: 500 }}>View changelog</a>
-              <button onClick={() => setUpdateInfo(null)} style={{ background: "none", border: "none", color: "var(--text-muted)", cursor: "pointer", fontSize: 16, padding: "0 4px" }}>&times;</button>
+            <div className="ub-body">
+              <div className="ub-head">
+                Sairo <strong>v{updateInfo.latest}</strong> is here <span className="ub-cur">· you're on v{updateInfo.current}</span>
+              </div>
+              <div className="ub-chips">
+                {UPDATE_HIGHLIGHTS.map((h) => <span className="ub-chip" key={h}>{h}</span>)}
+              </div>
+              <div className="ub-actions">
+                <button className="ub-btn ub-primary" onClick={() => setShowUpgradeCmd((v) => !v)}>
+                  Update now
+                  <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round"><path d="M5 12h14M12 5l7 7-7 7" /></svg>
+                </button>
+                <a className="ub-btn ub-link" href="https://github.com/AshwathStephen/sairo/releases/latest" target="_blank" rel="noopener noreferrer">See what's new</a>
+              </div>
+              {showUpgradeCmd && (
+                <div className="ub-cmd">
+                  <code>{UPGRADE_CMD}</code>
+                  <button className="ub-copy" onClick={() => { navigator.clipboard?.writeText(UPGRADE_CMD); setUpgradeCmdCopied(true); setTimeout(() => setUpgradeCmdCopied(false), 1400); }}>{upgradeCmdCopied ? "Copied" : "Copy"}</button>
+                </div>
+              )}
             </div>
+            <button className="ub-dismiss" aria-label="Dismiss" onClick={() => setUpdateInfo(null)}>&times;</button>
           </div>
         )}
         <BucketList onSelect={navigateBucket} role={user.role} onDashboard={setDashboardBucket} />

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -880,6 +880,53 @@ button.btn-danger:disabled { background: var(--bg-surface); }
 .version-row-latest td { background: var(--success-bg); }
 .version-row-latest:hover td { background: var(--success-bg); filter: brightness(0.97); }
 .version-row-deleted td { background: var(--danger-light); }
+
+/* Update banner */
+.update-banner {
+  display: flex; align-items: flex-start; gap: 13px;
+  margin: 0 16px 12px; padding: 13px 14px;
+  border: 1px solid var(--primary-ring); border-radius: 10px;
+  background: var(--primary-light);
+}
+.update-banner .ub-icon {
+  width: 30px; height: 30px; border-radius: 8px; flex-shrink: 0; margin-top: 1px;
+  background: var(--primary); color: #fff; display: grid; place-items: center;
+}
+.update-banner .ub-icon svg { width: 16px; height: 16px; }
+.update-banner .ub-body { flex: 1; min-width: 0; }
+.update-banner .ub-head { font-size: 14px; font-weight: 600; color: var(--text); }
+.update-banner .ub-head .ub-cur { color: var(--text-muted); font-weight: 400; }
+.update-banner .ub-chips { display: flex; flex-wrap: wrap; gap: 6px; margin: 9px 0 2px; }
+.update-banner .ub-chip {
+  font-size: 11.5px; color: var(--primary); background: var(--bg-surface);
+  border: 1px solid var(--primary-ring); border-radius: 999px; padding: 3px 9px; white-space: nowrap;
+}
+.update-banner .ub-actions { display: flex; align-items: center; gap: 10px; margin-top: 12px; flex-wrap: wrap; }
+.update-banner .ub-btn {
+  font: inherit; font-size: 12.5px; font-weight: 600; border-radius: 7px; cursor: pointer;
+  padding: 7px 13px; border: 1px solid transparent; display: inline-flex; align-items: center; gap: 6px;
+}
+.update-banner .ub-btn svg { width: 13px; height: 13px; }
+.update-banner .ub-primary { background: var(--primary); color: #fff; }
+.update-banner .ub-primary:hover { background: var(--primary-hover); }
+.update-banner .ub-link { background: none; color: var(--primary); text-decoration: none; padding: 7px 4px; }
+.update-banner .ub-link:hover { text-decoration: underline; }
+.update-banner .ub-dismiss {
+  margin-left: auto; background: none; border: 0; color: var(--text-muted);
+  cursor: pointer; font-size: 16px; line-height: 1; padding: 2px 4px; align-self: flex-start;
+}
+.update-banner .ub-dismiss:hover { color: var(--text); }
+.update-banner .ub-cmd {
+  margin-top: 11px; display: flex; align-items: center; gap: 10px;
+  background: var(--bg-input); border: 1px solid var(--border); border-radius: 8px; padding: 9px 11px;
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 12px; color: var(--text-secondary);
+}
+.update-banner .ub-cmd code { flex: 1; overflow-x: auto; white-space: nowrap; }
+.update-banner .ub-copy {
+  font: inherit; font-size: 11px; color: var(--primary); background: none;
+  border: 1px solid var(--border); border-radius: 6px; padding: 4px 9px; cursor: pointer; flex-shrink: 0;
+}
+.update-banner .ub-copy:hover { border-color: var(--primary-ring); }
 .version-row-deleted:hover td { background: var(--danger-light); filter: brightness(0.97); }
 
 .version-badge-latest {


### PR DESCRIPTION
## Banner redesign
Replaces the passive update banner (a line of version numbers + a faint "View changelog" text link) with a value-forward, more clickable version:
- **Highlight chips** for the cumulative user-facing wins (direct uploads any size, instant million-object folders, per-user S3-key access, faster crawling) — because v3.5.0's own headline (telemetry) is operator-facing, the banner sells what users actually feel.
- A filled **"Update now"** button (reads as a button, unlike the old text link) that reveals the **copy-ready upgrade command**.
- **"See what's new"** → the latest release notes (not a bare releases list).
- Themed entirely via existing CSS vars, so it respects light/dark and a custom `PRIMARY_COLOR`. Still dismissible and login-gated.

## Version-compare fix
The update check compared versions **lexically** — `"3.10.0" > "3.9.0"` is `false` — so the banner would have **silently stopped firing at 3.10**. Added `_version_gt()` (numeric, dotted-segment compare, tolerates `v` prefix / non-numeric parts) and used it in both `/api/version` and the telemetry `update_available` field. Verified across the 3.9→3.10 boundary and equal/older cases.

The highlight chips live in one constant (`UPDATE_HIGHLIGHTS` in App.jsx) to refresh per release.