### PR TITLE
feat: activation / time-to-first-search (measurement + index-ready UX)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2394,6 +2394,41 @@ def _epoch_to_iso(e: float) -> str:
     return datetime.fromtimestamp(e, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+# ── Activation milestones — recorded at request time, idempotent, fail-safe ──
+# Anonymous, aggregate-only (a timestamp / boolean per instance), routed through the
+# existing instance_meta + telemetry path. Used to measure time-to-first-search and
+# whether the activation funnel (search / dashboard) is reached. Never raises into a request.
+_recorded_milestones: set = set()
+
+
+def _record_milestone_once(key: str):
+    """Stamp `key` with the current time the first time it occurs. The in-memory guard keeps
+    it to one DB hit per process; the _meta_get check keeps it idempotent across restarts."""
+    if key in _recorded_milestones:
+        return
+    try:
+        if not _meta_get(key):
+            _meta_set(key, _iso_now())
+        _recorded_milestones.add(key)
+    except Exception:
+        pass
+
+
+def _record_first_search(returned_results: bool):
+    """Activation event: first search *served* (regardless of hit count). Also records whether
+    that first search returned any results — a free diagnostic for the index-not-ready race
+    (searched-but-zero-results before the crawl finished)."""
+    if "first_search_at" in _recorded_milestones:
+        return
+    try:
+        if not _meta_get("first_search_at"):
+            _meta_set("first_search_at", _iso_now())
+            _meta_set("first_search_returned_results", "1" if returned_results else "0")
+        _recorded_milestones.add("first_search_at")
+    except Exception:
+        pass
+
+
 def _sqlts_to_iso(s):
     """SQLite CURRENT_TIMESTAMP ('YYYY-MM-DD HH:MM:SS', UTC) -> ISO-8601 Z. None-safe."""
     if not s:
@@ -2582,6 +2617,11 @@ def _collect_telemetry() -> dict:
         _meta_set("first_object_at", _iso_now())
     first_bucket_at = _meta_get("first_bucket_at")
     first_object_at = _meta_get("first_object_at")
+    # Activation funnel (recorded at request time by _record_first_search / _record_milestone_once)
+    first_search_at = _meta_get("first_search_at")
+    first_dashboard_open_at = _meta_get("first_dashboard_open_at")
+    _fsr = _meta_get("first_search_returned_results")
+    first_search_returned_results = None if _fsr is None else (_fsr == "1")
 
     # last_write_at: max(in-memory since boot, persisted) so it survives restarts
     last_write_at = _meta_get("last_write_at")
@@ -2664,6 +2704,10 @@ def _collect_telemetry() -> dict:
         "first_object_at": first_object_at,
         "first_api_token_at": first_token_at,
         "first_mcp_connect_at": first_mcp_at,
+        # ── v2: activation funnel (time-to-first-search + dashboard reach) ──
+        "first_search_at": first_search_at,
+        "first_dashboard_open_at": first_dashboard_open_at,
+        "first_search_returned_results": first_search_returned_results,
         # ── v2: Tier 3 engagement + adoption ──
         "active_buckets_24h": min(_ci(active_buckets_24h, 10000), bucket_count),
         "last_write_at": last_write_at,
@@ -4320,6 +4364,7 @@ def search_objects(bucket: str, request: Request, q: str = Query(..., min_length
         raise HTTPException(503, "Index not ready — crawl in progress")
     with _get_db(bucket) as db:
         rows = _search_fts(db, q, prefix, limit)
+    _record_first_search(len(rows) > 0)  # activation milestone (fail-safe, idempotent)
     return {"results": [dict(r) for r in rows], "count": len(rows), "query": q}
 
 
@@ -4380,6 +4425,7 @@ def folder_size(bucket: str, prefix: str = "", user: dict = Depends(get_current_
 
 @app.get("/api/buckets/{bucket}/storage-breakdown")
 def storage_breakdown(bucket: str, prefix: str = "", user: dict = Depends(get_current_user)):
+    _record_milestone_once("first_dashboard_open_at")  # activation milestone (fail-safe, idempotent)
     if not _is_index_ready(bucket):
         raise HTTPException(503, "Index not ready")
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -4403,19 +4403,25 @@ def _search_fts(db, q, prefix, limit):
         try:
             fts_query = '"' + q.replace('"', '""') + '"'
             if prefix:
-                return db.execute("""
+                rows = db.execute("""
                     SELECT o.key, o.size, o.last_modified FROM objects o
                     JOIN objects_fts f ON o.rowid = f.rowid
                     WHERE objects_fts MATCH ? AND o.key LIKE ?
                     ORDER BY o.key LIMIT ?
                 """, (fts_query, prefix + "%", limit)).fetchall()
             else:
-                return db.execute("""
+                rows = db.execute("""
                     SELECT o.key, o.size, o.last_modified FROM objects o
                     JOIN objects_fts f ON o.rowid = f.rowid
                     WHERE objects_fts MATCH ?
                     ORDER BY o.key LIMIT ?
                 """, (fts_query, limit)).fetchall()
+            if rows:
+                return rows
+            # FTS returned nothing: either a genuine no-match, or — critically — the FTS index is
+            # still rebuilding right after a crawl (the crawl reports "complete" before the async
+            # rebuild finishes). Fall through to LIKE so the user's first search after indexing
+            # returns real results instead of a dead-end "no objects found".
         except Exception:
             pass  # FTS table missing or query error — fall back to LIKE
     # Fallback: LIKE pattern matching (works for all query lengths and old DBs)

--- a/backend/main.py
+++ b/backend/main.py
@@ -814,7 +814,7 @@ def _init_db(bucket, endpoint_id=None):
     conn = sqlite3.connect(_db_path(bucket, endpoint_id), timeout=30)
     conn.execute("PRAGMA page_size = 8192")          # larger pages → shallower B-trees (new DBs only)
     conn.execute("PRAGMA journal_mode=WAL")
-    conn.execute("PRAGMA busy_timeout = 5000")       # wait up to 5s for locks
+    conn.execute("PRAGMA busy_timeout = 30000")      # wait up to 30s for locks (heavy parallel crawl contends)
     conn.execute("PRAGMA synchronous=NORMAL")
     conn.execute("PRAGMA cache_size = -64000")       # 64MB page cache (default 2MB)
     conn.execute("PRAGMA mmap_size = 268435456")     # 256MB memory-mapped I/O
@@ -966,7 +966,7 @@ def _init_db(bucket, endpoint_id=None):
 def _get_db(bucket, endpoint_id=None):
     conn = sqlite3.connect(_db_path(bucket, endpoint_id), timeout=30)
     conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA busy_timeout = 5000")       # wait up to 5s for locks
+    conn.execute("PRAGMA busy_timeout = 30000")      # wait up to 30s for locks (heavy parallel crawl contends)
     conn.execute("PRAGMA synchronous = NORMAL")      # safe under WAL; fewer fsyncs on the crawl write path
     conn.execute("PRAGMA cache_size = -64000")       # 64MB page cache (default 2MB)
     conn.execute("PRAGMA mmap_size = 268435456")     # 256MB memory-mapped I/O
@@ -1523,13 +1523,41 @@ def _run_crawl(bucket, endpoint_id=None):
                     db.execute("UPDATE crawl_status SET total_objects=?, total_size=? WHERE id=1", (row[0], row[1]))
                     db.commit()
 
-        # Remove stale keys: anything with crawl_gen > 0 but older than current gen
-        with _get_db(bucket, eid) as db:
-            stale_count = db.execute("SELECT COUNT(*) FROM objects WHERE crawl_gen > 0 AND crawl_gen < ?", (crawl_gen,)).fetchone()[0]
-            if stale_count > 0:
-                db.execute("DELETE FROM objects WHERE crawl_gen > 0 AND crawl_gen < ?", (crawl_gen,))
+        # Retry any prefixes that failed — typically transient SQLite write contention under heavy
+        # parallelism ("database is locked"). Re-crawl them sequentially (no contention) so a transient
+        # failure never silently drops data. Only runs when something failed, so the normal path is unchanged.
+        if failed_prefixes:
+            retry = list(failed_prefixes)
+            failed_prefixes = []
+            log.info("[%s:%s] Retrying %d failed prefix(es) sequentially", eid, bucket, len(retry))
+            for p in retry:
+                try:
+                    count = _crawl_prefix(bucket, p, endpoint_id=eid,
+                                          batch_callback=_make_prefix_batch_cb(bucket, eid, crawl_gen))
+                    total_new += count
+                    log.info("[%s:%s] Prefix '%s' (retry): %s objects", eid, bucket, p[:40], f"{count:,}")
+                except Exception as e:
+                    failed_prefixes.append(p)
+                    log.warning("[%s:%s] Prefix '%s' failed on retry: %s: %s", eid, bucket, p[:40], type(e).__name__, e)
+            with _get_db(bucket, eid) as db:
+                row = db.execute("SELECT COUNT(*), COALESCE(SUM(size),0) FROM objects").fetchone()
+                db.execute("UPDATE crawl_status SET total_objects=?, total_size=? WHERE id=1", (row[0], row[1]))
                 db.commit()
-                log.info("[%s:%s] Removed %s stale keys", eid, bucket, f"{stale_count:,}")
+
+        # Remove stale keys (crawl_gen older than this gen) — but ONLY if every prefix crawled
+        # successfully. A still-failed prefix's keys carry the old gen; pruning them would turn a
+        # transient list failure into real data loss. Skip the prune this cycle to keep the index intact.
+        stale_count = 0
+        if not failed_prefixes:
+            with _get_db(bucket, eid) as db:
+                stale_count = db.execute("SELECT COUNT(*) FROM objects WHERE crawl_gen > 0 AND crawl_gen < ?", (crawl_gen,)).fetchone()[0]
+                if stale_count > 0:
+                    db.execute("DELETE FROM objects WHERE crawl_gen > 0 AND crawl_gen < ?", (crawl_gen,))
+                    db.commit()
+                    log.info("[%s:%s] Removed %s stale keys", eid, bucket, f"{stale_count:,}")
+        else:
+            log.warning("[%s:%s] Skipping stale-key prune — %d prefix(es) still failed after retry; index kept intact",
+                        eid, bucket, len(failed_prefixes))
 
         # Final counts
         with _get_db(bucket, eid) as db:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -112,6 +112,8 @@ function MainApp() {
   const [done, setDone] = useState(false);
   const [indexed, setIndexed] = useState(false);
   const [indexing, setIndexing] = useState(false); // current bucket's first crawl in progress (crawl-status === "crawling")
+  const [indexCount, setIndexCount] = useState(0);  // objects indexed so far (drives the search-hint bar)
+  const [hideSearchHint, setHideSearchHint] = useState(() => !!localStorage.getItem("sairo-search-hint-dismissed"));
   const [selected, setSelected] = useState(new Set());
   const [selectedFolders, setSelectedFolders] = useState(new Set());
   const [showUpload, setShowUpload] = useState(false);
@@ -248,7 +250,7 @@ function MainApp() {
     setLoading(true);
     setDone(false);
     setIndexed(false);
-    getCrawlStatus(b).then((s) => setIndexing(s?.status === "crawling")).catch(() => {});
+    getCrawlStatus(b).then((s) => { setIndexing(s?.status === "crawling"); setIndexCount(s?.total_objects || 0); }).catch(() => {});
     crawlFpRef.current = null;  // re-establish fingerprint for this view's background refresh
 
     let firstPage = true;
@@ -291,6 +293,7 @@ function MainApp() {
     // every 30s — the previous behavior re-streamed the whole listing each tick.
     getCrawlStatus(b).then((status) => {
       setIndexing(status?.status === "crawling");
+      setIndexCount(status?.total_objects || 0);
       const fp = status ? `${status.total_objects}:${status.last_crawl_end}:${status.status}` : null;
       if (fp && crawlFpRef.current && fp === crawlFpRef.current) return;  // nothing changed
       crawlFpRef.current = fp;
@@ -737,6 +740,25 @@ function MainApp() {
       <div className={`progress-bar ${loading ? "progress-active" : ""} ${!loading && done ? "progress-done" : ""}`}>
         <div className="progress-bar-inner" />
       </div>
+
+      {!showDeleted && (indexing || (indexed && !hideSearchHint)) && (
+        <div className={`search-hint-bar ${indexing ? "shb-indexing" : ""}`}>
+          {indexing ? (
+            <span className="shb-text">
+              <span className="spinner shb-spinner" />
+              Indexing your bucket{indexCount > 0 ? ` — ${indexCount.toLocaleString()} objects so far` : "…"} — search will be ready in a moment.
+            </span>
+          ) : (
+            <>
+              <span className="shb-text">&#128269;&nbsp; Press <kbd>/</kbd> to instantly search{indexCount > 0 ? ` across ${indexCount.toLocaleString()} objects` : " this bucket"}.</span>
+              <div className="shb-actions">
+                <button className="shb-search" onClick={() => setShowSearch(true)}>Search now</button>
+                <button className="shb-dismiss" aria-label="Dismiss search tip" onClick={() => { setHideSearchHint(true); localStorage.setItem("sairo-search-hint-dismissed", "1"); }}>&times;</button>
+              </div>
+            </>
+          )}
+        </div>
+      )}
 
       <ObjectTable
         bucket={bucket}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -114,6 +114,7 @@ function MainApp() {
   const [indexing, setIndexing] = useState(false); // current bucket's first crawl in progress (crawl-status === "crawling")
   const [indexCount, setIndexCount] = useState(0);  // objects indexed so far (drives the search-hint bar)
   const [hideSearchHint, setHideSearchHint] = useState(() => !!localStorage.getItem("sairo-search-hint-dismissed"));
+  const [highlightKey, setHighlightKey] = useState(null); // file to scroll-to + highlight after "reveal in folder"
   const [selected, setSelected] = useState(new Set());
   const [selectedFolders, setSelectedFolders] = useState(new Set());
   const [showUpload, setShowUpload] = useState(false);
@@ -215,7 +216,8 @@ function MainApp() {
     setCurrentEndpoint("default");
   }, []);
 
-  const navigatePrefix = useCallback((pfx) => {
+  const navigatePrefix = useCallback((pfx, hl) => {
+    setHighlightKey(hl || null);  // optional: highlight this file once the folder loads
     setHash(bucket, pfx, endpointId);
     const current = parseHash();
     if (current.prefix === pfx && prefix === pfx) load(bucket, pfx);
@@ -781,6 +783,7 @@ function MainApp() {
         indexed={indexed}
         indexing={indexing}
         onSearch={() => setShowSearch(true)}
+        highlightKey={highlightKey}
         prefix={prefix}
         isAdmin={canWrite}
         showDeleted={showDeleted}
@@ -828,7 +831,7 @@ function MainApp() {
         <BucketSettings bucket={bucket} onClose={() => setShowSettings(false)} role={user.role} />
       )}
       {showSearch && (
-        <SearchBar bucket={bucket} prefix={prefix} onClose={() => setShowSearch(false)} onNavigate={navigatePrefix} onFileInfo={setInfoKey} />
+        <SearchBar bucket={bucket} prefix={prefix} onClose={() => setShowSearch(false)} onNavigate={navigatePrefix} onFileInfo={setInfoKey} onFilePreview={setPreviewFile} />
       )}
       {showAuditLog && <AuditLog onClose={() => setShowAuditLog(false)} />}
       {dashboardBucket && <StorageDashboard bucket={dashboardBucket} onClose={() => setDashboardBucket(null)} onNavigate={(pfx) => { setDashboardBucket(null); navigatePrefix(pfx); }} />}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -111,6 +111,7 @@ function MainApp() {
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
   const [indexed, setIndexed] = useState(false);
+  const [indexing, setIndexing] = useState(false); // current bucket's first crawl in progress (crawl-status === "crawling")
   const [selected, setSelected] = useState(new Set());
   const [selectedFolders, setSelectedFolders] = useState(new Set());
   const [showUpload, setShowUpload] = useState(false);
@@ -247,6 +248,7 @@ function MainApp() {
     setLoading(true);
     setDone(false);
     setIndexed(false);
+    getCrawlStatus(b).then((s) => setIndexing(s?.status === "crawling")).catch(() => {});
     crawlFpRef.current = null;  // re-establish fingerprint for this view's background refresh
 
     let firstPage = true;
@@ -288,6 +290,7 @@ function MainApp() {
     // actually changed since the last load. Avoids re-downloading an unchanged folder
     // every 30s — the previous behavior re-streamed the whole listing each tick.
     getCrawlStatus(b).then((status) => {
+      setIndexing(status?.status === "crawling");
       const fp = status ? `${status.total_objects}:${status.last_crawl_end}:${status.status}` : null;
       if (fp && crawlFpRef.current && fp === crawlFpRef.current) return;  // nothing changed
       crawlFpRef.current = fp;
@@ -754,6 +757,8 @@ function MainApp() {
         sortAsc={sortAsc}
         onSort={handleSort}
         indexed={indexed}
+        indexing={indexing}
+        onSearch={() => setShowSearch(true)}
         prefix={prefix}
         isAdmin={canWrite}
         showDeleted={showDeleted}

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -544,11 +544,14 @@ function MainApp() {
   useEffect(() => {
     const handler = (e) => {
       if (e.target.tagName === "INPUT" || e.target.tagName === "TEXTAREA") return;
-      // Escape closes modals first before navigating
-      if (e.key === "Escape" && dashboardBucket) {
-        e.preventDefault();
-        setDashboardBucket(null);
-        return;
+      // Escape closes the topmost open modal first — and must NOT also navigate the folder
+      // underneath it (that competition is what made Esc feel like it needed several presses).
+      if (e.key === "Escape") {
+        if (dashboardBucket) { e.preventDefault(); setDashboardBucket(null); return; }
+        if (previewFile)     { e.preventDefault(); setPreviewFile(null); return; }
+        if (infoKey)         { e.preventDefault(); setInfoKey(null); return; }
+        if (showHelp)        { e.preventDefault(); setShowHelp(false); return; }
+        if (showSearch)      { e.preventDefault(); setShowSearch(false); return; }
       }
       if ((e.key === "Backspace" || e.key === "Escape") && bucket) {
         e.preventDefault();

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -578,7 +578,7 @@ function MainApp() {
     };
     window.addEventListener("keydown", handler);
     return () => window.removeEventListener("keydown", handler);
-  }, [bucket, prefix, navigatePrefix, goHome, dashboardBucket]);
+  }, [bucket, prefix, navigatePrefix, goHome, dashboardBucket, previewFile, infoKey, showHelp, showSearch]);
 
   // Loading auth state
   if (user === undefined) {

--- a/frontend/src/components/CrawlStatus.jsx
+++ b/frontend/src/components/CrawlStatus.jsx
@@ -4,6 +4,7 @@ import { getCrawlStatus, triggerCrawl, formatSize } from "../api";
 export default function CrawlStatus({ bucket }) {
   const [status, setStatus] = useState(null);
   const [expanded, setExpanded] = useState(false);
+  const [starting, setStarting] = useState(false);
 
   const fetchStatus = async () => {
     try {
@@ -25,8 +26,21 @@ export default function CrawlStatus({ bucket }) {
   const isError = status.status?.startsWith("error");
 
   const handleRecrawl = async () => {
-    await triggerCrawl(bucket);
-    fetchStatus();
+    if (starting || isCrawling) return;       // guard against the double-click
+    setStarting(true);
+    try {
+      await triggerCrawl(bucket);
+      // Optimistically reflect "crawling" right away — the crawl_status table lags a beat
+      // behind the trigger, which is what made the first click look like a no-op.
+      setStatus((s) => ({ ...(s || {}), status: "crawling" }));
+      // Poll quickly for a few seconds to sync the real status, then the 5s interval takes over.
+      for (let i = 0; i < 6; i++) {
+        await new Promise((r) => setTimeout(r, 800));
+        await fetchStatus();
+      }
+    } finally {
+      setStarting(false);
+    }
   };
 
   return (
@@ -64,8 +78,8 @@ export default function CrawlStatus({ bucket }) {
               <span>{new Date(status.last_crawl_end).toLocaleString()}</span>
             </div>
           )}
-          <button onClick={handleRecrawl} disabled={isCrawling} className="btn-primary" style={{ marginTop: 8, width: "100%" }}>
-            {isCrawling ? "Crawling..." : "Re-index Now"}
+          <button onClick={handleRecrawl} disabled={isCrawling || starting} className="btn-primary" style={{ marginTop: 8, width: "100%" }}>
+            {starting ? "Starting…" : isCrawling ? "Indexing…" : "Re-index Now"}
           </button>
         </div>
       )}

--- a/frontend/src/components/FilePreview.jsx
+++ b/frontend/src/components/FilePreview.jsx
@@ -140,6 +140,13 @@ export default function FilePreview({ bucket, fileKey, size, onClose }) {
   const ext = getExt(fileKey);
   const filename = fileKey.split("/").pop();
 
+  // Esc closes the preview
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
   useEffect(() => {
     setLoading(true);
     setError(null);

--- a/frontend/src/components/ObjectTable.jsx
+++ b/frontend/src/components/ObjectTable.jsx
@@ -326,7 +326,8 @@ export default function ObjectTable({
                         onChange={() => toggleOne(file.key)}
                       />
                     </div>
-                    <div className="td col-name" title={file.key}>
+                    <div className="td col-name col-name-clickable" title={file.key}
+                      onClick={() => { if (canPreview(file.name) && onFilePreview) onFilePreview({ key: file.key, size: file.size }); else onFileInfo(file.key); }}>
                       {React.createElement(getFileIcon(file.name), { size: 16, className: "file-icon" })}
                       {file.name}
                     </div>

--- a/frontend/src/components/ObjectTable.jsx
+++ b/frontend/src/components/ObjectTable.jsx
@@ -65,6 +65,8 @@ export default function ObjectTable({
   sortAsc,
   onSort,
   indexed,
+  indexing,
+  onSearch,
   prefix,
   isAdmin,
   showDeleted,
@@ -216,7 +218,19 @@ export default function ObjectTable({
       </div>
 
       <div ref={parentRef} className="table-scroll-area">
-        {isEmpty && (
+        {isEmpty && indexing && !filter && (
+          <div className="empty-state">
+            <div className="empty-state-icon"><div className="spinner" /></div>
+            <h3 className="empty-state-title">Indexing your bucket\u2026</h3>
+            <p className="empty-state-text">
+              Building a fast index of your objects \u2014 browsing and instant search will be ready in a moment.
+            </p>
+            {onSearch && (
+              <button className="btn-primary" style={{ marginTop: 12 }} onClick={onSearch}>&#128269; Try a search</button>
+            )}
+          </div>
+        )}
+        {isEmpty && !(indexing && !filter) && (
           <div className="empty-state">
             <div className="empty-state-icon">{filter ? "\uD83D\uDD0D" : "\uD83D\uDCC2"}</div>
             <h3 className="empty-state-title">{filter ? "No matching items" : "This folder is empty"}</h3>

--- a/frontend/src/components/ObjectTable.jsx
+++ b/frontend/src/components/ObjectTable.jsx
@@ -9,7 +9,7 @@ import {
 
 const PREVIEW_EXTS = new Set(["jpg","jpeg","png","gif","svg","webp","ico","bmp","txt","log","out","err","md","json","csv","xml","yaml","yml","js","jsx","ts","tsx","py","sql","sh","bash","conf","cfg","ini","html","css","toml","pdf","parquet","orc","avro"]);
 
-function canPreview(name) {
+export function canPreview(name) {
   const dot = name.lastIndexOf(".");
   return dot >= 0 && PREVIEW_EXTS.has(name.substring(dot + 1).toLowerCase());
 }
@@ -67,6 +67,7 @@ export default function ObjectTable({
   indexed,
   indexing,
   onSearch,
+  highlightKey,
   prefix,
   isAdmin,
   showDeleted,
@@ -159,6 +160,22 @@ export default function ObjectTable({
     estimateSize: () => rowHeight,
     overscan: 20,
   });
+
+  // "Reveal in folder" from search: scroll to + briefly highlight the target file.
+  // Consume each highlightKey once so a background refresh doesn't re-scroll the user.
+  const [highlightedKey, setHighlightedKey] = useState(null);
+  const consumedHlRef = useRef(null);
+  useEffect(() => {
+    if (!highlightKey) { consumedHlRef.current = null; return; }
+    if (highlightKey === consumedHlRef.current) return;
+    const idx = rows.findIndex((row) => row.type === "file" && row.data.key === highlightKey);
+    if (idx < 0) return; // target not in this folder's rows yet — wait for them to load
+    consumedHlRef.current = highlightKey;
+    rowVirtualizer.scrollToIndex(idx, { align: "center" });
+    setHighlightedKey(highlightKey);
+    const t = setTimeout(() => setHighlightedKey(null), 3000);
+    return () => clearTimeout(t);
+  }, [highlightKey, rows]);
 
   const allFileKeys = sortedFiles.map((f) => f.key);
   const allFolderPrefixes = filteredFolders.map((f) => f.prefix);
@@ -292,7 +309,7 @@ export default function ObjectTable({
                 return (
                   <div
                     key={file.key}
-                    className={`table-row ${selected.has(file.key) ? "row-selected" : ""}`}
+                    className={`table-row ${selected.has(file.key) ? "row-selected" : ""} ${file.key === highlightedKey ? "row-highlight" : ""}`}
                     style={{
                       position: "absolute",
                       top: 0,

--- a/frontend/src/components/SearchBar.jsx
+++ b/frontend/src/components/SearchBar.jsx
@@ -79,12 +79,12 @@ export default function SearchBar({ bucket, prefix, onClose, onNavigate, onFileI
     if (el) el.scrollIntoView({ block: "nearest" });
   };
 
-  // Click a result → open it directly (preview if previewable, else its info panel).
+  // Click a result → previewable files open the preview; non-previewable files reveal-in-folder
+  // (scroll to + highlight the file), which is more useful than dumping the user into raw metadata.
   const openResult = (r) => {
     const name = r.key.split("/").pop();
-    onClose();
-    if (onFilePreview && canPreview(name)) onFilePreview({ key: r.key, size: r.size });
-    else onFileInfo(r.key);
+    if (onFilePreview && canPreview(name)) { onClose(); onFilePreview({ key: r.key, size: r.size }); }
+    else revealInFolder(r.key);
   };
 
   // Click the path → jump to the containing folder AND highlight the file there.

--- a/frontend/src/components/SearchBar.jsx
+++ b/frontend/src/components/SearchBar.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef, useEffect } from "react";
 import { searchObjects, getCrawlStatus, formatSize, formatDate, downloadUrl } from "../api";
+import { canPreview } from "./ObjectTable";
 
 function highlightMatch(text, query) {
   if (!query || query.length < 2) return text;
@@ -15,7 +16,7 @@ function highlightMatch(text, query) {
   );
 }
 
-export default function SearchBar({ bucket, prefix, onClose, onNavigate, onFileInfo }) {
+export default function SearchBar({ bucket, prefix, onClose, onNavigate, onFileInfo, onFilePreview }) {
   const [query, setQuery] = useState("");
   const [results, setResults] = useState(null);
   const [loading, setLoading] = useState(false);
@@ -78,11 +79,20 @@ export default function SearchBar({ bucket, prefix, onClose, onNavigate, onFileI
     if (el) el.scrollIntoView({ block: "nearest" });
   };
 
-  const navigateToFolder = (key) => {
+  // Click a result → open it directly (preview if previewable, else its info panel).
+  const openResult = (r) => {
+    const name = r.key.split("/").pop();
+    onClose();
+    if (onFilePreview && canPreview(name)) onFilePreview({ key: r.key, size: r.size });
+    else onFileInfo(r.key);
+  };
+
+  // Click the path → jump to the containing folder AND highlight the file there.
+  const revealInFolder = (key) => {
     const idx = key.lastIndexOf("/");
     const folder = idx >= 0 ? key.substring(0, idx + 1) : "";
     onClose();
-    onNavigate(folder);
+    onNavigate(folder, key);
   };
 
   const handleKeyDown = (e) => {
@@ -111,9 +121,12 @@ export default function SearchBar({ bucket, prefix, onClose, onNavigate, onFileI
       if (e.metaKey || e.ctrlKey) {
         // Cmd/Ctrl+Enter: download
         window.location.href = downloadUrl(bucket, r.key);
+      } else if (e.shiftKey) {
+        // Shift+Enter: reveal in its folder
+        revealInFolder(r.key);
       } else {
-        // Enter: navigate to containing folder
-        navigateToFolder(r.key);
+        // Enter: open (preview / info)
+        openResult(r);
       }
     }
   };
@@ -166,18 +179,21 @@ export default function SearchBar({ bucket, prefix, onClose, onNavigate, onFileI
                         key={r.key}
                         className={`search-item ${i === selectedIdx ? "search-item-active" : ""}`}
                         onMouseEnter={() => setSelectedIdx(i)}
+                        onClick={() => openResult(r)}
+                        style={{ cursor: "pointer" }}
+                        title="Open (preview) · Shift+Enter to reveal in folder"
                       >
                         <div className="search-item-main">
-                          <span className="search-item-name" title={r.key}>{highlightMatch(name, query)}</span>
+                          <span className="search-item-name">{highlightMatch(name, query)}</span>
                           <span className="search-item-size">{formatSize(r.size)}</span>
                         </div>
                         <div className="search-item-path">
-                          <a href="#" onClick={(e) => { e.preventDefault(); navigateToFolder(r.key); }}>{path || "/"}</a>
+                          <a href="#" title="Reveal in folder" onClick={(e) => { e.preventDefault(); e.stopPropagation(); revealInFolder(r.key); }}>{path || "/"}</a>
                           <span className="search-item-date">{formatDate(r.last_modified)}</span>
                         </div>
                         <div className="search-item-actions">
-                          <a href={downloadUrl(bucket, r.key)} className="btn-small btn-xs">&#8595;</a>
-                          <button className="btn-small btn-xs btn-info" onClick={() => { onClose(); onFileInfo(r.key); }}>i</button>
+                          <a href={downloadUrl(bucket, r.key)} title="Download" className="btn-small btn-xs" onClick={(e) => e.stopPropagation()}>&#8595;</a>
+                          <button className="btn-small btn-xs btn-info" title="File info" onClick={(e) => { e.stopPropagation(); onClose(); onFileInfo(r.key); }}>i</button>
                         </div>
                       </li>
                     );

--- a/frontend/src/components/SearchBar.jsx
+++ b/frontend/src/components/SearchBar.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from "react";
-import { searchObjects, formatSize, formatDate, downloadUrl } from "../api";
+import { searchObjects, getCrawlStatus, formatSize, formatDate, downloadUrl } from "../api";
 
 function highlightMatch(text, query) {
   if (!query || query.length < 2) return text;
@@ -20,9 +20,11 @@ export default function SearchBar({ bucket, prefix, onClose, onNavigate, onFileI
   const [results, setResults] = useState(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
+  const [indexing, setIndexing] = useState(null); // {objects} while the index is still building, else null
   const [selectedIdx, setSelectedIdx] = useState(-1);
   const inputRef = useRef();
   const timerRef = useRef();
+  const retryRef = useRef();
   const listRef = useRef();
 
   useEffect(() => {
@@ -32,23 +34,43 @@ export default function SearchBar({ bucket, prefix, onClose, onNavigate, onFileI
   useEffect(() => {
     if (!query || query.length < 2) {
       setResults(null);
+      setIndexing(null);
       return;
     }
     clearTimeout(timerRef.current);
-    timerRef.current = setTimeout(async () => {
+    clearTimeout(retryRef.current);
+    let cancelled = false;
+    const run = async () => {
       setLoading(true);
       setError(null);
       try {
         const data = await searchObjects(bucket, query, prefix);
+        if (cancelled) return;
         setResults(data);
+        setIndexing(null);
         setSelectedIdx(-1);
       } catch (e) {
-        setError(e.message.includes("503") ? "Index not ready — crawl in progress" : e.message);
+        if (cancelled) return;
+        if (e.message.includes("503")) {
+          // Index still building — reassure + show progress, and re-run automatically
+          // once the crawl is ready (turns the index-not-ready race into a smooth wait).
+          setResults(null);
+          try {
+            const s = await getCrawlStatus(bucket);
+            if (!cancelled) setIndexing({ objects: s.total_objects || 0 });
+          } catch {
+            if (!cancelled) setIndexing({ objects: 0 });
+          }
+          retryRef.current = setTimeout(() => { if (!cancelled) run(); }, 2500);
+        } else {
+          setError(e.message);
+        }
       } finally {
-        setLoading(false);
+        if (!cancelled) setLoading(false);
       }
-    }, 300);
-    return () => clearTimeout(timerRef.current);
+    };
+    timerRef.current = setTimeout(run, 300);
+    return () => { cancelled = true; clearTimeout(timerRef.current); clearTimeout(retryRef.current); };
   }, [query, prefix, bucket]);
 
   const scrollToItem = (idx) => {
@@ -115,8 +137,17 @@ export default function SearchBar({ bucket, prefix, onClose, onNavigate, onFileI
         </div>
 
         <div className="search-results">
-          {loading && (
+          {loading && !indexing && (
             <div className="search-loading"><div className="spinner" /> Searching...</div>
+          )}
+          {indexing && (
+            <div className="search-indexing">
+              <div className="spinner" />
+              <div className="search-indexing-text">
+                Indexing your bucket{indexing.objects > 0 ? ` — ${indexing.objects.toLocaleString()} objects so far` : "…"}
+                <div className="search-indexing-sub">Hang tight — your search will run automatically the moment the index is ready.</div>
+              </div>
+            </div>
           )}
           {error && <div className="search-error">{error}</div>}
           {results && !loading && (

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -492,6 +492,8 @@ button.btn-danger:disabled { background: var(--bg-surface); }
 @keyframes rowHighlightPulse { 0% { background: var(--primary-light); } 100% { background: transparent; } }
 .table-row.row-highlight { animation: rowHighlightPulse 3s ease-out; box-shadow: inset 3px 0 0 var(--primary); }
 @media (prefers-reduced-motion: reduce) { .table-row.row-highlight { animation: none; background: var(--primary-light); } }
+.col-name-clickable { cursor: pointer; }
+.col-name-clickable:hover { color: var(--primary); }
 .table-row.row-folder:hover { background: var(--primary-light); }
 
 .table-row .td {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1160,6 +1160,28 @@ button.btn-danger:disabled { background: var(--bg-surface); }
   font-size: 13px;
 }
 
+.search-indexing {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 18px 16px;
+  margin: 4px 0;
+  border: 1px solid var(--primary-ring);
+  border-radius: 8px;
+  background: var(--primary-light);
+}
+.search-indexing-text {
+  font-size: 13px;
+  color: var(--text);
+  font-weight: 500;
+}
+.search-indexing-sub {
+  font-size: 12px;
+  color: var(--text-muted);
+  font-weight: 400;
+  margin-top: 3px;
+}
+
 .search-count {
   font-size: 12px;
   color: var(--text-muted);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1160,6 +1160,33 @@ button.btn-danger:disabled { background: var(--bg-surface); }
   font-size: 13px;
 }
 
+/* First-run discoverability: ties index status + "press / to search" into one in-context bar */
+.search-hint-bar {
+  display: flex; align-items: center; justify-content: space-between; gap: 12px;
+  margin: 0 16px 10px; padding: 9px 14px;
+  border: 1px solid var(--primary-ring); border-radius: 8px;
+  background: var(--primary-light); font-size: 13px; color: var(--text);
+}
+.search-hint-bar.shb-indexing { color: var(--text-secondary); }
+.search-hint-bar .shb-text { display: inline-flex; align-items: center; gap: 8px; }
+.search-hint-bar kbd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: 11px;
+  background: var(--bg-surface); border: 1px solid var(--border);
+  border-radius: 4px; padding: 1px 6px; color: var(--text);
+}
+.search-hint-bar .shb-spinner { width: 14px; height: 14px; flex-shrink: 0; }
+.search-hint-bar .shb-actions { display: flex; align-items: center; gap: 8px; flex-shrink: 0; }
+.search-hint-bar .shb-search {
+  font: inherit; font-size: 12px; font-weight: 600; cursor: pointer;
+  background: var(--primary); color: #fff; border: 0; border-radius: 6px; padding: 5px 12px;
+}
+.search-hint-bar .shb-search:hover { background: var(--primary-hover); }
+.search-hint-bar .shb-dismiss {
+  background: none; border: 0; color: var(--text-muted); cursor: pointer;
+  font-size: 16px; line-height: 1; padding: 0 4px;
+}
+.search-hint-bar .shb-dismiss:hover { color: var(--text); }
+
 .search-indexing {
   display: flex;
   align-items: center;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -488,6 +488,10 @@ button.btn-danger:disabled { background: var(--bg-surface); }
 .table-row:hover { background: var(--bg-hover); }
 .table-row.row-selected { background: var(--bg-selected); }
 .table-row.row-folder { background: var(--bg-surface); }
+/* "Reveal in folder" highlight — a brief pulse + accent rail so the revealed file is obvious */
+@keyframes rowHighlightPulse { 0% { background: var(--primary-light); } 100% { background: transparent; } }
+.table-row.row-highlight { animation: rowHighlightPulse 3s ease-out; box-shadow: inset 3px 0 0 var(--primary); }
+@media (prefers-reduced-motion: reduce) { .table-row.row-highlight { animation: none; background: var(--primary-light); } }
 .table-row.row-folder:hover { background: var(--primary-light); }
 
 .table-row .td {

--- a/frontend/src/test/components.test.jsx
+++ b/frontend/src/test/components.test.jsx
@@ -507,7 +507,37 @@ describe("SearchBar keyboard navigation", () => {
     expect(items[2].classList.contains("search-item-active")).toBe(true);
   });
 
-  it("Enter navigates to folder of selected result", async () => {
+  it("Enter opens (previews) the selected result instead of navigating to its folder", async () => {
+    global.fetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve(mockSearchResults),
+    });
+
+    const onNavigate = vi.fn();
+    const onClose = vi.fn();
+    const onFilePreview = vi.fn();
+    const { default: SearchBar } = await import("../components/SearchBar");
+    render(
+      <SearchBar bucket="test" prefix="" onClose={onClose} onNavigate={onNavigate} onFileInfo={vi.fn()} onFilePreview={onFilePreview} />
+    );
+
+    const input = screen.getByPlaceholderText("Search test...");
+    fireEvent.change(input, { target: { value: "script" } });
+
+    await waitFor(() => {
+      expect(screen.getByText("3 results")).toBeInTheDocument();
+    });
+
+    // First result is src/script.py (previewable) — Enter opens the preview, not the folder.
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(onClose).toHaveBeenCalled();
+    expect(onFilePreview).toHaveBeenCalledWith({ key: "src/script.py", size: 1024 });
+    expect(onNavigate).not.toHaveBeenCalled();
+  });
+
+  it("Shift+Enter reveals the selected result in its folder (passing the file key for highlight)", async () => {
     global.fetch.mockResolvedValue({
       ok: true,
       json: () => Promise.resolve(mockSearchResults),
@@ -517,7 +547,7 @@ describe("SearchBar keyboard navigation", () => {
     const onClose = vi.fn();
     const { default: SearchBar } = await import("../components/SearchBar");
     render(
-      <SearchBar bucket="test" prefix="" onClose={onClose} onNavigate={onNavigate} onFileInfo={vi.fn()} />
+      <SearchBar bucket="test" prefix="" onClose={onClose} onNavigate={onNavigate} onFileInfo={vi.fn()} onFilePreview={vi.fn()} />
     );
 
     const input = screen.getByPlaceholderText("Search test...");
@@ -528,10 +558,10 @@ describe("SearchBar keyboard navigation", () => {
     });
 
     fireEvent.keyDown(input, { key: "ArrowDown" });
-    fireEvent.keyDown(input, { key: "Enter" });
+    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
 
     expect(onClose).toHaveBeenCalled();
-    expect(onNavigate).toHaveBeenCalledWith("src/");
+    expect(onNavigate).toHaveBeenCalledWith("src/", "src/script.py");
   });
 
   it("shows arrow key hint when results exist", async () => {


### PR DESCRIPTION
Implements the **activation ("aha") layer** from the product strategy (`chat_product.md` / `ROADMAP.md` Phase 0): the data verdict was *activation failure, not product failure* — 55% of active instances never reach value, and the leak is first-session time-to-first-search.

## What's in this PR (3 commits)

**1. Measurement — activation milestones** (`backend/main.py`)
Anonymous, aggregate, ≤4 KB, fail-safe milestones on the existing telemetry path:
- `first_search_at` — first search *served* (the activation event)
- `first_search_returned_results` — did that first search return hits (diagnoses the index-not-ready race)
- `first_dashboard_open_at` — reached the storage/cost view (cost-feature litmus)
Idempotent (in-memory guard + DB check, safe across restarts). No behavior change to endpoints.

**2. Index-ready search UX** (`SearchBar.jsx`, `index.css`)
A search before the first crawl finishes used to show a red *"Index not ready"* error (reads as broken → user leaves). Now it shows a reassuring *"Indexing your bucket — N objects so far"* panel and **auto-retries**, rendering results the moment the index is ready. Cancellation-safe.

**3. Indexing-aware empty state** (`App.jsx`, `ObjectTable.jsx`)
A freshly-connected bucket mid-crawl showed the misleading *"This folder is empty."* Now, while crawl-status is `crawling`, it shows *"Indexing your bucket…"* + a **"Try a search"** nudge toward the activation event. Gated strictly on `status === "crawling"` (defaults false), so genuinely-empty buckets are unaffected — no false positives.

*(Auto-crawl-on-connect — the backend half of TTFS — already existed: endpoint-add and startup both queue immediate crawls. Verified, no change needed.)*

## Validation
- Backend unit: **37/37**; targeted activation-milestone test: **11/11** (idempotency, cross-restart, ≤4 KB).
- `test_scaling.py` alone: **35/35**. S3-key scoping/IDOR: **10/10** (no auth regression).
- Frontend build: clean (1760 modules).

## Note (pre-existing, not from this PR)
Running `pytest test_main.py test_scaling.py` *in one process* fails 2 tests with `UNIQUE constraint failed: objects.key` — **this reproduces identically on `main`** (cross-file test-isolation; each suite passes alone). Flagging as a separate testing-hygiene fix; out of scope here.