### PR TITLE
feat: OpenID Connect (OIDC) SSO + per-bucket access management

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,13 +28,36 @@ DB_DIR=/data                 # Directory for SQLite databases
 # LDAP_ADMIN_GROUP=CN=Admins,OU=Groups,DC=example,DC=com
 # LDAP_DEFAULT_ROLE=viewer
 
-# OAuth / OIDC (optional)
+# OAuth — built-in Google / GitHub (optional)
 # OAUTH_GOOGLE_CLIENT_ID=
 # OAUTH_GOOGLE_CLIENT_SECRET=
 # OAUTH_GITHUB_CLIENT_ID=
 # OAUTH_GITHUB_CLIENT_SECRET=
 # OAUTH_DEFAULT_ROLE=viewer
 # OAUTH_ALLOWED_DOMAINS=example.com
+
+# OIDC — generic OpenID Connect SSO (Keycloak, Okta, Auth0, Entra ID, Authentik, …)
+# Enabled when OIDC_ISSUER and OIDC_CLIENT_ID are both set. Endpoints are
+# auto-discovered from <issuer>/.well-known/openid-configuration; the ID token is
+# validated (JWKS signature + iss/aud/exp) before any claim is trusted.
+# Only the username is synced — a new user lands as OIDC_DEFAULT_ROLE (viewer)
+# with no bucket access, and an admin assigns permissions.
+# Register this redirect URI with your provider: https://<your-host>/api/auth/oidc/callback
+# OIDC_ISSUER=https://login.example.com/realms/main
+# OIDC_CLIENT_ID=
+# OIDC_CLIENT_SECRET=
+# OIDC_PROVIDER_NAME=SSO                  # label on the login button
+# OIDC_USERNAME_CLAIM=preferred_username  # claim used as the local username
+# OIDC_SCOPES=openid profile email
+# OIDC_DEFAULT_ROLE=viewer
+# OIDC_ALLOWED_DOMAINS=example.com        # optional email-domain allowlist
+# Optional group→role mapping (off by default = username-only; admins assign access).
+# When OIDC_ADMIN_GROUP is set, membership maps to admin and re-syncs each login.
+# OIDC_ADMIN_GROUP=sairo-admins           # group whose members become admins
+# OIDC_GROUPS_CLAIM=groups                # claim containing the user's groups
+# Optional hardening:
+# OIDC_REQUIRE_VERIFIED_EMAIL=false       # reject logins whose email isn't verified
+# OIDC_RP_LOGOUT=false                    # also end the IdP session on logout (single logout)
 
 # White-labeling (optional)
 # APP_NAME=Sairo

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ node_modules/
 frontend/dist/
 website/dist/
 website/.astro/
+backend/static/
 
 # Python
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,26 @@
 
 All notable changes to Sairo are documented here. This project uses [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+Generic OpenID Connect SSO + a real per-bucket access UI (issue #9).
+
+### Added
+
+- **OpenID Connect (OIDC) SSO** — a standards-compliant client for any provider (Keycloak, Authentik, Okta, Auth0, Entra ID, Google, Dex, …). Endpoints are auto-discovered from `<issuer>/.well-known/openid-configuration`; every ID token is fully validated (JWKS signature, `iss`/`aud`/`exp`/`azp`, nonce) and the flow is protected with **state + nonce + PKCE (S256)**. Per issue #9, **only the username is synced** — new users are viewers with no access until an admin grants it. Configured entirely via `OIDC_*` env vars; works with a confidential **or** public (secretless) client. Tested end-to-end against Keycloak, Authentik, and Dex. See [docs/SSO.md](docs/SSO.md).
+- **Optional OIDC group→role mapping** (`OIDC_ADMIN_GROUP` / `OIDC_GROUPS_CLAIM`) — off by default; when enabled, admin-group membership maps to the admin role and re-syncs each login. Matching is exact / path-segment / DN — never a loose substring.
+- **Optional hardening toggles** — `OIDC_REQUIRE_VERIFIED_EMAIL`, `OIDC_ALLOWED_DOMAINS`, and RP-initiated single logout (`OIDC_RP_LOGOUT`).
+- **Per-bucket access management UI** — Users now shows an auth-source badge (Local / SSO / LDAP / OAuth) and a bucket-grant count; "Manage access" opens a Read / Write / No-Access editor with search and bulk grant/revoke. (The backend permission API already existed; this makes it usable.)
+- Friendly login-page error messages for SSO failures.
+
+### Changed
+
+- **`auth_source` is now tracked per user** (with a backfill migration). All federated logins — OIDC, OAuth, and LDAP — go through one hardened sync path.
+
+### Security
+
+- Closed an **account-takeover** vector: a federated (OIDC/OAuth/LDAP) login can no longer sign in as a username already owned by a different auth source — notably the local admin.
+
 ## [3.5.0] - 2026-06-27
 
 Anonymous telemetry schema v2 — richer, still privacy-first.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to Sairo are documented here. This project uses [Semantic Versioning](https://semver.org/).
 
-## [Unreleased]
+## [3.6.0] - 2026-06-29
 
 Generic OpenID Connect SSO + a real per-bucket access UI (issue #9).
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Works with **AWS S3**, **MinIO**, **Ceph**, **Wasabi**, **Cloudflare R2**, **Bac
 - **User Management** — Role-based access control (admin / viewer) with per-bucket permissions
 - **S3-Key Auth** — Optional `AUTH_MODE=s3`: users log in with their own S3 keys and see only the buckets their provider IAM allows — access is delegated entirely to the provider
 - **Two-Factor Auth** — TOTP-based 2FA with QR setup and recovery codes
-- **OAuth & LDAP** — Google, GitHub OAuth and LDAP authentication
+- **SSO — OAuth, OIDC & LDAP** — Google/GitHub OAuth, generic OpenID Connect (Keycloak, Okta, Auth0, Entra ID, Google, Authentik, Dex, …) with auto-discovery + full ID-token validation (PKCE, nonce, JWKS), and LDAP. OIDC syncs the username only; admins assign per-bucket access. **Setup guide: [docs/SSO.md](docs/SSO.md)**
 - **AI-Powered Analysis (MCP)** — Connect Claude, Cursor, or any MCP client to ask natural language questions about your storage. 26 tools for analytics, cost optimization, pipeline health, and more
 - **Petabyte-Scale Performance** — Proven on a live 269 TB / 15.5M-object deployment. Constant-time folder listing at any scale via pre-computed prefix hierarchies, 64MB SQLite page cache, 256MB memory-mapped I/O, async FTS rebuilds
 - **Anonymous Telemetry (opt-out)** — A privacy-first heartbeat reports aggregate counts, instance health, and activation timestamps only (never names, keys, paths, or content). Disable with `TELEMETRY=false`
@@ -122,7 +122,7 @@ Validated read-only against a live production deployment (Leaseweb S3-compatible
 | Upload | Direct browser→S3 multipart, up to 5 TB/object, **flat server memory** |
 | Crawl throughput | 16 parallel prefix workers, 10K batch inserts, adaptive delta crawl |
 
-**Scaling:** Folder navigation is a constant-time index lookup, so it stays instant at any dataset size. See [Benchmarks](https://docs.sairo.dev/reference/benchmarks/) for the full methodology and server-compute microbenchmarks.
+**Scaling:** Folder navigation is a constant-time index lookup, so it stays instant at any dataset size. See [benchmark results](benchmark/results/LATEST-RESULTS.md) for the full methodology and server-compute microbenchmarks.
 
 ## Environment Variables
 
@@ -145,7 +145,7 @@ Validated read-only against a live production deployment (Leaseweb S3-compatible
 | `TELEMETRY` | `true` | Anonymous usage heartbeat (aggregate counts + health only). Set `false` to disable |
 | `TELEMETRY_INTERVAL` | `3600` | Seconds between telemetry heartbeats |
 
-> This is a summary. See the [full environment-variable reference](https://docs.sairo.dev/reference/environment-variables/) for delta-crawl tuning, uploads, LDAP/OAuth, branding, and rate limiting.
+> This is a summary; see **[.env.example](.env.example)** for the full annotated environment-variable reference (delta-crawl tuning, uploads, LDAP/OAuth, branding, rate limiting). For single sign-on (OIDC / OAuth / LDAP) setup with per-provider examples, see **[docs/SSO.md](docs/SSO.md)**.
 
 ## Tech Stack
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -605,16 +605,29 @@ def _init_users_db():
         )
     """)
     conn.execute("CREATE INDEX IF NOT EXISTS idx_bp_username ON bucket_permissions(username)")
-    # 2FA columns (added via ALTER TABLE for backward compat)
+    # 2FA + auth-source columns (added via ALTER TABLE for backward compat)
     for col, coldef in [
         ("totp_secret", "TEXT"),
         ("totp_enabled", "INTEGER DEFAULT 0"),
         ("recovery_codes", "TEXT"),  # JSON array of bcrypt-hashed codes
+        ("auth_source", "TEXT"),     # local | ldap | oauth_google | oauth_github | oidc
     ]:
         try:
             conn.execute(f"ALTER TABLE users ADD COLUMN {col} {coldef}")
         except sqlite3.OperationalError:
             pass  # column already exists
+    # Backfill auth_source for rows created before the column existed, inferring
+    # the original identity provider from the placeholder password_hash prefix
+    # (federated logins store "LDAP:"/"OAUTH:"/"OIDC:"; everything else is local).
+    # This is what lets us block one provider from hijacking another's account.
+    conn.execute("""
+        UPDATE users SET auth_source = CASE
+            WHEN password_hash LIKE 'LDAP:%'  THEN 'ldap'
+            WHEN password_hash LIKE 'OIDC:%'  THEN 'oidc'
+            WHEN password_hash LIKE 'OAUTH:%' THEN 'oauth'
+            ELSE 'local' END
+        WHERE auth_source IS NULL
+    """)
     # S3 endpoints table for multi-endpoint support
     conn.execute("""
         CREATE TABLE IF NOT EXISTS s3_endpoints (
@@ -735,6 +748,53 @@ def require_admin(request: Request, user: dict = Depends(get_current_user)):
     if request.url.path.startswith("/api/buckets/") and bp == "write":
         return user
     raise HTTPException(403, "Admin access required")
+
+
+class FederatedAuthError(Exception):
+    """Raised when a federated (SSO) login can't be completed safely."""
+
+
+def _sync_federated_user(username: str, source: str, hash_prefix: str,
+                         default_role: str, mapped_role: str | None = None):
+    """Create-or-fetch a user logging in via an external IdP (OIDC/OAuth/LDAP).
+
+    The single security-critical chokepoint for every SSO path:
+
+    * **Account-takeover guard** — if a user with this name already exists from a
+      *different* auth source, the login is rejected. Without this, an IdP user
+      who can set their username to ``admin`` would log straight into the local
+      admin account. A user is only ever logged in against the provider that
+      created them.
+    * New users are created with ``default_role`` and NO bucket grants (an admin
+      assigns access). When ``mapped_role`` is provided (e.g. derived from IdP
+      groups), it sets the role on create and re-syncs it for that provider's
+      own users on later logins — never for a user owned by another source.
+
+    Returns ``(role, totp_enabled)``. Raises ``FederatedAuthError`` on conflict.
+    """
+    with _get_users_db() as db:
+        row = db.execute(
+            "SELECT role, totp_enabled, auth_source FROM users WHERE username=?",
+            (username,)).fetchone()
+        if row is not None:
+            existing_source = row["auth_source"] or "local"
+            if existing_source != source:
+                raise FederatedAuthError(
+                    f"username '{username}' already exists via '{existing_source}'")
+            role = row["role"]
+            if mapped_role and mapped_role != role:
+                # Provider-managed role (group mapping) — keep DB in sync.
+                db.execute("UPDATE users SET role=? WHERE username=?", (mapped_role, username))
+                db.commit()
+                role = mapped_role
+            return role, bool(row["totp_enabled"])
+        role = mapped_role or default_role
+        db.execute(
+            "INSERT INTO users (username, password_hash, role, auth_source) VALUES (?,?,?,?)",
+            (username, f"{hash_prefix}:{secrets.token_hex(16)}", role, source))
+        db.commit()
+        _audit("user_created", username, details=f"method={source}")
+        return role, False
 
 
 def _summarize_keys(keys, max_items=3):
@@ -2879,19 +2939,47 @@ def auth_login_s3(req: LoginS3Request, request: Request):
 
 
 @app.post("/api/auth/logout")
-def auth_logout():
-    response = JSONResponse({"logged_out": True})
+def auth_logout(request: Request):
+    # Always clear the local session. If the session belongs to an OIDC user and
+    # RP-initiated logout is enabled, also hand back the IdP end-session URL so the
+    # frontend can complete a single logout (the SSO session, not just ours).
+    sso_logout_url = None
+    if OIDC_ENABLED and OIDC_RP_LOGOUT:
+        token = request.cookies.get("access_token")
+        if token:
+            try:
+                sub = jwt.decode(token, JWT_SECRET, algorithms=["HS256"]).get("sub")
+            except Exception:
+                sub = None
+            if sub:
+                with _get_users_db() as db:
+                    row = db.execute("SELECT auth_source FROM users WHERE username=?", (sub,)).fetchone()
+                if row and (row["auth_source"] or "local") == "oidc":
+                    try:
+                        end = _oidc_config().get("end_session_endpoint")
+                        if end:
+                            import urllib.parse
+                            base = str(request.base_url).rstrip("/")
+                            qs = urllib.parse.urlencode({
+                                "client_id": OIDC_CLIENT_ID,
+                                "post_logout_redirect_uri": base + "/",
+                            })
+                            sso_logout_url = f"{end}?{qs}"
+                    except Exception:
+                        sso_logout_url = None
+    response = JSONResponse({"logged_out": True, "sso_logout_url": sso_logout_url})
     response.delete_cookie("access_token", path="/")
     return response
 
 @app.get("/api/auth/me")
 def auth_me(user: dict = Depends(get_current_user), request: Request = None):
     result = {"username": user["username"], "role": user["role"]}
-    # Include 2FA status
+    # Include 2FA status + which provider this account authenticates against
     with _get_users_db() as db:
-        row = db.execute("SELECT totp_enabled FROM users WHERE username=?", (user["username"],)).fetchone()
+        row = db.execute("SELECT totp_enabled, auth_source FROM users WHERE username=?", (user["username"],)).fetchone()
     if row:
         result["totp_enabled"] = bool(row["totp_enabled"])
+        result["auth_source"] = row["auth_source"] or "local"
     token = request.cookies.get("access_token") if request else None
     if token:
         try:
@@ -2917,11 +3005,16 @@ def auth_refresh(user: dict = Depends(get_current_user)):
 @app.get("/api/auth/users")
 def auth_list_users(user: dict = Depends(require_admin)):
     with _get_users_db() as db:
-        rows = db.execute("SELECT username, role, created_at, totp_enabled FROM users ORDER BY created_at").fetchall()
+        rows = db.execute("SELECT username, role, created_at, totp_enabled, auth_source FROM users ORDER BY created_at").fetchall()
+        # bucket-grant counts per user, so the UI can show "N buckets" at a glance
+        counts = {r["username"]: r["n"] for r in db.execute(
+            "SELECT username, COUNT(*) AS n FROM bucket_permissions GROUP BY username").fetchall()}
     users = []
     for r in rows:
         u = dict(r)
         u["totp_enabled"] = bool(u.get("totp_enabled"))
+        u["auth_source"] = u.get("auth_source") or "local"
+        u["bucket_count"] = counts.get(u["username"], 0)
         users.append(u)
     return {"users": users}
 
@@ -3393,18 +3486,13 @@ def activate_license(req: ActivateLicenseRequest, user: dict = Depends(require_a
 @app.get("/api/branding")
 def get_branding():
     """Public endpoint — returns custom branding. No auth required."""
-    oauth_providers = []
-    if os.environ.get("OAUTH_GOOGLE_CLIENT_ID"):
-        oauth_providers.append({"id": "google", "name": "Google"})
-    if os.environ.get("OAUTH_GITHUB_CLIENT_ID"):
-        oauth_providers.append({"id": "github", "name": "GitHub"})
     return {
         "app_name": os.environ.get("APP_NAME", "Sairo"),
         "app_logo": os.environ.get("APP_LOGO", ""),  # URL to custom logo
         "primary_color": os.environ.get("PRIMARY_COLOR", "#3b82f6"),
         "login_message": os.environ.get("LOGIN_MESSAGE", ""),
         "ldap_enabled": os.environ.get("LDAP_ENABLED", "false").lower() == "true",
-        "oauth_providers": oauth_providers,
+        "oauth_providers": _auth_providers(),
         "auth_mode": AUTH_MODE,
         "version": SAIRO_VERSION,
     }
@@ -3498,19 +3586,18 @@ def auth_ldap(req: LoginRequest, request: Request):
         log.error("LDAP error: %s", e)
         raise HTTPException(502, f"LDAP error: {e}")
 
-    # Sync to local users table (create or update role)
-    with _get_users_db() as db:
-        existing = db.execute("SELECT username, totp_enabled FROM users WHERE username=?", (req.username,)).fetchone()
-        if existing:
-            db.execute("UPDATE users SET role=? WHERE username=?", (role, req.username))
-        else:
-            # Create user with a random unusable password (LDAP-only auth)
-            db.execute("INSERT INTO users (username, password_hash, role) VALUES (?,?,?)",
-                       (req.username, f"LDAP:{secrets.token_hex(16)}", role))
-        db.commit()
+    # Sync to local users table via the hardened federated chokepoint. LDAP role
+    # is group-derived, so it's passed as mapped_role (re-synced each login for
+    # LDAP-owned users, never for a local/other-IdP account of the same name).
+    try:
+        role, totp_enabled = _sync_federated_user(
+            req.username, "ldap", "LDAP", LDAP_DEFAULT_ROLE, mapped_role=role)
+    except FederatedAuthError:
+        _audit("login_failed", req.username, details="ldap account-source conflict")
+        raise HTTPException(409, "This username already exists with a different sign-in method")
 
     # Check 2FA
-    if existing and existing["totp_enabled"]:
+    if totp_enabled:
         pending_token = jwt.encode(
             {"sub": req.username, "role": role, "purpose": "2fa",
              "exp": datetime.now(timezone.utc) + timedelta(minutes=5)},
@@ -3543,15 +3630,25 @@ OAUTH_GITHUB_CLIENT_SECRET = os.environ.get("OAUTH_GITHUB_CLIENT_SECRET", "")
 OAUTH_DEFAULT_ROLE = os.environ.get("OAUTH_DEFAULT_ROLE", "viewer")
 OAUTH_ALLOWED_DOMAINS = [d.strip() for d in os.environ.get("OAUTH_ALLOWED_DOMAINS", "").split(",") if d.strip()]
 
-@app.get("/api/auth/oauth/providers")
-def oauth_providers():
-    """Public endpoint — list available OAuth providers."""
+def _auth_providers() -> list:
+    """Single source of truth for the SSO buttons the frontend renders.
+
+    Each entry carries an explicit ``login_path`` so the frontend doesn't have
+    to assume a URL shape (OIDC lives under /oidc, not /oauth/<id>)."""
     providers = []
     if OAUTH_GOOGLE_CLIENT_ID:
-        providers.append({"id": "google", "name": "Google"})
+        providers.append({"id": "google", "name": "Google", "login_path": "/api/auth/oauth/google/login"})
     if OAUTH_GITHUB_CLIENT_ID:
-        providers.append({"id": "github", "name": "GitHub"})
-    return {"providers": providers}
+        providers.append({"id": "github", "name": "GitHub", "login_path": "/api/auth/oauth/github/login"})
+    if OIDC_ENABLED:
+        providers.append({"id": "oidc", "name": OIDC_PROVIDER_NAME, "login_path": "/api/auth/oidc/login"})
+    return providers
+
+
+@app.get("/api/auth/oauth/providers")
+def oauth_providers():
+    """Public endpoint — list available SSO providers (OAuth + OIDC)."""
+    return {"providers": _auth_providers()}
 
 @app.get("/api/auth/oauth/{provider}/login")
 def oauth_start(provider: str, request: Request):
@@ -3640,18 +3737,14 @@ def oauth_callback(provider: str, code: str, request: Request):
     else:
         return RedirectResponse(f"/?error=unknown_provider")
 
-    # Sync to local DB
-    role = OAUTH_DEFAULT_ROLE
-    totp_enabled = False
-    with _get_users_db() as db:
-        existing = db.execute("SELECT role, totp_enabled FROM users WHERE username=?", (username,)).fetchone()
-        if existing:
-            role = existing["role"]  # Preserve existing role
-            totp_enabled = bool(existing["totp_enabled"])
-        else:
-            db.execute("INSERT INTO users (username, password_hash, role) VALUES (?,?,?)",
-                       (username, f"OAUTH:{secrets.token_hex(16)}", role))
-            db.commit()
+    # Sync to local DB through the hardened federated chokepoint (rejects a login
+    # for a username already owned by a different auth source — e.g. local admin).
+    try:
+        role, totp_enabled = _sync_federated_user(
+            username, "oauth", "OAUTH", OAUTH_DEFAULT_ROLE, mapped_role=None)
+    except FederatedAuthError:
+        _audit("login_failed", username, details="oauth account-source conflict")
+        return RedirectResponse("/?error=account_conflict")
 
     # Check 2FA
     if totp_enabled:
@@ -3675,6 +3768,296 @@ def oauth_callback(provider: str, code: str, request: Request):
     response.set_cookie("access_token", token, httponly=True, samesite="strict",
                         secure=_secure_cookie, max_age=SESSION_HOURS * 3600, path="/")
     _audit("login", username, details=f"method=oauth_{provider}")
+    return response
+
+
+# ── API: OpenID Connect (generic OIDC) ──────────────────────────────────────
+#
+# Unlike the hardcoded Google/GitHub OAuth above, this is a standards-compliant
+# OIDC client for ANY issuer (Keycloak, Okta, Auth0, Entra ID, Authentik, …):
+#   • discovers endpoints from <issuer>/.well-known/openid-configuration
+#   • protects the round-trip with state + nonce + PKCE (S256)
+#   • validates the ID token properly — signature via the issuer's JWKS, plus
+#     iss / aud / exp — before trusting any claim
+#
+# Per the product decision (issue #9): we sync ONLY the username. Role and
+# per-bucket permissions are NOT derived from OIDC claims/groups — a brand-new
+# user lands as OIDC_DEFAULT_ROLE (viewer) with zero bucket grants, and an admin
+# assigns access. An existing user's role/permissions are never overwritten on
+# login, so OIDC can't silently escalate or downgrade someone an admin set up.
+
+OIDC_ISSUER = os.environ.get("OIDC_ISSUER", "").rstrip("/")
+OIDC_CLIENT_ID = os.environ.get("OIDC_CLIENT_ID", "")
+OIDC_CLIENT_SECRET = os.environ.get("OIDC_CLIENT_SECRET", "")
+OIDC_SCOPES = os.environ.get("OIDC_SCOPES", "openid profile email")
+OIDC_USERNAME_CLAIM = os.environ.get("OIDC_USERNAME_CLAIM", "preferred_username")
+OIDC_PROVIDER_NAME = os.environ.get("OIDC_PROVIDER_NAME", "SSO")
+OIDC_DEFAULT_ROLE = os.environ.get("OIDC_DEFAULT_ROLE", "viewer")
+OIDC_ALLOWED_DOMAINS = [d.strip().lower() for d in os.environ.get("OIDC_ALLOWED_DOMAINS", "").split(",") if d.strip()]
+# Optional group→role mapping (off by default → issue #9 username-only behaviour).
+# When OIDC_ADMIN_GROUP is set, membership of that group in the OIDC_GROUPS_CLAIM
+# claim maps the user to admin; everyone else gets OIDC_DEFAULT_ROLE. Mirrors LDAP.
+OIDC_GROUPS_CLAIM = os.environ.get("OIDC_GROUPS_CLAIM", "groups")
+OIDC_ADMIN_GROUP = os.environ.get("OIDC_ADMIN_GROUP", "")
+# Optional hardening toggles.
+OIDC_REQUIRE_VERIFIED_EMAIL = os.environ.get("OIDC_REQUIRE_VERIFIED_EMAIL", "false").lower() == "true"
+OIDC_RP_LOGOUT = os.environ.get("OIDC_RP_LOGOUT", "false").lower() == "true"
+# Enabled only when both an issuer and a client id are configured.
+OIDC_ENABLED = bool(OIDC_ISSUER and OIDC_CLIENT_ID)
+# Only asymmetric algs — never HS*/none — so a leaked/forged token signed with a
+# symmetric key (or the alg-confusion attack using the public key as an HMAC
+# secret) can't pass validation.
+_OIDC_ALLOWED_ALGS = ["RS256", "RS384", "RS512", "ES256", "ES384", "ES512", "PS256", "PS384", "PS512"]
+
+_oidc_discovery_cache: dict = {"doc": None, "fetched_at": 0}
+_oidc_jwks_client = None  # lazily-built jwt.PyJWKClient (caches keys internally)
+
+
+def _oidc_config() -> dict:
+    """Fetch + cache (1h TTL) the issuer's OpenID discovery document."""
+    import httpx
+    now = time.time()
+    if _oidc_discovery_cache["doc"] and now - _oidc_discovery_cache["fetched_at"] < 3600:
+        return _oidc_discovery_cache["doc"]
+    resp = httpx.get(f"{OIDC_ISSUER}/.well-known/openid-configuration", timeout=10)
+    resp.raise_for_status()
+    doc = resp.json()
+    _oidc_discovery_cache["doc"] = doc
+    _oidc_discovery_cache["fetched_at"] = now
+    return doc
+
+
+def _oidc_jwks():
+    """Lazy, cached PyJWKClient pointed at the issuer's jwks_uri."""
+    global _oidc_jwks_client
+    if _oidc_jwks_client is None:
+        _oidc_jwks_client = jwt.PyJWKClient(_oidc_config()["jwks_uri"])
+    return _oidc_jwks_client
+
+
+def _oidc_userinfo(access_token: str, cfg: dict) -> dict:
+    """Best-effort fetch of the userinfo endpoint, to fill claims an IdP omits
+    from the ID token (commonly groups or email). Never raises into the flow."""
+    import httpx
+    ep = cfg.get("userinfo_endpoint")
+    if not ep or not access_token:
+        return {}
+    try:
+        r = httpx.get(ep, headers={"Authorization": f"Bearer {access_token}"}, timeout=10)
+        return r.json() if r.status_code == 200 else {}
+    except Exception:
+        return {}
+
+
+def _oidc_mapped_role(claims: dict):
+    """Optional group→role mapping. Returns None when OIDC_ADMIN_GROUP is unset
+    (username-only mode — role left to admins). Otherwise returns 'admin' if the
+    user is in the admin group, else OIDC_DEFAULT_ROLE — a provider-managed role
+    that re-syncs on every login (so removing someone from the group demotes them).
+
+    Matching is on the WHOLE group value or a delimited component — never a loose
+    substring — so admin group "sairo-admins" does NOT match "sairo-admins-readonly".
+    Handles plain names ("sairo-admins"), Keycloak paths ("/parent/sairo-admins"),
+    and LDAP/AD DNs ("cn=sairo-admins,ou=groups,dc=corp")."""
+    if not OIDC_ADMIN_GROUP:
+        return None
+    want = OIDC_ADMIN_GROUP.strip().strip("/").lower()
+    raw = claims.get(OIDC_GROUPS_CLAIM)
+    groups = raw if isinstance(raw, list) else ([raw] if raw else [])
+    for g in groups:
+        g = str(g).strip().lower()
+        # Candidate identities for this group: the whole value, each path/DN
+        # component, and the value side of any "key=value" DN component.
+        candidates = {g, g.strip("/")}
+        for part in g.replace(",", "/").split("/"):
+            part = part.strip()
+            if not part:
+                continue
+            candidates.add(part)
+            if "=" in part:
+                candidates.add(part.split("=", 1)[1].strip())
+        if want in candidates:
+            return "admin"
+    return OIDC_DEFAULT_ROLE
+
+
+@app.get("/api/auth/oidc/login")
+def oidc_start(request: Request):
+    """Begin the OIDC authorization-code (+ PKCE) flow: redirect to the issuer."""
+    if not OIDC_ENABLED:
+        raise HTTPException(404, "OIDC is not configured")
+    import urllib.parse, hashlib, base64
+    try:
+        cfg = _oidc_config()
+    except Exception:
+        raise HTTPException(502, "OIDC issuer discovery failed")
+    base_url = str(request.base_url).rstrip("/")
+    redirect_uri = f"{base_url}/api/auth/oidc/callback"
+    state = secrets.token_urlsafe(24)
+    nonce = secrets.token_urlsafe(24)
+    verifier = secrets.token_urlsafe(64)  # PKCE code_verifier
+    challenge = base64.urlsafe_b64encode(
+        hashlib.sha256(verifier.encode()).digest()).rstrip(b"=").decode()
+    params = urllib.parse.urlencode({
+        "client_id": OIDC_CLIENT_ID,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": OIDC_SCOPES,
+        "state": state,
+        "nonce": nonce,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+    })
+    # Stash state/nonce/verifier in a short-lived signed cookie bound to this
+    # browser. SameSite=Lax (not Strict) so it survives the top-level redirect
+    # back from the IdP; Strict would drop it on the cross-site return.
+    state_token = jwt.encode(
+        {"state": state, "nonce": nonce, "cv": verifier, "purpose": "oidc_state",
+         "exp": datetime.now(timezone.utc) + timedelta(minutes=10)},
+        JWT_SECRET, algorithm="HS256")
+    response = RedirectResponse(f"{cfg['authorization_endpoint']}?{params}")
+    _secure_cookie = os.environ.get("SECURE_COOKIE", "true").lower() != "false"
+    response.set_cookie("oidc_state", state_token, httponly=True, samesite="lax",
+                        secure=_secure_cookie, max_age=600, path="/api/auth/oidc")
+    return response
+
+
+@app.get("/api/auth/oidc/callback")
+def oidc_callback(request: Request, code: str = "", state: str = "", error: str = ""):
+    """Handle the OIDC redirect: verify state, exchange code, validate the ID token."""
+    if not OIDC_ENABLED:
+        raise HTTPException(404, "OIDC is not configured")
+    if error:
+        return RedirectResponse("/?error=oidc_failed")
+
+    # 1) CSRF: the state param must match the signed state cookie we set.
+    state_cookie = request.cookies.get("oidc_state")
+    if not state_cookie or not code or not state:
+        return RedirectResponse("/?error=oidc_failed")
+    try:
+        st = jwt.decode(state_cookie, JWT_SECRET, algorithms=["HS256"])
+    except jwt.InvalidTokenError:
+        return RedirectResponse("/?error=oidc_failed")
+    if st.get("purpose") != "oidc_state" or not secrets.compare_digest(st.get("state", ""), state):
+        return RedirectResponse("/?error=oidc_state_mismatch")
+
+    import httpx
+    try:
+        cfg = _oidc_config()
+    except Exception:
+        return RedirectResponse("/?error=oidc_failed")
+    base_url = str(request.base_url).rstrip("/")
+    redirect_uri = f"{base_url}/api/auth/oidc/callback"
+
+    # 2) Exchange the code (with the PKCE verifier) for tokens.
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "redirect_uri": redirect_uri,
+        "client_id": OIDC_CLIENT_ID,
+        "code_verifier": st.get("cv", ""),
+    }
+    if OIDC_CLIENT_SECRET:
+        data["client_secret"] = OIDC_CLIENT_SECRET
+    try:
+        token_resp = httpx.post(cfg["token_endpoint"], data=data, timeout=10,
+                                headers={"Accept": "application/json"})
+    except Exception:
+        return RedirectResponse("/?error=oidc_failed")
+    if token_resp.status_code != 200:
+        return RedirectResponse("/?error=oidc_failed")
+    tokens = token_resp.json()
+    id_token = tokens.get("id_token")
+    access_token = tokens.get("access_token")
+    if not id_token:
+        return RedirectResponse("/?error=oidc_no_id_token")
+
+    # 3) Validate the ID token: signature via JWKS + iss/aud/exp. This is the
+    #    step that makes the claims trustworthy — do NOT skip it.
+    try:
+        signing_key = _oidc_jwks().get_signing_key_from_jwt(id_token)
+        claims = jwt.decode(
+            id_token, signing_key.key,
+            algorithms=_OIDC_ALLOWED_ALGS,
+            audience=OIDC_CLIENT_ID,
+            issuer=cfg.get("issuer", OIDC_ISSUER),
+            leeway=60,  # tolerate small clock skew between us and the IdP
+            options={"require": ["exp", "iat", "iss", "aud"]},
+        )
+    except Exception:
+        _audit("login_failed", "(oidc)", details="id_token validation failed")
+        return RedirectResponse("/?error=oidc_invalid_token")
+
+    # 4) Replay protection: the nonce must match the one we sent.
+    if claims.get("nonce") != st.get("nonce"):
+        return RedirectResponse("/?error=oidc_nonce_mismatch")
+
+    # 4a) Authorized-party: when present (typically with multiple audiences), azp
+    #     MUST be our client id — otherwise the token was minted for someone else.
+    if claims.get("azp") and claims["azp"] != OIDC_CLIENT_ID:
+        _audit("login_failed", "(oidc)", details="azp mismatch")
+        return RedirectResponse("/?error=oidc_invalid_token")
+
+    # 4b) Fill claims some IdPs keep out of the ID token (commonly groups/email)
+    #     from the userinfo endpoint — only when we actually need them.
+    need_username = not claims.get(OIDC_USERNAME_CLAIM)
+    need_groups = bool(OIDC_ADMIN_GROUP) and not claims.get(OIDC_GROUPS_CLAIM)
+    need_email = (OIDC_REQUIRE_VERIFIED_EMAIL or bool(OIDC_ALLOWED_DOMAINS)) and not claims.get("email")
+    if access_token and (need_username or need_groups or need_email):
+        for k, v in _oidc_userinfo(access_token, cfg).items():
+            claims.setdefault(k, v)
+
+    # 5) Optional email checks.
+    email = claims.get("email", "") or ""
+    if OIDC_REQUIRE_VERIFIED_EMAIL and claims.get("email_verified") is not True:
+        return RedirectResponse("/?error=email_not_verified")
+    if OIDC_ALLOWED_DOMAINS:
+        domain = email.split("@")[1].lower() if "@" in email else ""
+        if domain not in OIDC_ALLOWED_DOMAINS:
+            return RedirectResponse("/?error=domain_not_allowed")
+
+    # 6) Pick the username claim (sync ONLY the username, unless group mapping is on).
+    username = str(claims.get(OIDC_USERNAME_CLAIM) or claims.get("preferred_username")
+                   or claims.get("email") or claims.get("sub") or "").strip()
+    if not username:
+        return RedirectResponse("/?error=oidc_no_username")
+
+    # 7) Sync through the hardened federated chokepoint:
+    #    new user → default role + no bucket grants (admin assigns later);
+    #    existing user → reject if it belongs to a different auth source
+    #    (account-takeover guard, protects the local admin especially).
+    #    mapped_role is None in username-only mode, or admin/viewer when groups map.
+    try:
+        role, totp_enabled = _sync_federated_user(
+            username, "oidc", "OIDC", OIDC_DEFAULT_ROLE, mapped_role=_oidc_mapped_role(claims))
+    except FederatedAuthError:
+        _audit("login_failed", username, details="oidc account-source conflict")
+        return RedirectResponse("/?error=account_conflict")
+
+    _secure_cookie = os.environ.get("SECURE_COOKIE", "true").lower() != "false"
+
+    # 7a) If the synced user has 2FA, hand off to the existing 2FA flow.
+    if totp_enabled:
+        pending_token = jwt.encode(
+            {"sub": username, "role": role, "purpose": "2fa",
+             "exp": datetime.now(timezone.utc) + timedelta(minutes=5)},
+            JWT_SECRET, algorithm="HS256")
+        response = RedirectResponse("/?requires_2fa=true")
+        response.set_cookie("access_token", pending_token, httponly=True, samesite="strict",
+                            secure=_secure_cookie, max_age=300, path="/")
+        response.delete_cookie("oidc_state", path="/api/auth/oidc")
+        return response
+
+    # 7b) Issue the normal session token and land in the app.
+    token = jwt.encode(
+        {"sub": username, "role": role,
+         "exp": datetime.now(timezone.utc) + timedelta(hours=SESSION_HOURS)},
+        JWT_SECRET, algorithm="HS256")
+    response = RedirectResponse("/")
+    response.set_cookie("access_token", token, httponly=True, samesite="strict",
+                        secure=_secure_cookie, max_age=SESSION_HOURS * 3600, path="/")
+    response.delete_cookie("oidc_state", path="/api/auth/oidc")
+    _audit("login", username, details="method=oidc")
     return response
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -294,7 +294,7 @@ async def s3_error_handler(request, exc):
 
 
 _app_start_time = time.time()
-SAIRO_VERSION = "3.5.0"
+SAIRO_VERSION = "3.6.0"
 
 
 def _version_gt(a: str, b: str) -> bool:

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -255,6 +255,397 @@ class TestOAuth:
         assert resp.status_code == 404
 
 
+def _main_module():
+    try:
+        import backend.main as m
+    except ModuleNotFoundError:
+        import main as m
+    return m
+
+
+class TestOIDC:
+    """Generic OpenID Connect login (issue #9): username-only sync, admin perms."""
+
+    ISSUER = "https://issuer.test"
+    CLIENT_ID = "client123"
+
+    def _enable(self, monkeypatch):
+        """Turn OIDC on at runtime + stub discovery (no real network)."""
+        m = _main_module()
+        monkeypatch.setattr(m, "OIDC_ENABLED", True)
+        monkeypatch.setattr(m, "OIDC_ISSUER", self.ISSUER)
+        monkeypatch.setattr(m, "OIDC_CLIENT_ID", self.CLIENT_ID)
+        monkeypatch.setattr(m, "OIDC_CLIENT_SECRET", "shh")
+        monkeypatch.setattr(m, "OIDC_USERNAME_CLAIM", "preferred_username")
+        monkeypatch.setattr(m, "OIDC_PROVIDER_NAME", "Corp SSO")
+        monkeypatch.setattr(m, "OIDC_DEFAULT_ROLE", "viewer")
+        monkeypatch.setattr(m, "OIDC_ALLOWED_DOMAINS", [])
+        monkeypatch.setattr(m, "_oidc_config", lambda: {
+            "issuer": self.ISSUER,
+            "authorization_endpoint": f"{self.ISSUER}/authorize",
+            "token_endpoint": f"{self.ISSUER}/token",
+            "jwks_uri": f"{self.ISSUER}/jwks",
+        })
+        return m
+
+    def test_disabled_by_default(self, client):
+        """With no OIDC env, login is 404 and it's absent from branding."""
+        resp = client.get("/api/auth/oidc/login", follow_redirects=False)
+        assert resp.status_code == 404
+        branding = client.get("/api/branding").json()
+        assert not any(p["id"] == "oidc" for p in branding["oauth_providers"])
+
+    def test_enabled_appears_in_branding(self, client, monkeypatch):
+        self._enable(monkeypatch)
+        providers = client.get("/api/branding").json()["oauth_providers"]
+        oidc = next(p for p in providers if p["id"] == "oidc")
+        assert oidc["name"] == "Corp SSO"
+        assert oidc["login_path"] == "/api/auth/oidc/login"
+
+    def test_login_redirects_with_state_and_pkce(self, app, monkeypatch):
+        self._enable(monkeypatch)
+        with TestClient(app) as c:
+            resp = c.get("/api/auth/oidc/login", follow_redirects=False)
+            assert resp.status_code in (302, 307)
+            loc = resp.headers["location"]
+            assert loc.startswith(f"{self.ISSUER}/authorize?")
+            # PKCE + CSRF params present
+            assert "code_challenge=" in loc and "code_challenge_method=S256" in loc
+            assert "state=" in loc and "nonce=" in loc
+            assert f"client_id={self.CLIENT_ID}" in loc
+            # signed state cookie set
+            assert resp.cookies.get("oidc_state")
+
+    def test_callback_without_state_cookie_redirects_error(self, app, monkeypatch):
+        self._enable(monkeypatch)
+        with TestClient(app) as c:
+            resp = c.get("/api/auth/oidc/callback?code=x&state=y", follow_redirects=False)
+            assert resp.status_code in (302, 307)
+            assert "error=oidc_failed" in resp.headers["location"]
+
+    def test_callback_state_mismatch_redirects_error(self, app, monkeypatch):
+        import jwt
+        from datetime import datetime, timezone, timedelta
+        m = self._enable(monkeypatch)
+        bad_state = jwt.encode(
+            {"state": "REAL", "nonce": "n", "cv": "v", "purpose": "oidc_state",
+             "exp": datetime.now(timezone.utc) + timedelta(minutes=10)},
+            m.JWT_SECRET, algorithm="HS256")
+        with TestClient(app) as c:
+            resp = c.get("/api/auth/oidc/callback?code=x&state=ATTACKER",
+                         cookies={"oidc_state": bad_state}, follow_redirects=False)
+            assert resp.status_code in (302, 307)
+            assert "error=oidc_state_mismatch" in resp.headers["location"]
+
+    def test_full_login_flow_creates_viewer_and_session(self, app, monkeypatch):
+        """End-to-end: real RS256 ID token validated through the live code path."""
+        import jwt
+        from datetime import datetime, timezone, timedelta
+        from types import SimpleNamespace
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        m = self._enable(monkeypatch)
+        priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+
+        with TestClient(app) as c:
+            # 1) start → capture the signed state cookie, decode state+nonce
+            start = c.get("/api/auth/oidc/login", follow_redirects=False)
+            state_cookie = start.cookies.get("oidc_state")
+            st = jwt.decode(state_cookie, m.JWT_SECRET, algorithms=["HS256"])
+
+            # 2) issuer mints an ID token bound to our nonce/aud/iss
+            id_token = jwt.encode(
+                {"iss": self.ISSUER, "aud": self.CLIENT_ID,
+                 "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+                 "iat": datetime.now(timezone.utc),
+                 "preferred_username": "alice", "email": "alice@corp.test",
+                 "nonce": st["nonce"]},
+                priv, algorithm="RS256", headers={"kid": "test"})
+
+            # 3) stub token exchange + JWKS verification
+            monkeypatch.setattr("httpx.post", lambda *a, **k: SimpleNamespace(
+                status_code=200, json=lambda: {"id_token": id_token}))
+            monkeypatch.setattr(m, "_oidc_jwks", lambda: SimpleNamespace(
+                get_signing_key_from_jwt=lambda t: SimpleNamespace(key=priv.public_key())))
+
+            # 4) callback with the matching state
+            resp = c.get(f"/api/auth/oidc/callback?code=abc&state={st['state']}",
+                         cookies={"oidc_state": state_cookie}, follow_redirects=False)
+            assert resp.status_code in (302, 307)
+            assert resp.headers["location"] == "/"
+            session = resp.cookies.get("access_token")
+            assert session, "should set a session cookie"
+            claims = jwt.decode(session, m.JWT_SECRET, algorithms=["HS256"])
+            assert claims["sub"] == "alice"
+            assert claims["role"] == "viewer"  # admin assigns real perms later
+
+        # user persisted with no bucket grants (admin-assigns-permissions model)
+        with m._get_users_db() as db:
+            row = db.execute("SELECT role FROM users WHERE username='alice'").fetchone()
+            assert row is not None and row["role"] == "viewer"
+            perms = db.execute("SELECT COUNT(*) AS n FROM bucket_permissions WHERE username='alice'").fetchone()
+            assert perms["n"] == 0
+
+    def test_oidc_cannot_take_over_local_admin(self, app, monkeypatch):
+        """SECURITY: an OIDC user claiming preferred_username=admin must NOT log
+        into the pre-existing local admin account."""
+        import jwt
+        from datetime import datetime, timezone, timedelta
+        from types import SimpleNamespace
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        m = self._enable(monkeypatch)
+        priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        with TestClient(app) as c:
+            start = c.get("/api/auth/oidc/login", follow_redirects=False)
+            state_cookie = start.cookies.get("oidc_state")
+            st = jwt.decode(state_cookie, m.JWT_SECRET, algorithms=["HS256"])
+            id_token = jwt.encode(
+                {"iss": self.ISSUER, "aud": self.CLIENT_ID,
+                 "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+                 "iat": datetime.now(timezone.utc),
+                 "preferred_username": "admin", "nonce": st["nonce"]},
+                priv, algorithm="RS256", headers={"kid": "test"})
+            monkeypatch.setattr("httpx.post", lambda *a, **k: SimpleNamespace(
+                status_code=200, json=lambda: {"id_token": id_token}))
+            monkeypatch.setattr(m, "_oidc_jwks", lambda: SimpleNamespace(
+                get_signing_key_from_jwt=lambda t: SimpleNamespace(key=priv.public_key())))
+            resp = c.get(f"/api/auth/oidc/callback?code=abc&state={st['state']}",
+                         cookies={"oidc_state": state_cookie}, follow_redirects=False)
+            assert "error=account_conflict" in resp.headers["location"]
+            assert not resp.cookies.get("access_token"), "must NOT issue a session for admin"
+        # local admin row is untouched (still local, still admin)
+        with m._get_users_db() as db:
+            row = db.execute("SELECT role, auth_source FROM users WHERE username='admin'").fetchone()
+            assert row["role"] == "admin" and (row["auth_source"] or "local") == "local"
+
+    def test_full_login_flow_rejects_bad_nonce(self, app, monkeypatch):
+        """A token whose nonce doesn't match the request is rejected (replay guard)."""
+        import jwt
+        from datetime import datetime, timezone, timedelta
+        from types import SimpleNamespace
+        from cryptography.hazmat.primitives.asymmetric import rsa
+
+        m = self._enable(monkeypatch)
+        priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        with TestClient(app) as c:
+            start = c.get("/api/auth/oidc/login", follow_redirects=False)
+            state_cookie = start.cookies.get("oidc_state")
+            st = jwt.decode(state_cookie, m.JWT_SECRET, algorithms=["HS256"])
+            id_token = jwt.encode(
+                {"iss": self.ISSUER, "aud": self.CLIENT_ID,
+                 "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+                 "iat": datetime.now(timezone.utc),
+                 "preferred_username": "mallory", "nonce": "WRONG-NONCE"},
+                priv, algorithm="RS256", headers={"kid": "test"})
+            monkeypatch.setattr("httpx.post", lambda *a, **k: SimpleNamespace(
+                status_code=200, json=lambda: {"id_token": id_token}))
+            monkeypatch.setattr(m, "_oidc_jwks", lambda: SimpleNamespace(
+                get_signing_key_from_jwt=lambda t: SimpleNamespace(key=priv.public_key())))
+            resp = c.get(f"/api/auth/oidc/callback?code=abc&state={st['state']}",
+                         cookies={"oidc_state": state_cookie}, follow_redirects=False)
+            assert "error=oidc_nonce_mismatch" in resp.headers["location"]
+
+
+class _OIDCFlow:
+    """Shared OIDC flow helpers (not collected — no Test prefix), so the
+    enterprise + provider-quirk suites reuse one full-flow driver."""
+
+    ISSUER = "https://issuer.test"
+    CLIENT_ID = "client123"
+
+    def _enable(self, monkeypatch, **over):
+        m = _main_module()
+        monkeypatch.setattr(m, "OIDC_ENABLED", True)
+        monkeypatch.setattr(m, "OIDC_ISSUER", self.ISSUER)
+        monkeypatch.setattr(m, "OIDC_CLIENT_ID", self.CLIENT_ID)
+        monkeypatch.setattr(m, "OIDC_CLIENT_SECRET", "shh")
+        monkeypatch.setattr(m, "OIDC_USERNAME_CLAIM", "preferred_username")
+        monkeypatch.setattr(m, "OIDC_DEFAULT_ROLE", "viewer")
+        monkeypatch.setattr(m, "OIDC_ALLOWED_DOMAINS", [])
+        monkeypatch.setattr(m, "OIDC_ADMIN_GROUP", over.get("admin_group", ""))
+        monkeypatch.setattr(m, "OIDC_GROUPS_CLAIM", over.get("groups_claim", "groups"))
+        monkeypatch.setattr(m, "OIDC_REQUIRE_VERIFIED_EMAIL", over.get("require_verified", False))
+        monkeypatch.setattr(m, "OIDC_RP_LOGOUT", over.get("rp_logout", False))
+        cfg = {"issuer": self.ISSUER, "authorization_endpoint": f"{self.ISSUER}/authorize",
+               "token_endpoint": f"{self.ISSUER}/token", "jwks_uri": f"{self.ISSUER}/jwks"}
+        if over.get("end_session"):
+            cfg["end_session_endpoint"] = f"{self.ISSUER}/logout"
+        monkeypatch.setattr(m, "_oidc_config", lambda: cfg)
+        return m
+
+    def _login(self, app, monkeypatch, m, username, claims=None, userinfo=None):
+        """Run the full OIDC flow with a real RS256 token; return the callback response.
+
+        username=None omits preferred_username (to exercise claim fallbacks).
+        userinfo, when given, stands in for the IdP's userinfo endpoint."""
+        import jwt
+        from datetime import datetime, timezone, timedelta
+        from types import SimpleNamespace
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        priv = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+        with TestClient(app) as c:
+            start = c.get("/api/auth/oidc/login", follow_redirects=False)
+            sc = start.cookies.get("oidc_state")
+            st = jwt.decode(sc, m.JWT_SECRET, algorithms=["HS256"])
+            payload = {"iss": self.ISSUER, "aud": self.CLIENT_ID,
+                       "exp": datetime.now(timezone.utc) + timedelta(minutes=5),
+                       "iat": datetime.now(timezone.utc), "nonce": st["nonce"]}
+            if username is not None:
+                payload["preferred_username"] = username
+            payload.update(claims or {})
+            id_token = jwt.encode(payload, priv, algorithm="RS256", headers={"kid": "t"})
+            monkeypatch.setattr("httpx.post", lambda *a, **k: SimpleNamespace(
+                status_code=200, json=lambda: {"id_token": id_token, "access_token": "AT"}))
+            monkeypatch.setattr(m, "_oidc_jwks", lambda: SimpleNamespace(
+                get_signing_key_from_jwt=lambda t: SimpleNamespace(key=priv.public_key())))
+            if userinfo is not None:
+                monkeypatch.setattr(m, "_oidc_userinfo", lambda at, cfg: userinfo)
+            return c.get(f"/api/auth/oidc/callback?code=abc&state={st['state']}",
+                         cookies={"oidc_state": sc}, follow_redirects=False)
+
+    def _sub_of(self, m, token):
+        import jwt
+        return jwt.decode(token, m.JWT_SECRET, algorithms=["HS256"])["sub"]
+
+    def _role_of(self, m, token):
+        import jwt
+        return jwt.decode(token, m.JWT_SECRET, algorithms=["HS256"])["role"]
+
+
+class TestOIDCEnterprise(_OIDCFlow):
+    """Phase 2: group→role mapping, userinfo fallback, email_verified, RP-logout."""
+
+    def test_group_member_becomes_admin(self, app, monkeypatch):
+        m = self._enable(monkeypatch, admin_group="sairo-admins")
+        resp = self._login(app, monkeypatch, m, "boss", claims={"groups": ["staff", "sairo-admins"]})
+        assert resp.headers["location"] == "/"
+        assert self._role_of(m, resp.cookies.get("access_token")) == "admin"
+
+    def test_group_non_member_is_viewer(self, app, monkeypatch):
+        m = self._enable(monkeypatch, admin_group="sairo-admins")
+        resp = self._login(app, monkeypatch, m, "peon", claims={"groups": ["staff"]})
+        assert self._role_of(m, resp.cookies.get("access_token")) == "viewer"
+
+    def test_group_keycloak_slash_prefix_matches(self, app, monkeypatch):
+        m = self._enable(monkeypatch, admin_group="sairo-admins")
+        resp = self._login(app, monkeypatch, m, "kcadmin", claims={"groups": ["/sairo-admins"]})
+        assert self._role_of(m, resp.cookies.get("access_token")) == "admin"
+
+    def test_requires_verified_email(self, app, monkeypatch):
+        m = self._enable(monkeypatch, require_verified=True)
+        resp = self._login(app, monkeypatch, m, "unverified",
+                           claims={"email": "u@corp.test", "email_verified": False})
+        assert "error=email_not_verified" in resp.headers["location"]
+        assert not resp.cookies.get("access_token")
+
+    def test_rp_logout_returns_idp_url_for_oidc_user(self, app, monkeypatch):
+        m = self._enable(monkeypatch, rp_logout=True, end_session=True)
+        login = self._login(app, monkeypatch, m, "logme")
+        session = login.cookies.get("access_token")
+        with TestClient(app) as c:
+            out = c.post("/api/auth/logout", cookies={"access_token": session}).json()
+        assert out["logged_out"] is True
+        assert out["sso_logout_url"].startswith(f"{self.ISSUER}/logout")
+        assert "post_logout_redirect_uri=" in out["sso_logout_url"]
+
+    def test_rp_logout_none_for_local_user(self, app, monkeypatch, client, admin_cookies):
+        self._enable(monkeypatch, rp_logout=True, end_session=True)
+        out = client.post("/api/auth/logout", cookies=admin_cookies).json()
+        assert out["sso_logout_url"] is None  # local admin is not an OIDC session
+
+
+class TestOIDCProviderQuirks(_OIDCFlow):
+    """Cross-provider claim-shape coverage. Real OIDC IdPs differ mostly in how
+    they shape claims, not crypto — these simulate the big ones so the flow is
+    validated beyond the single live Keycloak run."""
+
+    def test_auth0_namespaced_groups_and_custom_username(self, app, monkeypatch):
+        # Auth0: no preferred_username (uses nickname), custom-namespaced groups claim.
+        m = self._enable(monkeypatch, admin_group="sairo-admins",
+                         groups_claim="https://sairo.example.com/groups")
+        monkeypatch.setattr(m, "OIDC_USERNAME_CLAIM", "nickname")
+        resp = self._login(app, monkeypatch, m, username=None, claims={
+            "nickname": "auth0user",
+            "https://sairo.example.com/groups": ["sairo-admins"],
+        })
+        assert self._sub_of(m, resp.cookies.get("access_token")) == "auth0user"
+        assert self._role_of(m, resp.cookies.get("access_token")) == "admin"
+
+    def test_okta_groups_only_in_userinfo(self, app, monkeypatch):
+        # Okta/Auth0 commonly omit groups from the ID token — we must fall back to userinfo.
+        m = self._enable(monkeypatch, admin_group="Sairo-Admins")
+        resp = self._login(app, monkeypatch, m, "oktauser", claims={},
+                           userinfo={"groups": ["Everyone", "Sairo-Admins"]})
+        assert self._role_of(m, resp.cookies.get("access_token")) == "admin"
+
+    def test_entra_group_object_ids(self, app, monkeypatch):
+        # Entra ID (Azure AD) emits group object-IDs (GUIDs), not names.
+        gid = "11111111-2222-3333-4444-555555555555"
+        m = self._enable(monkeypatch, admin_group=gid)
+        resp = self._login(app, monkeypatch, m, "entrauser",
+                           claims={"groups": ["00000000-0000-0000-0000-000000000000", gid]})
+        assert self._role_of(m, resp.cookies.get("access_token")) == "admin"
+
+    def test_google_username_falls_back_to_email(self, app, monkeypatch):
+        # Google has no preferred_username/groups — username should fall back to email.
+        m = self._enable(monkeypatch)
+        resp = self._login(app, monkeypatch, m, username=None,
+                           claims={"email": "person@corp.test", "email_verified": True})
+        assert self._sub_of(m, resp.cookies.get("access_token")) == "person@corp.test"
+        assert self._role_of(m, resp.cookies.get("access_token")) == "viewer"
+
+    def test_email_only_in_userinfo_satisfies_domain_allowlist(self, app, monkeypatch):
+        # Domain allowlist must work even when the IdP puts email only in userinfo.
+        m = self._enable(monkeypatch)
+        monkeypatch.setattr(m, "OIDC_ALLOWED_DOMAINS", ["corp.test"])
+        resp = self._login(app, monkeypatch, m, "domainuser", claims={},
+                           userinfo={"email": "domainuser@corp.test"})
+        assert resp.headers["location"] == "/"
+        assert resp.cookies.get("access_token")
+
+    def test_string_groups_claim_is_tolerated(self, app, monkeypatch):
+        # Some IdPs emit a single group as a string, not a list — must not crash.
+        m = self._enable(monkeypatch, admin_group="sairo-admins")
+        resp = self._login(app, monkeypatch, m, "stringgroup", claims={"groups": "sairo-admins"})
+        assert self._role_of(m, resp.cookies.get("access_token")) == "admin"
+
+    def test_similar_group_name_does_not_grant_admin(self, app, monkeypatch):
+        # SECURITY: "sairo-admins-readonly" must NOT satisfy admin group "sairo-admins".
+        m = self._enable(monkeypatch, admin_group="sairo-admins")
+        resp = self._login(app, monkeypatch, m, "almostadmin",
+                           claims={"groups": ["sairo-admins-readonly", "staff"]})
+        assert self._role_of(m, resp.cookies.get("access_token")) == "viewer"
+
+    def test_ldap_dn_group_value_matches(self, app, monkeypatch):
+        # AD/LDAP-sourced groups arrive as DNs — match the cn value, not a substring.
+        m = self._enable(monkeypatch, admin_group="sairo-admins")
+        resp = self._login(app, monkeypatch, m, "dnuser",
+                           claims={"groups": ["cn=sairo-admins,ou=groups,dc=corp,dc=test"]})
+        assert self._role_of(m, resp.cookies.get("access_token")) == "admin"
+
+    def test_azp_mismatch_is_rejected(self, app, monkeypatch):
+        # A token whose authorized-party is a different client must be rejected.
+        m = self._enable(monkeypatch)
+        resp = self._login(app, monkeypatch, m, "azpvictim", claims={"azp": "some-other-client"})
+        assert "error=oidc_invalid_token" in resp.headers["location"]
+        assert not resp.cookies.get("access_token")
+
+
+class TestAuthSource:
+    """auth_source migration + exposure (powers the takeover guard + UI badges)."""
+
+    def test_me_reports_auth_source_for_local_admin(self, client, admin_cookies):
+        me = client.get("/api/auth/me", cookies=admin_cookies).json()
+        assert me["auth_source"] == "local"
+
+    def test_users_list_includes_auth_source_and_bucket_count(self, client, admin_cookies):
+        users = client.get("/api/auth/users", cookies=admin_cookies).json()["users"]
+        admin = next(u for u in users if u["username"] == "admin")
+        assert admin["auth_source"] == "local"
+        assert "bucket_count" in admin and isinstance(admin["bucket_count"], int)
+
+
 # ── Health Check ─────────────────────────────────────────
 
 class TestHealth:

--- a/charts/sairo/Chart.yaml
+++ b/charts/sairo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sairo-helm
 description: S3-compatible object storage browser with search, versioning, and analytics
 type: application
-version: 1.3.0
-appVersion: "3.5.0"
+version: 1.4.0
+appVersion: "3.6.0"
 keywords:
   - s3
   - object-storage

--- a/charts/sairo/templates/deployment.yaml
+++ b/charts/sairo/templates/deployment.yaml
@@ -147,6 +147,42 @@ spec:
             - name: OAUTH_ALLOWED_DOMAINS
               value: {{ .Values.oauth.allowedDomains | quote }}
             {{- end }}
+            # ── OIDC — generic OpenID Connect SSO (optional) ──
+            {{- if .Values.oidc.issuer }}
+            - name: OIDC_ISSUER
+              value: {{ .Values.oidc.issuer | quote }}
+            - name: OIDC_CLIENT_ID
+              value: {{ .Values.oidc.clientId | quote }}
+            {{- if .Values.oidc.clientSecret }}
+            - name: OIDC_CLIENT_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-secrets
+                  key: oidc-client-secret
+            {{- end }}
+            - name: OIDC_PROVIDER_NAME
+              value: {{ .Values.oidc.providerName | quote }}
+            - name: OIDC_USERNAME_CLAIM
+              value: {{ .Values.oidc.usernameClaim | quote }}
+            - name: OIDC_SCOPES
+              value: {{ .Values.oidc.scopes | quote }}
+            - name: OIDC_DEFAULT_ROLE
+              value: {{ .Values.oidc.defaultRole | quote }}
+            {{- if .Values.oidc.allowedDomains }}
+            - name: OIDC_ALLOWED_DOMAINS
+              value: {{ .Values.oidc.allowedDomains | quote }}
+            {{- end }}
+            {{- if .Values.oidc.adminGroup }}
+            - name: OIDC_ADMIN_GROUP
+              value: {{ .Values.oidc.adminGroup | quote }}
+            - name: OIDC_GROUPS_CLAIM
+              value: {{ .Values.oidc.groupsClaim | quote }}
+            {{- end }}
+            - name: OIDC_REQUIRE_VERIFIED_EMAIL
+              value: {{ .Values.oidc.requireVerifiedEmail | quote }}
+            - name: OIDC_RP_LOGOUT
+              value: {{ .Values.oidc.rpLogout | quote }}
+            {{- end }}
             # ── Branding (optional) ──
             {{- if .Values.branding.appName }}
             - name: APP_NAME

--- a/charts/sairo/templates/secrets.yaml
+++ b/charts/sairo/templates/secrets.yaml
@@ -22,3 +22,6 @@ stringData:
   {{- if .Values.oauth.github.clientSecret }}
   oauth-github-secret: {{ .Values.oauth.github.clientSecret | quote }}
   {{- end }}
+  {{- if and .Values.oidc.issuer .Values.oidc.clientSecret }}
+  oidc-client-secret: {{ .Values.oidc.clientSecret | quote }}
+  {{- end }}

--- a/charts/sairo/values.yaml
+++ b/charts/sairo/values.yaml
@@ -83,6 +83,25 @@ oauth:
   defaultRole: "viewer"
   allowedDomains: ""       # Comma-separated: "example.com,corp.com"
 
+# OIDC — generic OpenID Connect SSO (optional).
+# Enabled when issuer + clientId are set. Endpoints are auto-discovered from
+# <issuer>/.well-known/openid-configuration and the ID token is fully validated.
+# Only the username is synced; admins assign roles/bucket permissions.
+# Redirect URI to register with your provider: https://<host>/api/auth/oidc/callback
+oidc:
+  issuer: ""               # e.g. https://login.example.com/realms/main
+  clientId: ""
+  clientSecret: ""
+  providerName: "SSO"      # label on the login button
+  usernameClaim: "preferred_username"
+  scopes: "openid profile email"
+  defaultRole: "viewer"
+  allowedDomains: ""       # optional email-domain allowlist
+  adminGroup: ""           # optional: members of this group become admins (off = username-only)
+  groupsClaim: "groups"    # claim containing the user's groups
+  requireVerifiedEmail: false
+  rpLogout: false          # also end the IdP session on logout (single logout)
+
 # White-labeling (optional)
 branding:
   appName: "Sairo"

--- a/docs/SSO.md
+++ b/docs/SSO.md
@@ -1,0 +1,145 @@
+# Single Sign-On (SSO)
+
+Sairo supports three ways to sign users in through your own identity provider:
+
+- **OIDC** (OpenID Connect) — a generic client that works with any compliant provider (Keycloak, Authentik, Okta, Auth0, Entra ID, Google, Dex, Zitadel, …)
+- **OAuth** — built-in Google / GitHub
+- **LDAP** — Active Directory and other LDAP directories
+
+This guide focuses on **OIDC**, the recommended path for most providers.
+
+## The model: identity in, access assigned
+
+By design, **OIDC syncs the username only**. A user signing in for the first time is created as a **viewer with no bucket access**. An admin then grants per-bucket Read/Write under **Users → Manage access**. This keeps your identity provider as the source of *who someone is*, while Sairo stays the source of *what they can touch*. (Optional group→role mapping is available — see [Group mapping](#optional-grouprole-mapping) — but it's off by default.)
+
+## Enable it
+
+OIDC turns on when `OIDC_ISSUER` and `OIDC_CLIENT_ID` are both set. Endpoints are auto-discovered from `<issuer>/.well-known/openid-configuration`, and every ID token is fully validated (JWKS signature, `iss`/`aud`/`exp`, nonce) before any claim is trusted.
+
+| Variable | Required | Default | Notes |
+|---|---|---|---|
+| `OIDC_ISSUER` | ✅ | — | e.g. `https://login.example.com/realms/main` |
+| `OIDC_CLIENT_ID` | ✅ | — | the client/app id from your provider |
+| `OIDC_CLIENT_SECRET` | — | — | omit for a **public** client (PKCE is always used) |
+| `OIDC_PROVIDER_NAME` | — | `SSO` | label on the login button |
+| `OIDC_USERNAME_CLAIM` | — | `preferred_username` | claim used as the local username |
+| `OIDC_SCOPES` | — | `openid profile email` | |
+| `OIDC_DEFAULT_ROLE` | — | `viewer` | role for new users |
+| `OIDC_ALLOWED_DOMAINS` | — | — | comma-separated email-domain allowlist |
+| `OIDC_ADMIN_GROUP` | — | — | members become admins (enables group mapping) |
+| `OIDC_GROUPS_CLAIM` | — | `groups` | claim that carries the user's groups |
+| `OIDC_REQUIRE_VERIFIED_EMAIL` | — | `false` | reject logins whose email isn't verified |
+| `OIDC_RP_LOGOUT` | — | `false` | also end the IdP session on logout (single logout) |
+
+**Redirect URI to register with your provider:**
+```
+https://<your-sairo-host>/api/auth/oidc/callback
+```
+Use `http://localhost:8000/api/auth/oidc/callback` for local testing. Most providers require **HTTPS** redirect URIs in production (`http://localhost` is the common exception).
+
+## Reusing an existing identity provider
+
+You don't need a new IdP — point Sairo at one you already run, and **register a new client** for Sairo on it. Your users, passwords, MFA, and SSO sessions are reused; only the client registration is new. Reusing another application's *exact* client is possible (add Sairo's redirect URI to it, ensure it emits the claims you need) but not recommended — a dedicated client per app is cleaner and safer.
+
+## Per-provider setup
+
+> Validation status as of this release: **Keycloak, Authentik, and Dex are tested end-to-end** (live, in a browser). **Google** is validated against its real discovery + JWKS; **Okta / Auth0 / Entra ID** are validated at the claim-shape level. All are standards-compliant and use the same generic client.
+
+### Keycloak
+Create a client (`Clients → Create`): client type **OpenID Connect**, valid redirect URI `https://<host>/api/auth/oidc/callback`, and (for a confidential client) copy the secret from the **Credentials** tab.
+```
+OIDC_ISSUER=https://<keycloak>/realms/<realm>
+OIDC_CLIENT_ID=sairo
+OIDC_CLIENT_SECRET=<from Credentials tab>
+OIDC_PROVIDER_NAME=Keycloak
+```
+For group mapping, add a **Group Membership** mapper (claim name `groups`) to the client and set `OIDC_ADMIN_GROUP`.
+
+### Authentik
+`Applications → Providers → Create → OAuth2/OpenID Provider`. Set the redirect URI, pick a signing key, then create an Application bound to that provider.
+```
+OIDC_ISSUER=https://<authentik>/application/o/<app-slug>/
+OIDC_CLIENT_ID=<provider client id>
+OIDC_CLIENT_SECRET=<provider client secret>
+OIDC_PROVIDER_NAME=Authentik
+```
+
+### Okta
+`Applications → Create App Integration → OIDC → Web Application`. Add the sign-in redirect URI.
+```
+OIDC_ISSUER=https://<your-org>.okta.com         # or https://<org>.okta.com/oauth2/<authz-server>
+OIDC_CLIENT_ID=<client id>
+OIDC_CLIENT_SECRET=<client secret>
+OIDC_PROVIDER_NAME=Okta
+```
+Okta often delivers groups via **userinfo** — Sairo fetches it automatically. Add a "groups" claim to enable group mapping.
+
+### Auth0
+Create a **Regular Web Application**, add the callback URL.
+```
+OIDC_ISSUER=https://<tenant>.us.auth0.com/
+OIDC_CLIENT_ID=<client id>
+OIDC_CLIENT_SECRET=<client secret>
+OIDC_USERNAME_CLAIM=nickname             # Auth0 has no preferred_username
+OIDC_PROVIDER_NAME=Auth0
+```
+Auth0 custom/group claims are usually **namespaced** (e.g. `https://your-app/groups`) — set `OIDC_GROUPS_CLAIM` to that full URL if you use group mapping.
+
+### Microsoft Entra ID (Azure AD)
+Register an app, add a Web redirect URI, create a client secret.
+```
+OIDC_ISSUER=https://login.microsoftonline.com/<tenant-id>/v2.0
+OIDC_CLIENT_ID=<application (client) id>
+OIDC_CLIENT_SECRET=<client secret>
+OIDC_PROVIDER_NAME=Microsoft
+```
+Entra emits groups as **object IDs (GUIDs)** — set `OIDC_ADMIN_GROUP` to the admin group's GUID. Add a groups claim to the token configuration.
+
+### Google
+Create an **OAuth client ID** (type: Web application) in the Google Cloud Console and add the redirect URI.
+```
+OIDC_ISSUER=https://accounts.google.com
+OIDC_CLIENT_ID=<client id>
+OIDC_CLIENT_SECRET=<client secret>
+OIDC_USERNAME_CLAIM=email                # Google has no username concept
+OIDC_SCOPES=openid email profile
+OIDC_PROVIDER_NAME=Google
+# optional — lock to a Workspace domain:
+OIDC_ALLOWED_DOMAINS=yourcompany.com
+```
+Plain Google OIDC does not emit groups, so group→role mapping doesn't apply — use the default username-only model and assign access in Sairo.
+
+### Dex
+Add a `staticClient` with the redirect URI in your Dex config.
+```
+OIDC_ISSUER=https://<dex-host>/dex
+OIDC_CLIENT_ID=sairo
+OIDC_CLIENT_SECRET=<staticClient secret>
+OIDC_USERNAME_CLAIM=name
+OIDC_PROVIDER_NAME=Dex
+```
+
+## Optional: group→role mapping
+
+Off by default (username-only). When you set `OIDC_ADMIN_GROUP`, members of that group become **admins** and everyone else gets `OIDC_DEFAULT_ROLE` — re-evaluated on **every** login, so removing someone from the group demotes them next time. Matching is on the whole group value or a delimited component (path segment / DN `cn=`), never a loose substring, so `sairo-admins` will **not** match `sairo-admins-readonly`.
+
+## Optional: single logout
+
+With `OIDC_RP_LOGOUT=true`, logging out of Sairo also ends the session at your identity provider (RP-initiated logout via the provider's `end_session_endpoint`).
+
+## Helm
+
+The chart exposes all of the above under `oidc:` in `values.yaml` (the client secret is stored in the release Secret). See [`charts/sairo/values.yaml`](../charts/sairo/values.yaml).
+
+## Troubleshooting
+
+If sign-in fails, the login page shows a friendly message and the URL carries an `?error=` code:
+
+| Code | Meaning / fix |
+|---|---|
+| `account_conflict` | The username already exists with a different sign-in method (e.g. a local account). Reconcile the account; SSO won't take over an account from another source. |
+| `oidc_invalid_token` | The ID token failed validation (signature/`iss`/`aud`/`azp`). Check the issuer + client id. |
+| `oidc_state_mismatch` / `oidc_nonce_mismatch` | The sign-in session expired or cookies were dropped. Retry; ensure cookies aren't blocked. |
+| `oidc_no_username` | The provider didn't return a username claim — set `OIDC_USERNAME_CLAIM` to one it does send (e.g. `email`). |
+| `email_not_verified` | `OIDC_REQUIRE_VERIFIED_EMAIL=true` and the provider reports the email unverified. |
+| `domain_not_allowed` | The email domain isn't in `OIDC_ALLOWED_DOMAINS`. |

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sairo",
-  "version": "3.5.0",
+  "version": "3.6.0",
   "description": "S3-compatible object storage browser with search, versioning, and analytics",
   "private": true,
   "type": "module",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -208,12 +208,14 @@ function MainApp() {
   }, []);
 
   const handleLogout = useCallback(async () => {
-    await logout();
+    const ssoLogoutUrl = await logout();
     setUser(null);
     setBucket("");
     setPrefix("");
     setEndpointId("default");
     setCurrentEndpoint("default");
+    // Complete single logout at the identity provider if one was returned.
+    if (ssoLogoutUrl) window.location.href = ssoLogoutUrl;
   }, []);
 
   const navigatePrefix = useCallback((pfx, hl) => {

--- a/frontend/src/auth.js
+++ b/frontend/src/auth.js
@@ -31,7 +31,15 @@ export async function login(username, password) {
 }
 
 export async function logout() {
-  await fetch(`${BASE}/logout`, { method: "POST" });
+  // Returns an SSO end-session URL when the session is an OIDC one and
+  // RP-initiated logout is enabled, so the caller can complete a single logout.
+  try {
+    const res = await fetch(`${BASE}/logout`, { method: "POST" });
+    const data = await res.json().catch(() => ({}));
+    return data.sso_logout_url || null;
+  } catch {
+    return null;
+  }
 }
 
 export async function loginS3(accessKey, secretKey) {

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -2,6 +2,21 @@ import React, { useState, useEffect } from "react";
 import { login, loginLdap, loginS3 } from "../auth";
 import { verify2FA, recover2FA } from "../api";
 
+// Friendly messages for the ?error=… codes the SSO callbacks redirect with.
+const SSO_ERRORS = {
+  account_conflict: "That username already has a local or different sign-in method. Ask an admin to reconcile the account.",
+  oidc_invalid_token: "Your identity provider returned a token we couldn't verify. Please try again.",
+  oidc_state_mismatch: "Your sign-in session expired or didn't match. Please try again.",
+  oidc_nonce_mismatch: "Your sign-in session couldn't be verified. Please try again.",
+  oidc_no_id_token: "Your identity provider didn't return an ID token. Check the client configuration.",
+  oidc_no_username: "Your identity provider didn't supply a username claim.",
+  oidc_failed: "Single sign-on failed. Please try again or contact your administrator.",
+  email_not_verified: "Your email isn't verified with the identity provider yet.",
+  domain_not_allowed: "Your email domain isn't allowed to sign in here.",
+  oauth_failed: "Sign-in with that provider failed. Please try again.",
+  domain_not_allowed_oauth: "Your email domain isn't allowed to sign in here.",
+};
+
 const FEATURES = [
   { icon: "\uD83D\uDD0D", title: "Full-text Search", desc: "Find any file across all your buckets instantly" },
   { icon: "\uD83D\uDCC4", title: "File Preview", desc: "Preview images, PDFs, text, CSV, JSON, and Parquet schemas" },
@@ -28,12 +43,18 @@ export default function Login({ onLogin, branding = {} }) {
   const loginMessage = branding.login_message;
   const oauthProviders = branding.oauth_providers || [];
 
-  // Check URL params for OAuth 2FA redirect
+  // Check URL params for SSO redirect outcomes (2FA handoff or an error).
   useEffect(() => {
     const params = new URLSearchParams(window.location.search);
     if (params.get("requires_2fa") === "true") {
       setNeeds2FA(true);
-      setUsername("(OAuth)");
+      setUsername("(SSO)");
+      window.history.replaceState({}, "", "/");
+      return;
+    }
+    const err = params.get("error");
+    if (err) {
+      setError(SSO_ERRORS[err] || "Sign-in failed. Please try again or contact your administrator.");
       window.history.replaceState({}, "", "/");
     }
   }, []);
@@ -219,9 +240,10 @@ export default function Login({ onLogin, branding = {} }) {
           {oauthProviders.length > 0 && (
             <div className="login-oauth-buttons">
               {oauthProviders.map(p => (
-                <a key={p.id} href={`/api/auth/oauth/${p.id}/login`} className="btn-oauth">
+                <a key={p.id} href={p.login_path || `/api/auth/oauth/${p.id}/login`} className="btn-oauth">
                   {p.id === "google" && <svg viewBox="0 0 24 24" width="18" height="18"><path fill="#4285F4" d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"/><path fill="#34A853" d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"/><path fill="#FBBC05" d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"/><path fill="#EA4335" d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"/></svg>}
                   {p.id === "github" && <svg viewBox="0 0 24 24" width="18" height="18"><path fill="currentColor" d="M12 2C6.477 2 2 6.477 2 12c0 4.42 2.865 8.17 6.839 9.49.5.092.682-.217.682-.482 0-.237-.008-.866-.013-1.7-2.782.604-3.369-1.34-3.369-1.34-.454-1.156-1.11-1.464-1.11-1.464-.908-.62.069-.608.069-.608 1.003.07 1.531 1.03 1.531 1.03.892 1.529 2.341 1.087 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.11-4.555-4.943 0-1.091.39-1.984 1.029-2.683-.103-.253-.446-1.27.098-2.647 0 0 .84-.269 2.75 1.025A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.294 2.747-1.025 2.747-1.025.546 1.377.203 2.394.1 2.647.64.699 1.028 1.592 1.028 2.683 0 3.842-2.339 4.687-4.566 4.935.359.309.678.919.678 1.852 0 1.336-.012 2.415-.012 2.743 0 .267.18.578.688.48C19.138 20.167 22 16.418 22 12c0-5.523-4.477-10-10-10z"/></svg>}
+                  {p.id === "oidc" && <svg viewBox="0 0 24 24" width="18" height="18" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M21 2l-2 2m-7.61 7.61a5.5 5.5 0 1 1-7.778 7.778 5.5 5.5 0 0 1 7.777-7.777zm0 0L15.5 7.5m0 0l3 3L22 7l-3-3m-3.5 3.5L19 4"/></svg>}
                   Sign in with {p.name}
                 </a>
               ))}

--- a/frontend/src/components/UserManager.jsx
+++ b/frontend/src/components/UserManager.jsx
@@ -2,6 +2,18 @@ import React, { useState, useEffect } from "react";
 import { listUsers, createUser, updateUserRole, deleteUser, formatDate, getUserPermissions, setUserPermissions, listBuckets, reset2FA } from "../api";
 import ConfirmDialog from "./ConfirmDialog";
 
+// How each account authenticates — shown as a badge so admins can tell local
+// accounts apart from SSO/LDAP ones at a glance.
+const SOURCE_META = {
+  local: { label: "Local", cls: "src-local" },
+  oidc: { label: "SSO", cls: "src-sso" },
+  oauth: { label: "OAuth", cls: "src-oauth" },
+  oauth_google: { label: "Google", cls: "src-oauth" },
+  oauth_github: { label: "GitHub", cls: "src-oauth" },
+  ldap: { label: "LDAP", cls: "src-ldap" },
+};
+const sourceMeta = (s) => SOURCE_META[s] || SOURCE_META.local;
+
 export default function UserManager({ onClose, currentUser }) {
   const [users, setUsers] = useState([]);
   const [loading, setLoading] = useState(true);
@@ -16,6 +28,8 @@ export default function UserManager({ onClose, currentUser }) {
   const [allBuckets, setAllBuckets] = useState([]);
   const [userPerms, setUserPerms] = useState({}); // { bucket: "read"|"write" }
   const [permsLoading, setPermsLoading] = useState(false);
+  const [permSearch, setPermSearch] = useState("");
+  const [savedFlash, setSavedFlash] = useState(false);
 
   const load = async () => {
     setLoading(true);
@@ -80,6 +94,7 @@ export default function UserManager({ onClose, currentUser }) {
       return;
     }
     setExpandedUser(username);
+    setPermSearch("");
     setPermsLoading(true);
     setError("");
     try {
@@ -99,23 +114,36 @@ export default function UserManager({ onClose, currentUser }) {
     setPermsLoading(false);
   };
 
-  const handlePermChange = async (username, bucket, value) => {
-    setError("");
-    const updated = { ...userPerms };
-    if (value === "none") {
-      delete updated[bucket];
-    } else {
-      updated[bucket] = value;
-    }
-    setUserPerms(updated);
-    // Save all permissions
+  // Persist the whole permission map, then reflect the new grant count on the
+  // row and flash a "Saved" indicator.
+  const persistPerms = async (username, nextMap) => {
+    setUserPerms(nextMap);
     try {
-      const permissions = Object.entries(updated).map(([b, p]) => ({ bucket: b, permission: p }));
+      const permissions = Object.entries(nextMap).map(([b, p]) => ({ bucket: b, permission: p }));
       await setUserPermissions(username, permissions);
+      setUsers(prev => prev.map(u => u.username === username ? { ...u, bucket_count: permissions.length } : u));
+      setSavedFlash(true);
+      setTimeout(() => setSavedFlash(false), 1200);
     } catch (err) {
       setError(err.message);
     }
   };
+
+  const handlePermChange = (username, bucket, value) => {
+    setError("");
+    const updated = { ...userPerms };
+    if (value === "none") delete updated[bucket];
+    else updated[bucket] = value;
+    persistPerms(username, updated);
+  };
+
+  // Quick actions. "Grant read to all" keeps any existing write grants.
+  const grantReadAll = (username) => {
+    const m = {};
+    allBuckets.forEach(b => { m[b] = userPerms[b] === "write" ? "write" : "read"; });
+    persistPerms(username, m);
+  };
+  const revokeAll = (username) => persistPerms(username, {});
 
   return (
     <div className="modal-overlay" onClick={onClose}>
@@ -164,6 +192,7 @@ export default function UserManager({ onClose, currentUser }) {
                   <th>Username</th>
                   <th>Role</th>
                   <th>2FA</th>
+                  <th>Access</th>
                   <th>Created</th>
                   <th></th>
                 </tr>
@@ -179,6 +208,7 @@ export default function UserManager({ onClose, currentUser }) {
                       <td style={{ fontWeight: 500 }}>
                         {u.username}
                         {isSelf(u.username) && <span className="user-you-badge">you</span>}
+                        <span className={`src-badge ${sourceMeta(u.auth_source).cls}`}>{sourceMeta(u.auth_source).label}</span>
                       </td>
                       <td onClick={(e) => e.stopPropagation()}>
                         {isSelf(u.username) ? (
@@ -206,39 +236,84 @@ export default function UserManager({ onClose, currentUser }) {
                           <span className="tfa-badge tfa-badge-off">OFF</span>
                         )}
                       </td>
+                      <td onClick={(e) => e.stopPropagation()} style={{ fontSize: 12 }}>
+                        {u.role === "admin" ? (
+                          <span className="muted">All buckets</span>
+                        ) : (
+                          <button
+                            className={`access-pill ${expandedUser === u.username ? "access-pill-open" : ""}`}
+                            onClick={() => !isSelf(u.username) && togglePermissions(u.username)}
+                            disabled={isSelf(u.username)}
+                            title="Manage bucket access"
+                          >
+                            {(u.bucket_count || 0)} bucket{(u.bucket_count || 0) === 1 ? "" : "s"}
+                          </button>
+                        )}
+                      </td>
                       <td style={{ fontSize: 12 }}>{formatDate(u.created_at)}</td>
                       <td onClick={(e) => e.stopPropagation()}>
-                        {!isSelf(u.username) && (
-                          <button onClick={() => setConfirmDelete(u)} className="btn-small btn-danger">Delete</button>
-                        )}
+                        <div className="user-row-actions">
+                          {u.role !== "admin" && !isSelf(u.username) && (
+                            <button onClick={() => togglePermissions(u.username)} className="btn-small">
+                              {expandedUser === u.username ? "Done" : "Manage access"}
+                            </button>
+                          )}
+                          {!isSelf(u.username) && (
+                            <button onClick={() => setConfirmDelete(u)} className="btn-small btn-danger">Delete</button>
+                          )}
+                        </div>
                       </td>
                     </tr>
                     {expandedUser === u.username && u.role !== "admin" && (
                       <tr>
-                        <td colSpan={5} style={{ padding: 0 }}>
+                        <td colSpan={6} style={{ padding: 0 }}>
                           <div className="perm-panel">
-                            <div className="perm-header">Bucket Permissions</div>
+                            <div className="perm-panel-head">
+                              <strong>Bucket access for {u.username}</strong>
+                              <span className={`perm-saved ${savedFlash ? "perm-saved-on" : ""}`}>Saved ✓</span>
+                              <div className="perm-quick">
+                                <button className="btn-xs" onClick={() => grantReadAll(u.username)} disabled={allBuckets.length === 0}>Grant read to all</button>
+                                <button className="btn-xs" onClick={() => revokeAll(u.username)} disabled={Object.keys(userPerms).length === 0}>Revoke all</button>
+                              </div>
+                            </div>
                             {permsLoading ? (
                               <div className="empty"><div className="spinner" /></div>
                             ) : allBuckets.length === 0 ? (
-                              <p className="muted" style={{ margin: "8px 12px" }}>No buckets available.</p>
+                              <p className="muted" style={{ margin: "8px 12px" }}>No buckets available to grant.</p>
                             ) : (
-                              <div className="perm-grid">
-                                {allBuckets.map(bucket => (
-                                  <div key={bucket} className="perm-row">
-                                    <span className="perm-bucket">{bucket}</span>
-                                    <select
-                                      value={userPerms[bucket] || "none"}
-                                      onChange={(e) => handlePermChange(u.username, bucket, e.target.value)}
-                                      className="perm-select"
-                                    >
-                                      <option value="none">No Access</option>
-                                      <option value="read">Read</option>
-                                      <option value="write">Write</option>
-                                    </select>
-                                  </div>
-                                ))}
-                              </div>
+                              <>
+                                {allBuckets.length > 6 && (
+                                  <input
+                                    className="perm-search"
+                                    placeholder="Filter buckets…"
+                                    value={permSearch}
+                                    onChange={(e) => setPermSearch(e.target.value)}
+                                  />
+                                )}
+                                <div className="perm-grid">
+                                  {allBuckets
+                                    .filter(b => b.toLowerCase().includes(permSearch.toLowerCase()))
+                                    .map(bucket => {
+                                      const cur = userPerms[bucket] || "none";
+                                      return (
+                                        <div key={bucket} className="perm-row">
+                                          <span className="perm-bucket">{bucket}</span>
+                                          <div className="perm-seg" role="group" aria-label={`Access for ${bucket}`}>
+                                            {["none", "read", "write"].map(level => (
+                                              <button
+                                                key={level}
+                                                className={`perm-seg-btn ${cur === level ? "perm-seg-active perm-seg-" + level : ""}`}
+                                                onClick={() => handlePermChange(u.username, bucket, level)}
+                                              >
+                                                {level === "none" ? "No access" : level === "read" ? "Read" : "Write"}
+                                              </button>
+                                            ))}
+                                          </div>
+                                        </div>
+                                      );
+                                    })}
+                                </div>
+                              </>
                             )}
                           </div>
                         </td>
@@ -252,7 +327,7 @@ export default function UserManager({ onClose, currentUser }) {
         )}
 
         <p className="muted" style={{ fontSize: 12, margin: "8px 0 0" }}>
-          <strong>Admin</strong> = full access to all buckets. <strong>Viewer</strong> = click a row to assign per-bucket permissions (Read / Write / No Access).
+          <strong>Admin</strong> = full access to all buckets. <strong>Viewer</strong> = use <strong>Manage access</strong> to grant specific buckets (Read / Write). SSO &amp; LDAP users sign in through your identity provider; you assign their bucket access here.
         </p>
 
         <div className="modal-actions">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3051,6 +3051,94 @@ button.btn-danger:disabled { background: var(--bg-surface); }
   margin-left: 12px;
 }
 
+/* ── Auth-source badge (user list) ──────────────────────── */
+.src-badge {
+  display: inline-block;
+  margin-left: 8px;
+  padding: 1px 7px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  border-radius: 999px;
+  vertical-align: middle;
+  border: 1px solid transparent;
+}
+.src-local { background: var(--bg-secondary); color: var(--text-muted); border-color: var(--border); }
+.src-sso   { background: var(--primary-light); color: var(--primary); border-color: var(--primary-ring); }
+.src-oauth { background: var(--primary-light); color: var(--primary); border-color: var(--primary-ring); }
+.src-ldap  { background: #f5f0ff; color: #6d28d9; border-color: #ddd0fb; }
+[data-theme="dark"] .src-ldap { background: #1e1633; color: #c4b5fd; border-color: #4c1d95; }
+
+/* ── Access pill + row actions ──────────────────────────── */
+.user-row-actions { display: inline-flex; gap: 6px; }
+.access-pill {
+  padding: 2px 10px;
+  font-size: 12px;
+  font-weight: 600;
+  border: 1px solid var(--border-input);
+  border-radius: 999px;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  cursor: pointer;
+}
+.access-pill:hover:not(:disabled) { border-color: var(--primary); color: var(--primary); }
+.access-pill:disabled { cursor: default; opacity: 0.6; }
+.access-pill-open { background: var(--primary-light); color: var(--primary); border-color: var(--primary-ring); }
+
+/* ── Permission editor (polished) ───────────────────────── */
+.perm-panel-head {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  margin-bottom: 10px;
+  font-size: 13px;
+}
+.perm-quick { margin-left: auto; display: inline-flex; gap: 6px; }
+.perm-saved {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--success, #16a34a);
+  opacity: 0;
+  transition: opacity 0.2s;
+}
+.perm-saved-on { opacity: 1; }
+.perm-search {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 10px;
+  margin-bottom: 8px;
+  border: 1px solid var(--border-input);
+  border-radius: var(--radius-sm);
+  background: var(--bg-input);
+  color: var(--text);
+  font-size: 13px;
+}
+.perm-seg {
+  display: inline-flex;
+  margin-left: 12px;
+  border: 1px solid var(--border-input);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+.perm-seg-btn {
+  padding: 4px 12px;
+  font-size: 12px;
+  font-weight: 500;
+  background: var(--bg-input);
+  color: var(--text-secondary);
+  border: none;
+  border-left: 1px solid var(--border-input);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.perm-seg-btn:first-child { border-left: none; }
+.perm-seg-btn:hover { background: var(--bg-hover); }
+.perm-seg-active { color: #fff; }
+.perm-seg-active.perm-seg-none  { background: var(--text-light); }
+.perm-seg-active.perm-seg-read  { background: var(--primary); }
+.perm-seg-active.perm-seg-write { background: #d97706; }
+
 /* ── Lifecycle Rule Builder ─────────────────────────────── */
 .lc-warning {
   background: var(--danger-bg);

--- a/website/src/content/docs/reference/changelog.mdx
+++ b/website/src/content/docs/reference/changelog.mdx
@@ -13,6 +13,15 @@ Each version release produces all three artifacts from the same `v*` tag:
 
 ---
 
+## Unreleased
+
+**OpenID Connect SSO + a real per-bucket access UI** (issue #9)
+
+- **Generic OIDC single sign-on** — works with any compliant provider (Keycloak, Authentik, Okta, Auth0, Microsoft Entra ID, Google, Dex, …). Auto-discovers endpoints, fully validates the ID token (JWKS signature, `iss`/`aud`/`exp`/`azp`, nonce), and protects the flow with state + nonce + PKCE. Only the **username** is synced — new users are viewers with no access until an admin grants it. Confidential or public client. See [SSO setup](/security/oauth-ldap/).
+- **Optional** group→role mapping, verified-email and email-domain restrictions, and RP-initiated single logout — all opt-in.
+- **Per-bucket access management UI** — auth-source badges (Local / SSO / LDAP / OAuth), a bucket-grant count, and a **Manage access** editor (Read / Write / No Access, with search and bulk grant/revoke).
+- **Security:** federated logins (OIDC/OAuth/LDAP) now go through one hardened path that **cannot take over an account owned by a different auth source** — notably the local admin. An `auth_source` is tracked per user.
+
 ## v3.5.0
 
 **Anonymous telemetry schema v2** — richer, still privacy-first

--- a/website/src/content/docs/reference/changelog.mdx
+++ b/website/src/content/docs/reference/changelog.mdx
@@ -13,7 +13,7 @@ Each version release produces all three artifacts from the same `v*` tag:
 
 ---
 
-## Unreleased
+## v3.6.0
 
 **OpenID Connect SSO + a real per-bucket access UI** (issue #9)
 

--- a/website/src/content/docs/reference/environment-variables.mdx
+++ b/website/src/content/docs/reference/environment-variables.mdx
@@ -81,6 +81,25 @@ These bound how the incremental delta crawler discovers new data on large bucket
 | `OAUTH_DEFAULT_ROLE` | `viewer` | Default role for OAuth-provisioned users |
 | `OAUTH_ALLOWED_DOMAINS` | _(none)_ | Comma-separated list of allowed email domains for Google OAuth |
 
+## OIDC (OpenID Connect)
+
+Generic OIDC SSO for any compliant provider. Enabled when `OIDC_ISSUER` and `OIDC_CLIENT_ID` are both set. See [OAuth, OIDC & LDAP](/security/oauth-ldap/) for per-provider setup.
+
+| Variable | Default | Description |
+|---|---|---|
+| `OIDC_ISSUER` | _(none)_ | Issuer URL, e.g. `https://login.example.com/realms/main`. Endpoints are auto-discovered from `<issuer>/.well-known/openid-configuration` |
+| `OIDC_CLIENT_ID` | _(none)_ | Client/application ID from your provider |
+| `OIDC_CLIENT_SECRET` | _(none)_ | Client secret. Omit for a **public** client (PKCE is always used) |
+| `OIDC_PROVIDER_NAME` | `SSO` | Label on the login button |
+| `OIDC_USERNAME_CLAIM` | `preferred_username` | Claim used as the local username (e.g. `email` for Google) |
+| `OIDC_SCOPES` | `openid profile email` | Requested scopes |
+| `OIDC_DEFAULT_ROLE` | `viewer` | Role for new users (they get no bucket access until an admin grants it) |
+| `OIDC_ALLOWED_DOMAINS` | _(none)_ | Comma-separated email-domain allowlist |
+| `OIDC_ADMIN_GROUP` | _(none)_ | If set, members of this group become admins (enables group→role mapping) |
+| `OIDC_GROUPS_CLAIM` | `groups` | Claim that carries the user's groups |
+| `OIDC_REQUIRE_VERIFIED_EMAIL` | `false` | Reject logins whose email isn't verified |
+| `OIDC_RP_LOGOUT` | `false` | Also end the IdP session on logout (single logout) |
+
 ## Branding
 
 | Variable | Default | Description |

--- a/website/src/content/docs/security/oauth-ldap.mdx
+++ b/website/src/content/docs/security/oauth-ldap.mdx
@@ -1,11 +1,96 @@
 ---
-title: "OAuth & LDAP"
-description: "Configuring Google OAuth, GitHub OAuth, and LDAP authentication for Sairo."
+title: "SSO: OAuth, OIDC & LDAP"
+description: "Configuring OpenID Connect (OIDC), Google/GitHub OAuth, and LDAP single sign-on for Sairo."
 ---
 
-Sairo supports external authentication via Google OAuth, GitHub OAuth, and LDAP. Users authenticated through external providers are auto-provisioned on first login.
+Sairo supports external authentication via generic **OpenID Connect (OIDC)**, built-in **Google/GitHub OAuth**, and **LDAP**. Users authenticated through external providers are auto-provisioned on first login.
+
+For most providers, **OIDC is the recommended path** — it works with any compliant identity provider and validates tokens properly.
+
+## OIDC (OpenID Connect)
+
+A standards-compliant OIDC client that works with **any** provider — Keycloak, Authentik, Okta, Auth0, Microsoft Entra ID, Google, Dex, Zitadel, and more. Endpoints are auto-discovered from `<issuer>/.well-known/openid-configuration`, and every ID token is fully validated (JWKS signature, `iss` / `aud` / `exp` / `azp`, nonce). The flow is protected with **state + nonce + PKCE (S256)**, so a confidential *or* public (secretless) client both work.
+
+### The model: identity in, access assigned
+
+OIDC **syncs the username only**. A first-time user is created as a **viewer with no bucket access**; an admin then grants per-bucket Read/Write under **Users → Manage access** (see [User Management](/security/user-management/)). Optional group→role mapping is available but off by default.
+
+### Setup
+
+1. Register a new client/application on your identity provider.
+2. Add the redirect URI: `https://your-domain/api/auth/oidc/callback` (`http://localhost:8000/...` works for local testing).
+3. Set the environment variables:
+
+```yaml
+environment:
+  OIDC_ISSUER: "https://login.example.com/realms/main"
+  OIDC_CLIENT_ID: "sairo"
+  OIDC_CLIENT_SECRET: "your-client-secret"   # omit for a public client
+  OIDC_PROVIDER_NAME: "Company SSO"          # label on the login button
+```
+
+You can point Sairo at an identity provider you already run — just register a **new client** for Sairo on it; your users, passwords, MFA, and SSO sessions are reused.
+
+### Provider examples
+
+**Keycloak**
+
+```yaml
+OIDC_ISSUER: "https://keycloak.example.com/realms/main"
+OIDC_CLIENT_ID: "sairo"
+OIDC_CLIENT_SECRET: "..."
+```
+
+**Okta**
+
+```yaml
+OIDC_ISSUER: "https://your-org.okta.com"
+OIDC_CLIENT_ID: "..."
+OIDC_CLIENT_SECRET: "..."
+```
+
+**Auth0** (no `preferred_username`; group claims are namespaced)
+
+```yaml
+OIDC_ISSUER: "https://your-tenant.us.auth0.com/"
+OIDC_CLIENT_ID: "..."
+OIDC_CLIENT_SECRET: "..."
+OIDC_USERNAME_CLAIM: "nickname"
+```
+
+**Microsoft Entra ID** (groups are object-ID GUIDs)
+
+```yaml
+OIDC_ISSUER: "https://login.microsoftonline.com/<tenant-id>/v2.0"
+OIDC_CLIENT_ID: "..."
+OIDC_CLIENT_SECRET: "..."
+```
+
+**Google** (no username concept; use email)
+
+```yaml
+OIDC_ISSUER: "https://accounts.google.com"
+OIDC_CLIENT_ID: "...apps.googleusercontent.com"
+OIDC_CLIENT_SECRET: "..."
+OIDC_USERNAME_CLAIM: "email"
+OIDC_ALLOWED_DOMAINS: "yourcompany.com"
+```
+
+### Optional: group → role mapping
+
+Off by default (username-only). Set `OIDC_ADMIN_GROUP` (and `OIDC_GROUPS_CLAIM`, default `groups`) to map admin-group membership to the admin role — re-evaluated on every login. Matching is on the whole group value or a delimited component (path segment / DN), never a loose substring, so `sairo-admins` will not match `sairo-admins-readonly`. Plain Google OIDC does not emit groups.
+
+### Optional: single logout
+
+Set `OIDC_RP_LOGOUT: "true"` to also end the session at your identity provider when a user logs out of Sairo.
+
+### Troubleshooting
+
+Sign-in failures land back on the login page with a friendly message and an `?error=` code: `account_conflict` (username already exists with a different sign-in method), `oidc_invalid_token`, `oidc_state_mismatch` / `oidc_nonce_mismatch` (session expired / cookies blocked), `oidc_no_username` (set `OIDC_USERNAME_CLAIM`), `email_not_verified`, `domain_not_allowed`.
 
 ## Google OAuth
+
+The built-in Google integration below is a simpler, Google-specific OAuth flow. For new deployments, prefer the generic **OIDC** path above (it adds full ID-token validation and works with any provider).
 
 Google OAuth uses the OpenID Connect authorization code flow.
 

--- a/website/src/content/docs/security/user-management.mdx
+++ b/website/src/content/docs/security/user-management.mdx
@@ -63,9 +63,15 @@ Viewers have no access to any bucket by default. An admin must explicitly grant 
 
 ## Managing Permissions
 
-From the Admin Panel, click on a viewer's username to open their permission editor. You will see a list of all buckets with a dropdown for each.
+In the **Users** panel, each viewer row shows how many buckets they can access and a **Manage access** button. Click it to open the per-bucket editor, where each bucket has a **No Access / Read / Write** control that saves instantly. Use the filter box to find a bucket quickly, or **Grant read to all** / **Revoke all** for bulk changes. Admins implicitly have access to every bucket, so they have no per-bucket editor.
 
-For bulk changes, select multiple buckets and apply a permission level in one action.
+Each user row also shows an **auth-source badge** — **Local**, **SSO** (OIDC), **OAuth**, or **LDAP** — so you can tell at a glance who signs in through your identity provider.
+
+## SSO and externally-provisioned users
+
+Users who sign in via [OIDC, OAuth, or LDAP](/security/oauth-ldap/) appear here automatically on first login, created as **viewers with no bucket access**. You grant their access the same way as any local viewer — with **Manage access**. (When OIDC group→role mapping is enabled, admin-group members instead arrive as admins.)
+
+A username is bound to the auth source that created it: an SSO/OAuth/LDAP login **cannot** sign in as a username that already exists from a different source (for example, the local `admin` account), so an identity provider can't be used to take over a local account.
 
 ## Password Changes
 


### PR DESCRIPTION
Closes #9.

## What

Generic **OpenID Connect** single sign-on for any compliant provider (Keycloak, Authentik, Okta, Auth0, Microsoft Entra ID, Google, Dex, …), plus a real **per-bucket access management UI** so the issue's "admin assigns permissions" half is usable.

Per issue #9, **only the username is synced** — a first-time SSO user is created as a viewer with **no** bucket access until an admin grants it. Everything beyond that (group mapping, etc.) is opt-in and off by default.

## How it works

- **OIDC client**: auto-discovers endpoints from `<issuer>/.well-known/openid-configuration`; fully validates the ID token (JWKS signature, `iss`/`aud`/`exp`/`azp`, nonce); flow protected with **state + nonce + PKCE (S256)**. Works as a confidential **or** public (secretless) client.
- **Optional, off by default**: group→role mapping (`OIDC_ADMIN_GROUP`/`OIDC_GROUPS_CLAIM`, exact/path/DN match — never loose substring), `OIDC_REQUIRE_VERIFIED_EMAIL`, `OIDC_ALLOWED_DOMAINS`, RP-initiated single logout (`OIDC_RP_LOGOUT`).
- **User management UI**: auth-source badges (Local / SSO / LDAP / OAuth), a bucket-grant count, and a *Manage access* editor (Read / Write / No Access, with search and bulk grant/revoke).

## Security

- All federated logins (OIDC/OAuth/LDAP) now route through one hardened sync path. An `auth_source` is tracked per user (with a backfill migration), which **closes an account-takeover vector**: a federated login can no longer sign in as a username already owned by a different auth source — notably the local `admin`.

## Validation

- **Backend**: 62 tests (incl. negative cases — account takeover rejected, `azp` mismatch, similar-group-name denied, nonce mismatch).
- **Live browser e2e (Playwright)** — 18 checks: OIDC login on **Keycloak, Dex, and Authentik**; takeover rejection + error message; group→admin mapping; SSO logout; and the full UserManager UI (create, segmented editor, search, bulk grant/revoke, live access-count, role change, delete).
- **Google** validated against its real discovery document + JWKS.
- Helm chart lints clean; docs site compiles.

## Docs

`.env.example`, Helm `values`/`deployment`/`secrets`, `README`, `CHANGELOG`, new `docs/SSO.md`, and website pages (SSO, env-var reference, user-management, changelog).

## Notes / follow-ups (out of scope here)

- Okta/Auth0/Entra are validated at the claim-shape level (unit) + spec compliance; live tenant testing needs real credentials.
- The legacy Google/GitHub **OAuth** flow (separate from OIDC) still lacks state/PKCE — recommended as a follow-up to bring it to the OIDC bar.
- One pre-existing frontend test (`Login > shows LDAP toggle`) fails on `main` as well; unrelated to this change.