### PR TITLE
fix: activation metric (first_search_at) + white-label tab title (3.6.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,15 @@
 
 All notable changes to Sairo are documented here. This project uses [Semantic Versioning](https://semver.org/).
 
+## [3.6.1] - 2026-07-02
+
+Fixes for the activation metric and white-label branding.
+
+### Fixed
+
+- **Activation instrumentation: `first_search_at` was under-counted.** It recorded only *after* the search endpoint's index-ready 503 gate, while its paired milestone `first_dashboard_open_at` recorded on handler entry — so searches issued during a fresh instance's initial crawl 503'd and never registered, skewing the activation funnel toward a false zero on exactly the new-install cohort. It now records on the search *request* (symmetric with dashboard-open); `first_search_returned_results` still records on the first served search.
+- **Browser tab now follows `APP_NAME`.** White-label deployments that set `APP_NAME` showed the default "Sairo" in the browser tab title regardless; the document title now tracks the configured app name (falling back to "Sairo").
+
 ## [3.6.0] - 2026-06-29
 
 Generic OpenID Connect SSO + a real per-bucket access UI (issue #9).

--- a/backend/main.py
+++ b/backend/main.py
@@ -294,7 +294,7 @@ async def s3_error_handler(request, exc):
 
 
 _app_start_time = time.time()
-SAIRO_VERSION = "3.6.0"
+SAIRO_VERSION = "3.6.1"
 
 
 def _version_gt(a: str, b: str) -> bool:
@@ -2502,17 +2502,24 @@ def _record_milestone_once(key: str):
         pass
 
 
-def _record_first_search(returned_results: bool):
-    """Activation event: first search *served* (regardless of hit count). Also records whether
-    that first search returned any results — a free diagnostic for the index-not-ready race
-    (searched-but-zero-results before the crawl finished)."""
-    if "first_search_at" in _recorded_milestones:
+def _record_first_search():
+    """Activation event: the user reached search. Recorded on the search REQUEST — before the
+    index-ready gate — so it is symmetric with first_dashboard_open_at (which records on view
+    open). Recording it only on a served 200 response systematically under-counted fresh
+    installs whose early searches 503 during the initial crawl, manufacturing a false 0%."""
+    _record_milestone_once("first_search_at")
+
+
+def _record_search_returned(returned_results: bool):
+    """Diagnostic paired with first_search_at: did the first *served* search return any results
+    (distinguishes a genuine no-match from the index-not-ready race). Set once, on the first
+    search that actually reaches the index."""
+    if "first_search_returned_results" in _recorded_milestones:
         return
     try:
-        if not _meta_get("first_search_at"):
-            _meta_set("first_search_at", _iso_now())
+        if _meta_get("first_search_returned_results") is None:
             _meta_set("first_search_returned_results", "1" if returned_results else "0")
-        _recorded_milestones.add("first_search_at")
+        _recorded_milestones.add("first_search_returned_results")
     except Exception:
         pass
 
@@ -4771,11 +4778,14 @@ def refresh_prefix(bucket: str, prefix: str = "", user: dict = Depends(require_a
 @app.get("/api/buckets/{bucket}/search")
 @limiter.limit("60/minute")
 def search_objects(bucket: str, request: Request, q: str = Query(..., min_length=1), prefix: str = "", limit: int = 200, user: dict = Depends(get_current_user)):
+    _record_first_search()  # activation: reached search — record on the request (symmetric with
+                            # first_dashboard_open_at), BEFORE the index-ready gate, so a search
+                            # issued during the initial crawl still counts.
     if not _is_index_ready(bucket):
         raise HTTPException(503, "Index not ready — crawl in progress")
     with _get_db(bucket) as db:
         rows = _search_fts(db, q, prefix, limit)
-    _record_first_search(len(rows) > 0)  # activation milestone (fail-safe, idempotent)
+    _record_search_returned(len(rows) > 0)  # diagnostic, on the first served search
     return {"results": [dict(r) for r in rows], "count": len(rows), "query": q}
 
 

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -646,6 +646,27 @@ class TestAuthSource:
         assert "bucket_count" in admin and isinstance(admin["bucket_count"], int)
 
 
+class TestActivationMilestones:
+    """3.6.1 fix: first_search_at must record on the search REQUEST — symmetric with
+    first_dashboard_open_at — even when the index isn't ready and the search 503s. The old
+    placement (after the 503 gate) under-counted fresh installs and manufactured a false 0%."""
+
+    def test_first_search_records_even_when_index_not_ready(self, app, client, admin_cookies):
+        m = _main_module()
+        # reset any prior recording so we observe this request's effect
+        m._recorded_milestones.discard("first_search_at")
+        with m._get_users_db() as db:
+            db.execute("DELETE FROM instance_meta WHERE key='first_search_at'")
+            db.commit()
+        # a bucket with no index → the search 503s (index not ready) ...
+        resp = client.get("/api/buckets/unindexed-bucket/search",
+                          params={"q": "hello"}, cookies=admin_cookies)
+        assert resp.status_code == 503
+        # ... but the activation milestone must still have recorded (it fires before the gate)
+        assert m._meta_get("first_search_at") is not None, \
+            "first_search_at must record even when the search 503s during indexing"
+
+
 # ── Health Check ─────────────────────────────────────────
 
 class TestHealth:

--- a/charts/sairo/Chart.yaml
+++ b/charts/sairo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sairo-helm
 description: S3-compatible object storage browser with search, versioning, and analytics
 type: application
-version: 1.4.0
-appVersion: "3.6.0"
+version: 1.4.1
+appVersion: "3.6.1"
 keywords:
   - s3
   - object-storage

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sairo",
-  "version": "2.0.0",
+  "version": "3.6.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sairo",
-      "version": "2.0.0",
+      "version": "3.6.1",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.19",
         "lucide-react": "^0.575.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sairo",
-  "version": "3.6.0",
+  "version": "3.6.1",
   "description": "S3-compatible object storage browser with search, versioning, and analytics",
   "private": true,
   "type": "module",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -167,6 +167,12 @@ function MainApp() {
     getBranding().then(setBranding).catch(() => {});
   }, []);
 
+  // Keep the browser tab title in sync with the (white-label) app name, so a
+  // deployment that sets APP_NAME doesn't still read "Sairo" in the tab.
+  useEffect(() => {
+    if (branding.app_name) document.title = branding.app_name;
+  }, [branding.app_name]);
+
   // Listen for session-expired events from api.js (replaces hard page reload)
   useEffect(() => {
     const handler = () => {

--- a/website/src/content/docs/reference/changelog.mdx
+++ b/website/src/content/docs/reference/changelog.mdx
@@ -13,6 +13,13 @@ Each version release produces all three artifacts from the same `v*` tag:
 
 ---
 
+## v3.6.1
+
+**Fixes** for the activation metric and white-label branding
+
+- **`first_search_at` was under-counted** — it recorded only after the search endpoint's index-ready 503 gate, while its paired `first_dashboard_open_at` recorded on entry, so searches during a fresh instance's initial crawl never registered (false-zero activation on new installs). Now records on the search request, symmetric with dashboard-open.
+- **Browser tab title now follows `APP_NAME`** — white-label deployments no longer show "Sairo" in the tab regardless of the configured app name.
+
 ## v3.6.0
 
 **OpenID Connect SSO + a real per-bucket access UI** (issue #9)


### PR DESCRIPTION
Patch release **3.6.1** — two fixes, no features.

## Fixes

**1. `first_search_at` was under-counted (activation funnel skew).**
It recorded only *after* the search endpoint's index-ready `503` gate, while its paired milestone `first_dashboard_open_at` records on handler entry. So searches issued during a fresh instance's initial crawl `503`'d and never registered — producing a **false-zero activation rate on exactly the new-install cohort** (the observed `first_search_at = 0/N` while `first_dashboard_open_at` fired). Now records on the search **request**, symmetric with dashboard-open; `first_search_returned_results` still records on the first served search.

**2. Browser tab title ignored `APP_NAME`.**
White-label deployments that set `APP_NAME` still showed "Sairo" in the browser tab. `document.title` now follows the configured app name (falling back to "Sairo").

## Version
Bumped to **3.6.1** across backend (`SAIRO_VERSION`), Helm chart (`1.4.1` / appVersion `3.6.1`), frontend (`package.json` + lockfile), and both changelogs.

## Validation
- **Backend: 63 tests pass**, including a new test that a search which `503`s during indexing **still** records `first_search_at`.
- **Tab title verified in a real browser** (Playwright) for both `APP_NAME=Objex` → tab reads "Objex", and default → "Sairo".
- Frontend build clean; website docs compile; `helm lint` clean.

Companion to the dashboard-side actions already relayed (mature-instance residual check + reset the activation cohort clock to the 3.6.1 ship).