### PR TITLE
fix: no-cache the SPA shell so deploys aren't masked by stale browser cache (3.6.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to Sairo are documented here. This project uses [Semantic Versioning](https://semver.org/).
 
+## [3.6.3] - 2026-07-13
+
+### Fixed
+
+- **The SPA shell is no longer heuristically cached by browsers.** `index.html` and `/manifest.json` are now served with `Cache-Control: no-cache, must-revalidate`, so a new deploy is picked up on the next load instead of users being stuck on a stale cached bundle (e.g. old branding/title) until a manual hard-refresh. Hashed `/assets/*` remain long-cacheable.
+
 ## [3.6.2] - 2026-07-02
 
 White-label branding is now complete and seamless across every surface.

--- a/backend/main.py
+++ b/backend/main.py
@@ -294,7 +294,7 @@ async def s3_error_handler(request, exc):
 
 
 _app_start_time = time.time()
-SAIRO_VERSION = "3.6.2"
+SAIRO_VERSION = "3.6.3"
 
 
 def _version_gt(a: str, b: str) -> bool:
@@ -6934,6 +6934,12 @@ if os.path.isdir(static_dir):
                 _spa_cache["html"] = None
         return _spa_cache["html"]
 
+    # The SPA shell + manifest must revalidate on every load, or browsers
+    # heuristically cache them and users stay on a stale bundle after a deploy
+    # (e.g. old branding/title until a manual hard-refresh). Hashed /assets/*
+    # remain long-cacheable — only the entry documents are no-cache.
+    _NO_CACHE = {"Cache-Control": "no-cache, must-revalidate"}
+
     @app.get("/manifest.json")
     def serve_manifest():
         try:
@@ -6941,7 +6947,7 @@ if os.path.isdir(static_dir):
                 m = json.load(f)
         except Exception:
             m = {"start_url": "/", "display": "standalone"}
-        return JSONResponse(_branded_manifest(m, *_brand_name_color()))
+        return JSONResponse(_branded_manifest(m, *_brand_name_color()), headers=_NO_CACHE)
 
     @app.get("/{path:path}")
     def serve_spa(path: str):
@@ -6950,8 +6956,9 @@ if os.path.isdir(static_dir):
             raise HTTPException(403, "Forbidden")
         if os.path.isfile(file_path):
             return FileResponse(file_path)
-        # SPA entry: serve index.html with the app name/colour baked in.
+        # SPA entry: serve index.html with the app name/colour baked in, and
+        # never let the browser serve a stale shell after a deploy.
         doc = _spa_index_html()
         if doc is not None:
-            return HTMLResponse(doc)
-        return FileResponse(os.path.join(static_dir, "index.html"))
+            return HTMLResponse(doc, headers=_NO_CACHE)
+        return FileResponse(os.path.join(static_dir, "index.html"), headers=_NO_CACHE)

--- a/charts/sairo/Chart.yaml
+++ b/charts/sairo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sairo-helm
 description: S3-compatible object storage browser with search, versioning, and analytics
 type: application
-version: 1.4.2
-appVersion: "3.6.2"
+version: 1.4.3
+appVersion: "3.6.3"
 keywords:
   - s3
   - object-storage

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sairo",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sairo",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.19",
         "lucide-react": "^0.575.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sairo",
-  "version": "3.6.2",
+  "version": "3.6.3",
   "description": "S3-compatible object storage browser with search, versioning, and analytics",
   "private": true,
   "type": "module",

--- a/website/src/content/docs/reference/changelog.mdx
+++ b/website/src/content/docs/reference/changelog.mdx
@@ -13,6 +13,12 @@ Each version release produces all three artifacts from the same `v*` tag:
 
 ---
 
+## v3.6.3
+
+**Fixed** — the SPA shell is no longer heuristically cached
+
+- `index.html` and `/manifest.json` are served with `Cache-Control: no-cache, must-revalidate`, so a new deploy is picked up on the next page load rather than users being stuck on a stale cached bundle (old branding/title) until a manual hard-refresh. Hashed `/assets/*` stay long-cacheable.
+
 ## v3.6.2
 
 **White-label branding** is now complete and seamless across every surface


### PR DESCRIPTION
Patch **3.6.3**. Follow-up to the white-label work.

## Why
Prod (`objex.ingage.tech`) was correctly serving the branded HTML after 3.6.2 — `curl` confirmed `<title>Objex</title>`, `og:title=Objex`, `/api/branding→Objex`, `version=3.6.2` — yet the browser still showed "Sairo". Root cause: **`index.html` (and `/manifest.json`) are served with no `Cache-Control` header**, so browsers *heuristically* cache the SPA entry document. After any deploy, users keep loading the **old cached shell** (old static title + pre-branding JS bundle) until a manual hard-refresh.

## Fix
Serve the SPA entry documents with `Cache-Control: no-cache, must-revalidate`:
- `index.html` (both the branded `HTMLResponse` and the fallback `FileResponse`)
- `/manifest.json`

Hashed `/assets/*` are untouched (they stay long-cacheable — that's safe because their filenames change per build). Result: a new deploy is picked up on the **next page load**, no hard-refresh needed.

## Validation
Verified locally: `GET /` and `GET /manifest.json` now return `Cache-Control: no-cache, must-revalidate`; a hashed JS asset keeps default (cacheable) headers; served `<title>` still reflects `APP_NAME`. Backend 68 tests pass; website compiles.

Bumps 3.6.3 across backend, Helm chart (1.4.3), frontend (+lockfile), changelogs.