### PR TITLE
feat(s3): support public endpoint for presigned URLs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,7 +2,11 @@
 # Copy this file to .env and fill in your values
 
 # S3 Configuration (required)
+# Internal endpoint used by the Sairo backend
 S3_ENDPOINT=https://your-s3-endpoint.com
+# Optional browser-accessible endpoint used only for presigned upload/download URLs.
+# Defaults to S3_ENDPOINT when empty.
+S3_PUBLIC_ENDPOINT=
 S3_ACCESS_KEY=your-access-key
 S3_SECRET_KEY=your-secret-key
 S3_REGION=us-east-1

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Works with **AWS S3**, **MinIO**, **Ceph**, **Wasabi**, **Cloudflare R2**, **Bac
 ```bash
 docker run -d --name sairo -p 8000:8000 \
   -e S3_ENDPOINT=https://your-s3-endpoint.com \
+  -e S3_PUBLIC_ENDPOINT=https://your-browser-accessible-s3-endpoint.com \
   -e S3_ACCESS_KEY=your-access-key \
   -e S3_SECRET_KEY=your-secret-key \
   -e ADMIN_PASS=choose-a-strong-password \
@@ -128,7 +129,8 @@ Validated read-only against a live production deployment (Leaseweb S3-compatible
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `S3_ENDPOINT` | **(required)** | S3-compatible endpoint URL |
+| `S3_ENDPOINT` | **(required)** | Internal S3-compatible endpoint used by the Sairo backend |
+| `S3_PUBLIC_ENDPOINT` | `S3_ENDPOINT` | Optional browser-accessible endpoint used only to generate presigned upload/download URLs |
 | `S3_ACCESS_KEY` | (required) | S3 access key |
 | `S3_SECRET_KEY` | (required) | S3 secret key |
 | `S3_REGION` | _(empty)_ | S3 region (if required by provider) |

--- a/backend/main.py
+++ b/backend/main.py
@@ -80,8 +80,8 @@ def _csp_connect_origins():
     from urllib.parse import urlparse
     origins = set()
     try:
-        for info in list(_s3_manager._endpoints.values()):
-            p = urlparse(info.get("endpoint_url") or "")
+        for endpoint_id in list(_s3_manager._endpoints):
+            p = urlparse(_s3_manager.get_browser_endpoint_url(endpoint_id) or "")
             if p.scheme and p.netloc:
                 origins.add(f"{p.scheme}://{p.netloc}")
                 origins.add(f"{p.scheme}://*.{p.netloc}")
@@ -317,6 +317,7 @@ S3_ENDPOINT = os.environ.get("S3_ENDPOINT", "")
 if not S3_ENDPOINT:
     log.error("S3_ENDPOINT environment variable is required")
     raise SystemExit("S3_ENDPOINT environment variable is required")
+S3_PUBLIC_ENDPOINT = os.environ.get("S3_PUBLIC_ENDPOINT", "").strip() or S3_ENDPOINT
 S3_ACCESS_KEY = os.environ.get("S3_ACCESS_KEY", "")
 S3_SECRET_KEY = os.environ.get("S3_SECRET_KEY", "")
 DB_DIR = os.environ.get("DB_DIR", "/data")
@@ -394,12 +395,15 @@ _S3_CONFIG = Config(
 # ── Multi-Endpoint S3 Client Manager ──────────────────────────────────────
 
 class S3ClientManager:
-    """Thread-safe cache of boto3 S3 clients keyed by endpoint ID."""
-    def __init__(self):
+    """Thread-safe cache of internal and browser-facing S3 clients."""
+    def __init__(self, default_public_endpoint_url: str = ""):
         self._clients: dict = {}
+        self._presign_clients: dict = {}
         self._lock = threading.Lock()
         self._endpoints: dict = {}  # endpoint_id -> {endpoint_url, access_key, secret_key, region, path_style}
         self._user_clients: dict = {}  # (endpoint_id, access_key_hash) -> client (AUTH_MODE=s3, per-user creds)
+        self._user_presign_clients: dict = {}
+        self._default_public_endpoint_url = default_public_endpoint_url
 
     def register(self, endpoint_id: str, endpoint_url: str, access_key: str, secret_key: str,
                  region: str = "", path_style: bool = False):
@@ -409,15 +413,19 @@ class S3ClientManager:
                 "secret_key": secret_key, "region": region, "path_style": path_style,
             }
             self._clients.pop(endpoint_id, None)  # Invalidate cached client
+            self._presign_clients.pop(endpoint_id, None)
             for k in [k for k in self._user_clients if k[0] == endpoint_id]:
                 self._user_clients.pop(k, None)
+            for k in [k for k in self._user_presign_clients if k[0] == endpoint_id]:
+                self._user_presign_clients.pop(k, None)
 
-    def _build_client(self, info: dict, access_key: str, secret_key: str):
+    def _build_client(self, info: dict, access_key: str, secret_key: str,
+                      endpoint_url: str = ""):
         cfg = _S3_CONFIG
         if info.get("path_style"):
             cfg = _S3_CONFIG.merge(Config(s3={"addressing_style": "path"}))
         kwargs = {
-            "endpoint_url": info["endpoint_url"],
+            "endpoint_url": endpoint_url or info["endpoint_url"],
             "aws_access_key_id": access_key,
             "aws_secret_access_key": secret_key,
             "config": cfg,
@@ -444,27 +452,67 @@ class S3ClientManager:
             self._clients[endpoint_id] = client
             return client
 
-    def _get_user_client(self, endpoint_id: str, access_key: str, secret_key: str):
+    def get_presign_client(self, endpoint_id: str = "default"):
+        """Return a client configured for URLs that the browser will access.
+
+        Only the default endpoint has a separate public URL. Other registered
+        endpoints retain their existing endpoint URL until per-endpoint public URLs
+        are supported. Client creation is local; generating a presigned URL does not
+        connect to the configured public endpoint.
+        """
+        creds = _user_creds_ctx.get(None)
+        if creds and creds.get("ak"):
+            return self._get_user_client(
+                endpoint_id, creds["ak"], creds["sk"], presign=True)
+        with self._lock:
+            if endpoint_id in self._presign_clients:
+                return self._presign_clients[endpoint_id]
+            info = self._endpoints.get(endpoint_id)
+            if not info:
+                raise HTTPException(404, f"S3 endpoint '{endpoint_id}' not found")
+            client = self._build_client(
+                info, info["access_key"], info["secret_key"],
+                self.get_browser_endpoint_url(endpoint_id),
+            )
+            self._presign_clients[endpoint_id] = client
+            return client
+
+    def get_browser_endpoint_url(self, endpoint_id: str = "default"):
+        """Endpoint origin used by browser-facing presigned URLs and CSP."""
+        info = self._endpoints.get(endpoint_id)
+        if not info:
+            return ""
+        if endpoint_id == "default" and self._default_public_endpoint_url:
+            return self._default_public_endpoint_url
+        return info["endpoint_url"]
+
+    def _get_user_client(self, endpoint_id: str, access_key: str, secret_key: str,
+                         presign: bool = False):
         info = self._endpoints.get(endpoint_id) or self._endpoints.get("default")
         if not info:
             raise HTTPException(404, f"S3 endpoint '{endpoint_id}' not found")
         ak_hash = hashlib.sha256(access_key.encode()).hexdigest()[:16]
         key = (endpoint_id, ak_hash)
+        cache = self._user_presign_clients if presign else self._user_clients
         with self._lock:
-            client = self._user_clients.get(key)
+            client = cache.get(key)
             if client is None:
-                if len(self._user_clients) > 256:  # bound the cache; drop oldest insert
-                    self._user_clients.pop(next(iter(self._user_clients)), None)
-                client = self._build_client(info, access_key, secret_key)
-                self._user_clients[key] = client
+                if len(cache) > 256:  # bound the cache; drop oldest insert
+                    cache.pop(next(iter(cache)), None)
+                endpoint_url = self.get_browser_endpoint_url(endpoint_id) if presign else ""
+                client = self._build_client(info, access_key, secret_key, endpoint_url)
+                cache[key] = client
             return client
 
     def invalidate(self, endpoint_id: str):
         with self._lock:
             self._clients.pop(endpoint_id, None)
+            self._presign_clients.pop(endpoint_id, None)
             self._endpoints.pop(endpoint_id, None)
             for k in [k for k in self._user_clients if k[0] == endpoint_id]:
                 self._user_clients.pop(k, None)
+            for k in [k for k in self._user_presign_clients if k[0] == endpoint_id]:
+                self._user_presign_clients.pop(k, None)
 
     def get_endpoint_info(self, endpoint_id: str):
         return self._endpoints.get(endpoint_id)
@@ -472,7 +520,7 @@ class S3ClientManager:
     def get_all_ids(self):
         return list(self._endpoints.keys())
 
-_s3_manager = S3ClientManager()
+_s3_manager = S3ClientManager(S3_PUBLIC_ENDPOINT)
 # Register default endpoint from env vars
 _S3_PATH_STYLE = os.environ.get("S3_PATH_STYLE", "false").lower() in ("true", "1", "yes")
 _S3_REGION = os.environ.get("S3_REGION", "")
@@ -3415,7 +3463,8 @@ def resolve_share_link(token: str, password: str = ""):
         if not password or not bcrypt.verify(password, row["password_hash"]):
             raise HTTPException(401, "Password required")
     # Generate presigned URL
-    url = s3.generate_presigned_url(
+    client = _s3_manager.get_presign_client(_current_endpoint_id())
+    url = client.generate_presigned_url(
         "get_object",
         Params={"Bucket": row["bucket"], "Key": row["key"]},
         ExpiresIn=3600)
@@ -5316,7 +5365,8 @@ def trigger_crawl(bucket: str, user: dict = Depends(require_admin)):
 
 @app.get("/api/buckets/{bucket}/download")
 def download_object(bucket: str, key: str, user: dict = Depends(get_current_user)):
-    url = s3.generate_presigned_url("get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=3600)
+    client = _s3_manager.get_presign_client(_current_endpoint_id())
+    url = client.generate_presigned_url("get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=3600)
     return RedirectResponse(url)
 
 
@@ -6026,7 +6076,8 @@ def version_presigned_url(bucket: str, key: str, version_id: str, expires: int =
                           user: dict = Depends(get_current_user)):
     """Generate a presigned URL for downloading a specific version."""
     expires = min(max(60, expires), 604800)
-    url = s3.generate_presigned_url(
+    client = _s3_manager.get_presign_client(_current_endpoint_id())
+    url = client.generate_presigned_url(
         "get_object",
         Params={"Bucket": bucket, "Key": key, "VersionId": version_id},
         ExpiresIn=expires,
@@ -6037,7 +6088,8 @@ def version_presigned_url(bucket: str, key: str, version_id: str, expires: int =
 @app.get("/api/buckets/{bucket}/presigned-url")
 def get_presigned_url(bucket: str, key: str, expires: int = 3600, user: dict = Depends(get_current_user)):
     expires = min(max(60, expires), 604800)  # clamp 1 min to 7 days
-    url = s3.generate_presigned_url("get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=expires)
+    client = _s3_manager.get_presign_client(_current_endpoint_id())
+    url = client.generate_presigned_url("get_object", Params={"Bucket": bucket, "Key": key}, ExpiresIn=expires)
     return {"url": url, "expires_in": expires}
 
 
@@ -6060,6 +6112,7 @@ def presigned_upload(bucket: str, req: PresignedUploadRequest, request: Request,
     expires = 3600  # 1 hour
     eid = _current_endpoint_id()
     client = _s3_manager.get_client(eid)
+    presign_client = _s3_manager.get_presign_client(eid)
 
     # Ensure CORS allows PUT from the browser
     try:
@@ -6070,7 +6123,7 @@ def presigned_upload(bucket: str, req: PresignedUploadRequest, request: Request,
     urls = []
     for raw_key in req.keys:
         key = req.prefix + raw_key if req.prefix else raw_key
-        url = client.generate_presigned_url(
+        url = presign_client.generate_presigned_url(
             "put_object",
             Params={"Bucket": bucket, "Key": key},
             ExpiresIn=expires,
@@ -6188,7 +6241,7 @@ def multipart_sign(bucket: str, req: MultipartSignRequest, request: Request, use
     if any(pn < 1 or pn > 10000 for pn in req.part_numbers):
         raise HTTPException(400, "Part numbers must be between 1 and 10000 (S3 limit)")
     eid = _current_endpoint_id()
-    client = _s3_manager.get_client(eid)
+    client = _s3_manager.get_presign_client(eid)
     urls = [
         {"part_number": pn,
          "url": client.generate_presigned_url(

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -18,6 +18,7 @@ from unittest.mock import patch, MagicMock
 
 # Set env vars before importing the app
 os.environ.setdefault("S3_ENDPOINT", "http://localhost:9000")
+os.environ["S3_PUBLIC_ENDPOINT"] = "https://public-s3.example.test"
 os.environ.setdefault("S3_ACCESS_KEY", "minioadmin")
 os.environ.setdefault("S3_SECRET_KEY", "minioadmin")
 os.environ.setdefault("S3_REGION", "us-east-1")
@@ -688,6 +689,17 @@ class TestSecurityHeaders:
         assert "default-src 'self'" in csp
         assert "script-src 'self'" in csp
 
+    def test_csp_uses_public_s3_endpoint(self, client):
+        """Direct browser transfers must be allowed to reach the public S3 origin."""
+        m = _main_module()
+        resp = client.get("/healthz")
+        csp = resp.headers["content-security-policy"]
+        from urllib.parse import urlparse
+        public = urlparse(m.S3_PUBLIC_ENDPOINT)
+        origin = f"{public.scheme}://{public.netloc}"
+        assert origin in csp
+        assert f"{public.scheme}://*.{public.netloc}" in csp
+
     def test_x_content_type_options(self, client):
         """All responses should include X-Content-Type-Options: nosniff."""
         resp = client.get("/healthz")
@@ -708,6 +720,139 @@ class TestSecurityHeaders:
         resp = client.get("/api/auth/me", cookies=admin_cookies)
         assert "content-security-policy" in resp.headers
         assert resp.headers.get("x-content-type-options") == "nosniff"
+
+
+# ── Public S3 Endpoint / Presigning ─────────────────────
+
+class TestPublicS3Endpoint:
+    INTERNAL = "http://internal-s3.storage.svc.cluster.local:9000"
+    PUBLIC = "https://s3.example.test"
+
+    def _manager(self, m, public_endpoint):
+        manager = m.S3ClientManager(public_endpoint)
+        manager.register(
+            "default", self.INTERNAL, "server-ak", "server-sk",
+            region="us-east-1", path_style=True,
+        )
+        return manager
+
+    def test_presign_falls_back_to_internal_endpoint(self, app):
+        m = _main_module()
+        manager = self._manager(m, "")
+        from botocore.session import Session
+        session = Session()
+        with patch.object(m.boto3, "client", side_effect=session.create_client):
+            client = manager.get_presign_client("default")
+            url = client.generate_presigned_url(
+                "get_object", Params={"Bucket": "test-bucket", "Key": "folder/file.txt"})
+        assert url.startswith(f"{self.INTERNAL}/test-bucket/folder/file.txt?")
+
+    def test_public_presign_keeps_internal_operations_separate_and_path_style(self, app):
+        m = _main_module()
+        manager = self._manager(m, self.PUBLIC)
+        from botocore.session import Session
+        session = Session()
+        with patch.object(m.boto3, "client", side_effect=session.create_client):
+            internal = manager.get_client("default")
+            presign = manager.get_presign_client("default")
+
+            assert internal.meta.endpoint_url == self.INTERNAL
+            assert presign.meta.endpoint_url == self.PUBLIC
+            assert internal.meta.region_name == presign.meta.region_name == "us-east-1"
+            assert internal.meta.config.signature_version == presign.meta.config.signature_version == "s3v4"
+            assert presign.meta.config.s3["addressing_style"] == "path"
+            from botocore.stub import Stubber
+            with Stubber(internal) as stubber:
+                stubber.add_response("list_buckets", {"Buckets": []})
+                assert internal.list_buckets() == {"Buckets": []}
+            url = presign.generate_presigned_url(
+                "put_object", Params={"Bucket": "test-bucket", "Key": "upload.bin"})
+        assert url.startswith(f"{self.PUBLIC}/test-bucket/upload.bin?")
+
+    def test_s3_auth_presign_uses_current_user_credentials(self, app):
+        m = _main_module()
+        created = []
+
+        def fake_client(service, **kwargs):
+            created.append(kwargs)
+            return MagicMock()
+
+        manager = self._manager(m, self.PUBLIC)
+        token = m._user_creds_ctx.set({"ak": "user-ak", "sk": "user-sk"})
+        try:
+            with patch.object(m.boto3, "client", side_effect=fake_client):
+                manager.get_client("default")
+                manager.get_presign_client("default")
+        finally:
+            m._user_creds_ctx.reset(token)
+
+        assert [call["endpoint_url"] for call in created] == [self.INTERNAL, self.PUBLIC]
+        assert all(call["aws_access_key_id"] == "user-ak" for call in created)
+        assert all(call["aws_secret_access_key"] == "user-sk" for call in created)
+
+    def test_browser_download_upload_and_multipart_use_presign_client(
+            self, client, admin_cookies, app):
+        m = _main_module()
+        presign = MagicMock()
+
+        def signed_url(operation, **kwargs):
+            return f"{self.PUBLIC}/{operation}"
+
+        presign.generate_presigned_url.side_effect = signed_url
+        internal = MagicMock()
+        internal.create_multipart_upload.return_value = {"UploadId": "upload-1"}
+        with patch.object(m._s3_manager, "get_presign_client", return_value=presign), \
+             patch.object(m._s3_manager, "get_client", return_value=internal):
+            download = client.get(
+                "/api/buckets/test-bucket/download?key=file.txt",
+                cookies=admin_cookies, follow_redirects=False)
+            regular = client.get(
+                "/api/buckets/test-bucket/presigned-url?key=file.txt",
+                cookies=admin_cookies)
+            version = client.get(
+                "/api/buckets/test-bucket/version-presigned-url"
+                "?key=file.txt&version_id=v1",
+                cookies=admin_cookies)
+            upload = client.post(
+                "/api/buckets/test-bucket/presigned-upload",
+                json={"keys": ["upload.txt"]}, cookies=admin_cookies)
+            initiate = client.post(
+                "/api/buckets/test-bucket/multipart/initiate",
+                json={"key": "large.bin"}, cookies=admin_cookies)
+            multipart = client.post(
+                "/api/buckets/test-bucket/multipart/sign",
+                json={"key": "large.bin", "upload_id": "upload-1", "part_numbers": [1, 2]},
+                cookies=admin_cookies)
+
+        assert download.headers["location"] == f"{self.PUBLIC}/get_object"
+        assert regular.json()["url"] == f"{self.PUBLIC}/get_object"
+        assert version.json()["url"] == f"{self.PUBLIC}/get_object"
+        assert upload.json()["urls"][0]["url"] == f"{self.PUBLIC}/put_object"
+        assert initiate.json()["upload_id"] == "upload-1"
+        internal.create_multipart_upload.assert_called_once_with(
+            Bucket="test-bucket", Key="large.bin")
+        assert all(item["url"] == f"{self.PUBLIC}/upload_part"
+                   for item in multipart.json()["urls"])
+        operations = [call.args[0] for call in presign.generate_presigned_url.call_args_list]
+        assert operations == ["get_object", "get_object", "get_object", "put_object",
+                              "upload_part", "upload_part"]
+
+    def test_share_link_uses_presign_client(self, client, admin_cookies, app):
+        m = _main_module()
+        created = client.post(
+            "/api/share-links",
+            json={"bucket": "test-bucket", "key": "shared.txt", "expires_hours": 1},
+            cookies=admin_cookies,
+        )
+        token = created.json()["token"]
+        presign = MagicMock()
+        presign.generate_presigned_url.return_value = f"{self.PUBLIC}/shared.txt"
+        with patch.object(m._s3_manager, "get_presign_client", return_value=presign):
+            resolved = client.get(f"/api/share/{token}")
+
+        assert resolved.status_code == 200
+        assert resolved.json()["url"] == f"{self.PUBLIC}/shared.txt"
+        assert presign.generate_presigned_url.call_args.args[0] == "get_object"
 
 
 # ── 2FA Encryption ───────────────────────────────────────

--- a/charts/sairo/templates/deployment.yaml
+++ b/charts/sairo/templates/deployment.yaml
@@ -47,6 +47,8 @@ spec:
             # ── S3 Configuration ──
             - name: S3_ENDPOINT
               value: {{ .Values.s3.endpoint | quote }}
+            - name: S3_PUBLIC_ENDPOINT
+              value: {{ .Values.s3.publicEndpoint | quote }}
             - name: S3_REGION
               value: {{ .Values.s3.region | quote }}
             - name: S3_PATH_STYLE

--- a/charts/sairo/values.yaml
+++ b/charts/sairo/values.yaml
@@ -37,7 +37,8 @@ persistence:
 
 # S3 Configuration (required)
 s3:
-  endpoint: ""         # e.g., https://s3.us-east-1.amazonaws.com
+  endpoint: ""          # Internal/backend endpoint, e.g. http://minio.storage.svc:9000
+  publicEndpoint: ""    # Optional browser-facing endpoint for presigned URLs; defaults to endpoint
   region: ""
   accessKey: ""
   secretKey: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       - "8000:8000"
     environment:
       S3_ENDPOINT: ${S3_ENDPOINT:?Set S3_ENDPOINT in .env}
+      S3_PUBLIC_ENDPOINT: ${S3_PUBLIC_ENDPOINT:-${S3_ENDPOINT:?Set S3_ENDPOINT in .env}}
       S3_ACCESS_KEY: ${S3_ACCESS_KEY:?Set S3_ACCESS_KEY in .env}
       S3_SECRET_KEY: ${S3_SECRET_KEY:?Set S3_SECRET_KEY in .env}
       S3_REGION: ${S3_REGION:-us-east-1}


### PR DESCRIPTION
## Summary

  Add separate internal and public S3 endpoints for Kubernetes deployments where Sairo accesses S3 over internal HTTP,
  while browsers access S3 through an HAProxy endpoint with SSL termination.

  In this deployment:

  - Sairo accesses Ceph RGW through the Kubernetes Service over HTTP:

    http://rook-ceph-rgw-ceph-objectstore.rook-ceph.svc.cluster.local

  - Browsers access S3 through HAProxy over HTTPS:

    https://s3.devops.net

  The TLS certificate is installed and terminated at HAProxy and is valid for the public domain, not the internal
  Kubernetes Service hostname. Using the public HTTPS endpoint from Sairo would unnecessarily route backend S3 traffic
  through HAProxy, while using the internal HTTP endpoint for presigned URLs produces addresses that browsers cannot
  resolve or access.

  This change keeps server-side S3 traffic on the internal HTTP endpoint and uses the public HTTPS endpoint only when
  generating browser-facing presigned URLs. When S3_PUBLIC_ENDPOINT is unset or empty, it falls back to S3_ENDPOINT for
  backward compatibility.

  ## Changes

  - Added the optional S3_PUBLIC_ENDPOINT environment variable.
  - Added separate boto3 clients:
      - Internal client using S3_ENDPOINT for actual S3 API requests.
      - Presign client using S3_PUBLIC_ENDPOINT for browser-facing URLs.

  - Kept the same credentials, region, signature version, and path-style configuration across both clients.
  - Updated object downloads, version downloads, Share Links, direct uploads, and multipart part URLs to use the public
    HTTPS endpoint.

  - Kept bucket operations, CORS configuration, crawlers, and multipart initiate/complete/abort requests on the
    internal HTTP endpoint.

  - Ensured AUTH_MODE=s3 presigning uses the currently logged-in user’s S3 credentials.
  - Updated CSP connect-src to allow the public S3 origin and wildcard subdomains.
  - Added Helm and Docker Compose configuration.
  - Updated .env.example and README documentation.
  - Added tests for endpoint fallback, public URL generation, path-style addressing, S3 user credentials, upload/
    download flows, multipart uploads, Share Links, and CSP.

  Example configuration:

  # Internal HTTP endpoint used by the Sairo backend
  S3_ENDPOINT=http://rook-ceph-rgw-ceph-objectstore.rook-ceph.svc.cluster.local

  # Public HTTPS endpoint exposed by HAProxy with SSL termination
  S3_PUBLIC_ENDPOINT=https://s3.devops.net

  ## Testing

  - [x] Tested locally
  - [x] Existing tests pass
  - [x] Backend test suite passes (103 passed)
  - [x] Helm lint and template pass
  - [x] Docker Compose configuration renders correctly