### PR TITLE
fix(crawler): resume interrupted crawls, honest status, no duplicate crawls, graceful shutdown (Core A)

### DIFF
--- a/.github/workflows/restart-harness.yaml
+++ b/.github/workflows/restart-harness.yaml
@@ -1,0 +1,30 @@
+name: Restart Harness (nightly)
+
+on:
+  schedule:
+    - cron: "17 2 * * *"
+  workflow_dispatch:
+
+jobs:
+  harness:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: backend/requirements.txt
+      - run: python -m venv backend/.venv && backend/.venv/bin/pip install -q -r backend/requirements.txt
+      - run: sudo apt-get install -y -q sqlite3 bc
+      - run: docker compose -f benchmark/restart_harness/docker-compose.yml up -d
+      - name: Run the 4-phase restart reproduction and assert the Phase A gates
+        run: cd benchmark/restart_harness && ./driver.sh
+      - if: always()
+        run: cat benchmark/restart_harness/out/rca/REPORT.txt || true
+      - if: always()
+        uses: actions/upload-artifact@v4
+        with: { name: restart-harness-report, path: benchmark/restart_harness/out/rca/ }
+      - if: always()
+        run: docker compose -f benchmark/restart_harness/docker-compose.yml down -v

--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,5 @@ benchmark/validate_full.py
 # restart harness output
 benchmark/restart_harness/out/
 benchmark/restart_harness/out_driver.log
+benchmark/prodlab/out/
+benchmark/prodlab/spec-smoke.json

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ auth-state.json
 benchmark/results/prod-*.json
 benchmark/results/qlbench-*.json
 benchmark/validate_full.py
+
+# restart harness output
+benchmark/restart_harness/out/
+benchmark/restart_harness/out_driver.log

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,3 @@
+# gitleaks fingerprints to ignore (commit:file:rule:line)
+# Test-only JWT constant in the restart harness; replaced by a per-run random value in 238041c.
+4762ec6ded7f7a2f79c761d43631f338967736ff:benchmark/restart_harness/lib.sh:generic-api-key:11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to Sairo are documented here. This project uses [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+Crawler correctness (Core program, Phase A — SAE-63).
+
+### Fixed
+
+- **A restart during a crawl no longer leaves a partial index that reports itself complete.** Completed prefixes are recorded per crawl generation (`crawl_progress`); on boot an unfinished crawl is marked `interrupted` and **resumed**, skipping finished prefixes, instead of being seeded as "fully crawled" and left delta-only for an hour. Delta crawls can no longer flip an interrupted index to `complete`. `crawl-status` gains `full_crawl_complete` and `crawl_elapsed`; the UI shows "Finishing an interrupted index".
+- **A crawl running past the 2-hour limit is asked to stop and resumed, never duplicated.** The old force-release started a second concurrent crawl of the same bucket.
+- **Graceful SIGTERM.** Running crawls stop at the next page, flush their batch and record progress; the chart sets `terminationGracePeriodSeconds: 30`.
+- **Version-purge lock is never timed out** (it stored a boolean the timeout arithmetic misread as epoch 1).
+
+### Changed
+
+- Helm: the data PVC carries `helm.sh/resource-policy: keep` (`persistence.keep: true`) so `helm uninstall`/reinstall keeps the index; default `persistence.size` is now **20Gi** (≈1 GB per 1M objects). Existing PVCs keep their size.
+- Crawls refuse to start when the index volume has under `MIN_FREE_DISK_PCT` (10) percent free; `/healthz` reports `disk_low`.
+- MCP `get_crawl_status` / bucket discovery label the new `interrupted` state.
+
+### Upgrade note
+
+Buckets left in `crawling` by an earlier restart are marked `interrupted` on first boot and re-crawled once (resuming where progress exists). Expect one full-ish crawl per such bucket after upgrading.
+
 ## [3.6.0] - 2026-06-29
 
 Generic OpenID Connect SSO + a real per-bucket access UI (issue #9).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Crawler correctness (Core program, Phase A — SAE-63).
 - Helm: the data PVC carries `helm.sh/resource-policy: keep` (`persistence.keep: true`) so `helm uninstall`/reinstall keeps the index; default `persistence.size` is now **20Gi** (≈1 GB per 1M objects). Existing PVCs keep their size.
 - Crawls refuse to start when the index volume has under `MIN_FREE_DISK_PCT` (10) percent free; `/healthz` reports `disk_low`.
 - MCP `get_crawl_status` / bucket discovery label the new `interrupted` state.
+- Helm: new `telemetry.enabled` value (default `true`) sets the `TELEMETRY` env var; the chart previously offered no way to opt out of the anonymous heartbeat.
 
 ### Upgrade note
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to Sairo are documented here. This project uses [Semantic Ve
 
 ## [Unreleased]
 
+**Upgrade note (Helm):** the default `persistence.size` moved from 5Gi to 20Gi. An existing release's PVC is patched in place, which only works when the StorageClass allows volume expansion; otherwise pass your current size (`--set persistence.size=5Gi`). The PVC now carries `helm.sh/resource-policy: keep`, so `helm uninstall` no longer deletes the index.
+
 Crawler correctness (Core program, Phase A — SAE-63).
 
 ### Fixed

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ import os
 import secrets
 import sqlite3
 import threading
+import shutil
 import time
 import traceback
 import uuid
@@ -927,6 +928,9 @@ def _init_db(bucket, endpoint_id=None):
             current_crawl_gen INTEGER DEFAULT 0
         )
     """)
+    # Per-prefix completion for the running crawl generation: lets an interrupted crawl
+    # (restart, SIGTERM, cancel) resume instead of starting over or being mistaken for complete.
+    conn.execute("CREATE TABLE IF NOT EXISTS crawl_progress (prefix TEXT PRIMARY KEY, gen INTEGER NOT NULL)")
     # Migration: add current_crawl_gen column to existing databases
     try:
         conn.execute("ALTER TABLE crawl_status ADD COLUMN current_crawl_gen INTEGER DEFAULT 0")
@@ -1197,12 +1201,31 @@ def _record_storage_snapshot(bucket, endpoint_id=None):
 _crawl_pool = ThreadPoolExecutor(max_workers=12, thread_name_prefix="crawler")
 _rebuild_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="rebuild")
 _crawling = {}       # crawl_key -> timestamp when crawl started
+_crawl_futures = {}  # crawl_key -> Future of the running _run_crawl (for cancel/shutdown)
+_crawl_cancel = {}   # crawl_key -> threading.Event requesting a cooperative stop
+_shutting_down = threading.Event()
+MIN_FREE_DISK_PCT = int(os.environ.get("MIN_FREE_DISK_PCT", "10"))
+
+
+class CrawlInterrupted(Exception):
+    """Raised inside a crawl when shutdown or cancellation was requested. Progress is in
+    crawl_progress; the next crawl of the bucket resumes from it."""
+
+
+def _disk_low():
+    """True when the index volume has less than MIN_FREE_DISK_PCT free. A full disk makes
+    SQLite writes fail inside best-effort paths and the crawler silently looks 'stale'."""
+    try:
+        u = shutil.disk_usage(DB_DIR)
+        return u.total > 0 and (u.free * 100.0 / u.total) < MIN_FREE_DISK_PCT
+    except Exception:
+        return False
 _rebuilding = set()  # crawl_keys whose post-crawl rebuild is in progress (blocks a colliding recrawl)
 _crawl_lock = threading.Lock()
 _CRAWL_MAX_DURATION = 7200  # 2 hours — if a crawl exceeds this, force-release the lock
 
 
-def _crawl_prefix(bucket, prefix, max_retries=3, endpoint_id=None, batch_callback=None, batch_size=10000):
+def _crawl_prefix(bucket, prefix, max_retries=3, endpoint_id=None, batch_callback=None, batch_size=10000, should_stop=None):
     """List all objects under a specific prefix with retry logic.
 
     If batch_callback is provided, calls it with each batch of tuples during S3 pagination
@@ -1217,6 +1240,11 @@ def _crawl_prefix(bucket, prefix, max_retries=3, endpoint_id=None, batch_callbac
     token = None
     retries = 0
     while True:
+        if should_stop is not None and should_stop():
+            # Shutdown/cancel: persist what we have and stop; the prefix is re-listed on resume.
+            if batch_callback is not None and batch:
+                batch_callback(batch)
+            raise CrawlInterrupted(prefix)
         params = {"Bucket": bucket, "Prefix": prefix, "MaxKeys": 1000}
         if token:
             params["ContinuationToken"] = token
@@ -1386,17 +1414,42 @@ def _run_crawl(bucket, endpoint_id=None):
 
     _init_db(bucket, eid)
 
+    cancel_ev = _crawl_cancel.get(crawl_key) or threading.Event()
+    stop = lambda: _shutting_down.is_set() or cancel_ev.is_set()  # checked between S3 pages
+
     with _get_db(bucket, eid) as db:
-        db.execute("UPDATE crawl_status SET status='crawling', last_crawl_start=?, current_crawl_gen=current_crawl_gen+1 WHERE id=1",
-                    (time.strftime("%Y-%m-%dT%H:%M:%SZ"),))
+        prev = db.execute("SELECT status, current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
+        prev_status = (prev["status"] if prev else None) or ""
+        prev_gen = (prev["current_crawl_gen"] if prev else 0) or 0
+        # Resume: an interrupted crawl left per-prefix progress for its generation. Keep that
+        # generation and skip the prefixes it already completed instead of starting over.
+        done_prefixes = set()
+        if prev_status in ("crawling", "interrupted") and prev_gen:
+            done_prefixes = {r[0] for r in db.execute("SELECT prefix FROM crawl_progress WHERE gen=?", (prev_gen,))}
+        if done_prefixes:
+            db.execute("UPDATE crawl_status SET status='crawling', last_crawl_start=? WHERE id=1",
+                       (time.strftime("%Y-%m-%dT%H:%M:%SZ"),))
+        else:
+            db.execute("UPDATE crawl_status SET status='crawling', last_crawl_start=?, current_crawl_gen=current_crawl_gen+1 WHERE id=1",
+                       (time.strftime("%Y-%m-%dT%H:%M:%SZ"),))
+            db.execute("DELETE FROM crawl_progress")
         db.commit()
         crawl_gen = db.execute("SELECT current_crawl_gen FROM crawl_status WHERE id=1").fetchone()[0]
         initial_count = db.execute("SELECT COUNT(*) FROM objects").fetchone()[0]
         # Disable FTS triggers during bulk crawl for performance
         _disable_fts_triggers(db)
+    if done_prefixes:
+        log.info("[%s:%s] Resuming interrupted crawl (gen %d): %d prefix(es) already complete",
+                 eid, bucket, crawl_gen, len(done_prefixes))
+
+    def _mark_prefix_done(p):
+        with _get_db(bucket, eid) as _db:
+            _db.execute("INSERT OR REPLACE INTO crawl_progress (prefix, gen) VALUES (?, ?)", (p, crawl_gen))
+            _db.commit()
 
     crawl_start = time.monotonic()
     crawl_ok = False
+    interrupted = False
     fts_needs_rebuild = True  # safe default; refined below once we know what changed
     stale_count = 0
     try:
@@ -1497,7 +1550,7 @@ def _run_crawl(bucket, endpoint_id=None):
                             [row + (crawl_gen,) for row in batch])
                     db.commit()
 
-            total_count = _crawl_prefix(bucket, "", endpoint_id=eid, batch_callback=_simple_batch_cb)
+            total_count = _crawl_prefix(bucket, "", endpoint_id=eid, batch_callback=_simple_batch_cb, should_stop=stop)
             with _get_db(bucket, eid) as db:
                 # Remove stale keys: anything with crawl_gen > 0 but older than current gen
                 stale_count = db.execute("SELECT COUNT(*) FROM objects WHERE crawl_gen > 0 AND crawl_gen < ?", (crawl_gen,)).fetchone()[0]
@@ -1561,8 +1614,9 @@ def _run_crawl(bucket, endpoint_id=None):
         with ThreadPoolExecutor(max_workers=16, thread_name_prefix=f"pfx-{bucket[:8]}") as pool:
             futures = {
                 pool.submit(_crawl_prefix, bucket, p, endpoint_id=eid,
-                            batch_callback=_make_prefix_batch_cb(bucket, eid, crawl_gen)): p
-                for p in sorted(known_prefixes)
+                            batch_callback=_make_prefix_batch_cb(bucket, eid, crawl_gen),
+                            should_stop=stop): p
+                for p in sorted(known_prefixes) if p not in done_prefixes
             }
             for future in futures:
                 p = futures[future]
@@ -1571,8 +1625,11 @@ def _run_crawl(bucket, endpoint_id=None):
                     prefix_timeout = max(900, 900 + existing_count // 5000)
                     count = future.result(timeout=prefix_timeout)
                     total_new += count
+                    _mark_prefix_done(p)
                     log.info("[%s:%s] Prefix '%s': %s objects",
                              eid, bucket, p[:40], f"{count:,}")
+                except CrawlInterrupted:
+                    interrupted = True
                 except Exception as e:
                     failed_prefixes.append(p)
                     log.warning("[%s:%s] Prefix '%s' failed: %s: %s", eid, bucket, p[:40], type(e).__name__, e)
@@ -1582,6 +1639,9 @@ def _run_crawl(bucket, endpoint_id=None):
                     row = db.execute("SELECT COUNT(*), COALESCE(SUM(size),0) FROM objects").fetchone()
                     db.execute("UPDATE crawl_status SET total_objects=?, total_size=? WHERE id=1", (row[0], row[1]))
                     db.commit()
+
+        if interrupted:
+            raise CrawlInterrupted(bucket)
 
         # Retry any prefixes that failed — typically transient SQLite write contention under heavy
         # parallelism ("database is locked"). Re-crawl them sequentially (no contention) so a transient
@@ -1593,9 +1653,13 @@ def _run_crawl(bucket, endpoint_id=None):
             for p in retry:
                 try:
                     count = _crawl_prefix(bucket, p, endpoint_id=eid,
-                                          batch_callback=_make_prefix_batch_cb(bucket, eid, crawl_gen))
+                                          batch_callback=_make_prefix_batch_cb(bucket, eid, crawl_gen),
+                                          should_stop=stop)
                     total_new += count
+                    _mark_prefix_done(p)
                     log.info("[%s:%s] Prefix '%s' (retry): %s objects", eid, bucket, p[:40], f"{count:,}")
+                except CrawlInterrupted:
+                    raise
                 except Exception as e:
                     failed_prefixes.append(p)
                     log.warning("[%s:%s] Prefix '%s' failed on retry: %s: %s", eid, bucket, p[:40], type(e).__name__, e)
@@ -1645,6 +1709,17 @@ def _run_crawl(bucket, endpoint_id=None):
 
     except _CrawlDone:
         crawl_ok = True
+    except CrawlInterrupted:
+        crawl_ok = False
+        try:
+            with _get_db(bucket, eid) as db:
+                _enable_fts_triggers(db)
+                db.execute("UPDATE crawl_status SET status='interrupted' WHERE id=1")
+                db.commit()
+        except Exception:
+            pass
+        log.info("[%s:%s] Crawl interrupted (%s); progress saved, will resume",
+                 eid, bucket, "shutdown" if _shutting_down.is_set() else "cancelled")
     except BaseException as e:
         crawl_ok = False
         log.error("[%s:%s] Crawl error: %s\n%s", eid, bucket, e, traceback.format_exc())
@@ -1663,6 +1738,8 @@ def _run_crawl(bucket, endpoint_id=None):
         # rebuild with "database is locked", leaving folder_stats empty).
         with _crawl_lock:
             _crawling.pop(crawl_key, None)
+            _crawl_futures.pop(crawl_key, None)
+            _crawl_cancel.pop(crawl_key, None)
             if crawl_ok:
                 _rebuilding.add(crawl_key)
                 # Record full-crawl timing so the scheduler can decide between a
@@ -2140,7 +2217,7 @@ def _delta_crawl(bucket, endpoint_id):
     # queryable throughout because _is_index_ready treats any bucket with
     # total_objects>0 as ready. The caller resets status/last_crawl_end when done.
     with _get_db(bucket, eid) as db:
-        db.execute("UPDATE crawl_status SET status='crawling', last_crawl_start=? WHERE id=1",
+        db.execute("UPDATE crawl_status SET status='crawling', last_crawl_start=? WHERE id=1 AND status <> 'interrupted'",
                    (time.strftime("%Y-%m-%dT%H:%M:%SZ"),))
         db.commit()
 
@@ -2224,7 +2301,8 @@ def _queue_delta_crawl(bucket, endpoint_id=None):
             # reflects that the index was just refreshed (even on a no-change delta).
             try:
                 with _get_db(bucket, eid) as db:
-                    db.execute("UPDATE crawl_status SET status='complete', last_crawl_end=? WHERE id=1",
+                    # A delta refreshes hot prefixes only; it must not relabel an interrupted full crawl as complete.
+                    db.execute("UPDATE crawl_status SET status='complete', last_crawl_end=? WHERE id=1 AND status <> 'interrupted'",
                                (time.strftime("%Y-%m-%dT%H:%M:%SZ"),))
                     db.commit()
             except Exception:
@@ -2246,14 +2324,35 @@ def _queue_crawl(bucket, endpoint_id=None):
             return False
         started_at = _crawling.get(crawl_key)
         if started_at:
-            # Force-release stale locks (OOM kill, thread death, etc.)
-            if now - started_at > _CRAWL_MAX_DURATION:
-                log.warning("Force-releasing stale crawl lock for %s (started %.0f min ago)", crawl_key, (now - started_at) / 60)
-                del _crawling[crawl_key]
-            else:
+            # `True` marks a non-crawl owner (version purge); never time it out.
+            if started_at is True or now - started_at <= _CRAWL_MAX_DURATION:
                 return False
+            fut = _crawl_futures.get(crawl_key)
+            if fut is not None and not fut.done():
+                # Over the limit but still running: never start a second crawl of the same
+                # bucket (they would fight over the single SQLite writer). Ask it to stop; it
+                # exits 'interrupted' and the scheduler resumes it from crawl_progress.
+                ev = _crawl_cancel.get(crawl_key)
+                if ev is not None and not ev.is_set():
+                    ev.set()
+                    log.warning("Crawl for %s exceeded %d min; cancellation requested (will resume)",
+                                crawl_key, _CRAWL_MAX_DURATION // 60)
+                return False
+            # Thread is gone (OOM kill, executor death): the lock really is stale.
+            log.warning("Force-releasing stale crawl lock for %s (started %.0f min ago, thread gone)", crawl_key, (now - started_at) / 60)
+            del _crawling[crawl_key]
+        if _disk_low():
+            log.warning("Crawl for %s skipped: less than %d%% free on %s", crawl_key, MIN_FREE_DISK_PCT, DB_DIR)
+            try:
+                with _get_db(bucket, eid) as db:
+                    db.execute("UPDATE crawl_status SET status=? WHERE id=1", (f"error: disk below {MIN_FREE_DISK_PCT}% free",))
+                    db.commit()
+            except Exception:
+                pass
+            return False
         _crawling[crawl_key] = now  # Store timestamp, not bool
-    _crawl_pool.submit(_run_crawl, bucket, eid)
+        _crawl_cancel[crawl_key] = threading.Event()
+    _crawl_futures[crawl_key] = _crawl_pool.submit(_run_crawl, bucket, eid)
     return True
 
 
@@ -2343,16 +2442,24 @@ def startup():
                     # then trigger a redundant (multi-minute) full re-crawl. The scheduler
                     # keeps it fresh via fast delta crawls and a periodic full reconcile.
                     seeded = False
+                    prev_status = ""
                     try:
                         with _get_db(name, eid) as db:
-                            row = db.execute("SELECT total_objects, crawl_duration FROM crawl_status WHERE id=1").fetchone()
+                            row = db.execute("SELECT total_objects, crawl_duration, status FROM crawl_status WHERE id=1").fetchone()
                             total = (row["total_objects"] if row else 0) or 0
                             if total == 0:  # counters can lag an interrupted crawl — trust the table
                                 total = db.execute("SELECT COUNT(*) FROM objects").fetchone()[0]
                             dur = (row["crawl_duration"] if row else 0) or 0.0
-                        if total > 0:
-                            if not dur and total > 50000:  # estimate large-ness until a full crawl records a duration
-                                dur = LARGE_BUCKET_SECONDS + 1
+                            prev_status = (row["status"] if row else None) or ""
+                            if prev_status == "crawling":
+                                # The previous process died mid-crawl. Say so; the queued crawl resumes it.
+                                db.execute("UPDATE crawl_status SET status='interrupted' WHERE id=1")
+                                db.commit()
+                                prev_status = "interrupted"
+                        # Seed only from a COMPLETED full crawl (one that recorded a duration). Seeding
+                        # an interrupted index marked it "fresh" and left large buckets delta-only for
+                        # FULL_CRAWL_INTERVAL while a third of the data was missing.
+                        if total > 0 and dur > 0 and prev_status != "interrupted":
                             _crawl_meta[f"{eid}:{name}"] = {"last_full": time.time(), "duration": dur}
                             seeded = True
                             log.info("Seeded schedule for %s:%s from existing index (%s objects); will keep fresh via scheduler",
@@ -2361,7 +2468,8 @@ def startup():
                         pass
                     if not seeded:
                         _queue_crawl(name, eid)
-                        log.info("Queued crawl for %s:%s", eid, name)
+                        log.info("Queued %s crawl for %s:%s",
+                                 "resume of interrupted" if prev_status == "interrupted" else "initial", eid, name)
             except Exception as e:
                 log.error("Failed to list buckets on startup (endpoint=%s): %s", eid, e)
     threading.Thread(target=_startup_crawl, daemon=True).start()
@@ -2808,6 +2916,19 @@ def _telemetry_shutdown():
     """Record a clean shutdown so the next boot doesn't mis-count this as a crash."""
     if TELEMETRY:
         _tel_mark_clean_exit()
+
+
+@app.on_event("shutdown")
+def _crawl_shutdown():
+    """SIGTERM (every rollout): ask running crawls to stop at the next page and wait briefly so
+    they flush their batch and record 'interrupted'; the next boot resumes from crawl_progress."""
+    _shutting_down.set()
+    deadline = time.monotonic() + 20
+    for fut in list(_crawl_futures.values()):
+        try:
+            fut.result(timeout=max(0.1, deadline - time.monotonic()))
+        except Exception:
+            pass
 
 
 _telemetry_lockfile = None  # held for the process lifetime by the elected pinger
@@ -4105,7 +4226,7 @@ def healthz():
     # Liveness: just confirm the process is responsive.
     # Storage checks belong in readiness, not liveness — killing the pod
     # on a transient Longhorn unmount just causes a restart loop.
-    return {"status": "ok"}
+    return {"status": "ok", "disk_low": _disk_low()}
 
 
 @app.get("/readyz")
@@ -5300,7 +5421,15 @@ def crawl_status(bucket: str, user: dict = Depends(get_current_user)):
         return {"status": "not_indexed", "total_objects": 0, "total_size": 0}
     with _get_db(bucket) as db:
         row = db.execute("SELECT * FROM crawl_status WHERE id=1").fetchone()
-    return dict(row) if row else {"status": "unknown"}
+    if not row:
+        return {"status": "unknown"}
+    d = dict(row)
+    st = d.get("status") or ""
+    # True only when a full crawl has finished and nothing since has interrupted one.
+    d["full_crawl_complete"] = bool(d.get("crawl_duration")) and st != "interrupted" and not st.startswith("error")
+    started = _crawling.get(f"{_current_endpoint_id()}:{bucket}")
+    d["crawl_elapsed"] = round(time.time() - started, 1) if isinstance(started, float) else None
+    return d
 
 
 @app.post("/api/buckets/{bucket}/crawl")

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -857,3 +857,125 @@ class TestCompatPermissions:
                          "/api/presigned-url?key=test", "/api/multipart-uploads"]:
                 resp = fresh.get(path)
                 assert resp.status_code == 401, f"{path} should require auth, got {resp.status_code}"
+
+
+# ── Phase A: crawler correctness (SAE-63) ───────────────────────────────────
+
+class TestCrawlerCorrectness:
+    """Resume, honest status, cancel-not-fork, stop flag, disk guard."""
+
+    def _main(self):
+        import sys
+        return sys.modules.get("backend.main") or sys.modules["main"]
+
+    def test_crawl_prefix_should_stop_flushes_and_raises(self, app):
+        m = self._main()
+        pages = [
+            {"Contents": [{"Key": f"p/a{i}", "Size": 1, "LastModified": datetime(2026, 1, 1, tzinfo=timezone.utc), "ETag": '"e"'} for i in range(3)],
+             "IsTruncated": True, "NextContinuationToken": "t1"},
+            {"Contents": [{"Key": "p/b0", "Size": 1, "LastModified": datetime(2026, 1, 1, tzinfo=timezone.utc), "ETag": '"e"'}], "IsTruncated": False},
+        ]
+        client = MagicMock(); client.list_objects_v2.side_effect = pages
+        flushed = []
+        calls = {"n": 0}
+        def should_stop():
+            calls["n"] += 1
+            return calls["n"] > 1  # allow the first page, stop before the second
+        with patch.object(m._s3_manager, "get_client", return_value=client):
+            with pytest.raises(m.CrawlInterrupted):
+                m._crawl_prefix("stopbkt", "p/", endpoint_id="default", batch_callback=flushed.extend, should_stop=should_stop)
+        assert [r[0] for r in flushed] == ["p/a0", "p/a1", "p/a2"]  # first page persisted, not lost
+        assert client.list_objects_v2.call_count == 1
+
+    def test_queue_crawl_requests_cancel_instead_of_second_crawl(self, app):
+        m = self._main()
+        key = "default:dupbkt"
+        fut = MagicMock(); fut.done.return_value = False
+        ev = m.threading.Event()
+        with patch.object(m, "_CRAWL_MAX_DURATION", 0), patch.object(m._crawl_pool, "submit") as submit:
+            m._crawling[key] = time.time() - 10
+            m._crawl_futures[key] = fut
+            m._crawl_cancel[key] = ev
+            try:
+                assert m._queue_crawl("dupbkt", "default") is False
+                assert ev.is_set(), "running crawl must be asked to stop"
+                submit.assert_not_called()
+            finally:
+                m._crawling.pop(key, None); m._crawl_futures.pop(key, None); m._crawl_cancel.pop(key, None)
+
+    def test_queue_crawl_never_times_out_non_crawl_owner(self, app):
+        m = self._main()
+        key = "default:purgebkt"
+        with patch.object(m, "_CRAWL_MAX_DURATION", 0), patch.object(m._crawl_pool, "submit") as submit:
+            m._crawling[key] = True  # version purge holds the lock with a bool
+            try:
+                assert m._queue_crawl("purgebkt", "default") is False
+                submit.assert_not_called()
+            finally:
+                m._crawling.pop(key, None)
+
+    def test_disk_guard_blocks_crawl(self, app):
+        m = self._main()
+        from collections import namedtuple
+        DU = namedtuple("usage", "total used free")
+        m._init_db("diskbkt", "default")
+        with patch.object(m.shutil, "disk_usage", return_value=DU(100, 95, 5)), patch.object(m._crawl_pool, "submit") as submit:
+            assert m._disk_low() is True
+            assert m._queue_crawl("diskbkt", "default") is False
+            submit.assert_not_called()
+        with m._get_db("diskbkt", "default") as db:
+            assert (db.execute("SELECT status FROM crawl_status WHERE id=1").fetchone()[0] or "").startswith("error: disk")
+        with patch.object(m.shutil, "disk_usage", return_value=DU(100, 50, 50)):
+            assert m._disk_low() is False
+
+    def test_run_crawl_resumes_and_skips_completed_prefixes(self, app):
+        """Kill mid-crawl (simulated by pre-seeded progress) → the next crawl keeps the generation,
+        lists only unfinished prefixes, and ends complete with every object present."""
+        m = self._main()
+        bucket = "resumebkt"
+        m._init_db(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            db.execute("UPDATE crawl_status SET status='crawling', current_crawl_gen=7 WHERE id=1")
+            db.execute("INSERT INTO crawl_progress (prefix, gen) VALUES ('a/', 7)")
+            db.execute("INSERT INTO discovered_prefixes (prefix) VALUES ('a/'), ('b/')")
+            for i in range(2):  # rows the interrupted crawl already wrote for a/
+                db.execute("INSERT INTO objects (key,size,last_modified,etag,prefix,depth,crawl_gen) VALUES (?,?,?,?,?,?,?)",
+                           (f"a/{i}", 1, "2026-01-01T00:00:00+00:00", "e", "a/", 1, 7))
+            db.commit()
+        listed = []
+        def list_objects_v2(**p):
+            if "Delimiter" in p:
+                return {"CommonPrefixes": [{"Prefix": "a/"}, {"Prefix": "b/"}], "Contents": [], "IsTruncated": False}
+            listed.append(p["Prefix"])
+            return {"Contents": [{"Key": f"{p['Prefix']}{i}", "Size": 1, "LastModified": datetime(2026, 1, 1, tzinfo=timezone.utc), "ETag": '"e"'} for i in range(2)],
+                    "IsTruncated": False}
+        client = MagicMock(); client.list_objects_v2.side_effect = list_objects_v2
+        with patch.object(m._s3_manager, "get_client", return_value=client), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        assert "a/" not in listed and "b/" in listed, f"completed prefix must not be re-listed; listed={listed}"
+        with m._get_db(bucket, "default") as db:
+            row = db.execute("SELECT status, current_crawl_gen, total_objects FROM crawl_status WHERE id=1").fetchone()
+            assert row["status"] == "complete" and row["current_crawl_gen"] == 7 and row["total_objects"] == 4
+
+    def test_delta_does_not_relabel_interrupted_as_complete(self, app):
+        m = self._main()
+        bucket = "intbkt"
+        m._init_db(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            db.execute("UPDATE crawl_status SET status='interrupted' WHERE id=1"); db.commit()
+            # the guarded UPDATE the delta path uses
+            db.execute("UPDATE crawl_status SET status='complete', last_crawl_end=? WHERE id=1 AND status <> 'interrupted'", ("x",))
+            db.commit()
+            assert db.execute("SELECT status FROM crawl_status WHERE id=1").fetchone()[0] == "interrupted"
+
+    def test_crawl_status_reports_full_crawl_complete(self, client, admin_cookies):
+        m = self._main()
+        bucket = "statbkt"
+        m._init_db(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            db.execute("UPDATE crawl_status SET status='interrupted', crawl_duration=12.5, total_objects=10 WHERE id=1"); db.commit()
+        r = client.get(f"/api/buckets/{bucket}/crawl-status", cookies=admin_cookies)
+        assert r.status_code == 200 and r.json()["full_crawl_complete"] is False
+        with m._get_db(bucket, "default") as db:
+            db.execute("UPDATE crawl_status SET status='complete' WHERE id=1"); db.commit()
+        assert client.get(f"/api/buckets/{bucket}/crawl-status", cookies=admin_cookies).json()["full_crawl_complete"] is True

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -933,6 +933,9 @@ class TestCrawlerCorrectness:
         lists only unfinished prefixes, and ends complete with every object present."""
         m = self._main()
         bucket = "resumebkt"
+        for suffix in ("", "-wal", "-shm"):  # fresh DB every run: the shared test DB_DIR may hold a stale/corrupt copy
+            try: os.remove(m._db_path(bucket, "default") + suffix)
+            except FileNotFoundError: pass
         m._init_db(bucket, "default")
         with m._get_db(bucket, "default") as db:
             db.execute("UPDATE crawl_status SET status='crawling', current_crawl_gen=7 WHERE id=1")

--- a/benchmark/prodlab/README.md
+++ b/benchmark/prodlab/README.md
@@ -1,0 +1,27 @@
+# Production-shaped lab (kind + S3 listing simulator)
+
+Reproduces the production shape without production data: **19 buckets, 15,500,000 objects, one bucket of
+9,900,000**, Druid-deep-storage key layout (`druid/segments/<ds>/<interval>/<version>/<partition>/index.zip`),
+configurable provider latency and throttling, and injectable adds/deletes with a known truth count. The
+backend runs from the real Helm chart on a real PVC with `Recreate`, so rollouts behave like production.
+
+    kind create cluster --name sairo-lab
+    docker build -t sairo:phase-a . && kind load docker-image sairo:phase-a --name sairo-lab
+    kubectl create ns lab
+    kubectl -n lab create configmap s3sim --from-file=s3sim.py --from-file=spec.json=spec-prod.json
+    kubectl -n lab apply -f s3sim.yaml            # Deployment + Service (see below)
+    helm upgrade --install sairo charts/sairo -n lab \
+      --set image.repository=sairo --set image.tag=phase-a --set image.pullPolicy=Never \
+      --set s3.endpoint=http://s3sim:9000 --set s3.pathStyle=true --set s3.accessKey=lab --set s3.secretKey=lab \
+      --set telemetry.enabled=false --set auth.adminPass=labpass123 --set auth.jwtSecret=<fixed> --set auth.secureCookie=false
+    ./monitor.sh --for 5400            # progress CSV + log under out/
+
+Simulator admin API (port 9001 inside the cluster; `kubectl -n lab port-forward svc/s3sim 9001:9001`):
+`GET /truth?bucket=`, `GET /stats`, `POST /latency {"ms":..}`, `POST /error_rate {"rate":..}`,
+`POST /mutate {"bucket":..,"add":[..],"delete":[..]}`, `POST /delete_positions {"bucket":..,"n":..}`.
+
+Why a simulator: 15.5M real objects on MinIO would take hours to create and tens of GB; the simulator
+generates keys from a fixed grid so any position is O(1) and any prefix is a binary search. It answers
+exactly the calls the crawler makes (ListBuckets, HeadBucket, ListObjectsV2 with prefix / delimiter /
+max-keys / continuation-token / start-after) and benign metadata for the UI. What it cannot do: byte
+operations, real provider latency profiles, real throttling policy. Use the read-only production run for those.

--- a/benchmark/prodlab/monitor.sh
+++ b/benchmark/prodlab/monitor.sh
@@ -7,8 +7,8 @@ HERE=$(cd "$(dirname "$0")" && pwd); OUT=$HERE/out; mkdir -p "$OUT"
 FOR=7200; INT=30
 while [ $# -gt 0 ]; do case "$1" in --for) FOR=$2; shift 2;; --interval) INT=$2; shift 2;; *) shift;; esac; done
 NS=lab; PORT=18000
-kubectl -n $NS port-forward svc/sairo $PORT:8000 >/dev/null 2>&1 & PF=$!; trap 'kill $PF 2>/dev/null' EXIT
-for i in $(seq 1 30); do curl -sf http://127.0.0.1:$PORT/healthz >/dev/null && break; sleep 1; done
+kubectl -n $NS port-forward deploy/sairo $PORT:8000 >/dev/null 2>&1 & PF=$!; trap 'kill $PF 2>/dev/null' EXIT
+for i in $(seq 1 30); do curl -sf http://127.0.0.1:$PORT/healthz >/dev/null && break; sleep 1; [ $i -eq 30 ] && { echo "backend unreachable via port-forward"; exit 1; }; done
 CJ=$OUT/cj; curl -s -c $CJ -X POST http://127.0.0.1:$PORT/api/auth/login -H 'Content-Type: application/json' -d '{"username":"admin","password":"labpass123"}' >/dev/null
 api() { curl -s -b $CJ "http://127.0.0.1:$PORT$1"; }
 BUCKETS=$(api /api/buckets | python3 -c 'import sys,json; d=json.load(sys.stdin); bs=d if isinstance(d,list) else d.get("buckets",d); print(" ".join((b["name"] if isinstance(b,dict) else b) for b in bs))')

--- a/benchmark/prodlab/monitor.sh
+++ b/benchmark/prodlab/monitor.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+# Lab monitor: watches all buckets' crawl-status, pod RSS and DB size until every bucket is complete
+# (or --for SECONDS elapses). Writes a CSV + human log under out/. Read-only against the backend.
+#   ./monitor.sh [--for 3600] [--interval 30]
+set -u
+HERE=$(cd "$(dirname "$0")" && pwd); OUT=$HERE/out; mkdir -p "$OUT"
+FOR=7200; INT=30
+while [ $# -gt 0 ]; do case "$1" in --for) FOR=$2; shift 2;; --interval) INT=$2; shift 2;; *) shift;; esac; done
+NS=lab; PORT=18000
+kubectl -n $NS port-forward svc/sairo $PORT:8000 >/dev/null 2>&1 & PF=$!; trap 'kill $PF 2>/dev/null' EXIT
+for i in $(seq 1 30); do curl -sf http://127.0.0.1:$PORT/healthz >/dev/null && break; sleep 1; done
+CJ=$OUT/cj; curl -s -c $CJ -X POST http://127.0.0.1:$PORT/api/auth/login -H 'Content-Type: application/json' -d '{"username":"admin","password":"labpass123"}' >/dev/null
+api() { curl -s -b $CJ "http://127.0.0.1:$PORT$1"; }
+BUCKETS=$(api /api/buckets | python3 -c 'import sys,json; d=json.load(sys.stdin); bs=d if isinstance(d,list) else d.get("buckets",d); print(" ".join((b["name"] if isinstance(b,dict) else b) for b in bs))')
+echo "buckets: $BUCKETS"
+CSV=$OUT/progress.csv; echo "ts,bucket,status,total_objects,crawl_duration,crawl_elapsed,full_crawl_complete" > $CSV
+POD() { kubectl -n $NS get pod -l app=sairo -o jsonpath='{.items[0].metadata.name}'; }
+t0=$(date +%s)
+while :; do
+  now=$(date +%s); ts=$(date +%T); pod=$(POD)
+  rss=$(kubectl -n $NS exec $pod -- sh -c 'grep VmRSS /proc/1/status' 2>/dev/null | awk '{printf "%.0f", $2/1024}')
+  dbsz=$(kubectl -n $NS exec $pod -- sh -c 'du -sm /data 2>/dev/null | cut -f1' 2>/dev/null)
+  done_n=0; total_n=0; line=""
+  for b in $BUCKETS; do
+    j=$(api "/api/buckets/$b/crawl-status")
+    read st tot dur el fcc <<<"$(echo "$j" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("status",""), d.get("total_objects") or 0, d.get("crawl_duration") or 0, d.get("crawl_elapsed") or "", d.get("full_crawl_complete",""))')"
+    echo "$ts,$b,$st,$tot,$dur,$el,$fcc" >> $CSV
+    total_n=$((total_n+1)); [ "$st" = "complete" ] && done_n=$((done_n+1))
+    [ "$b" = "seg-main" ] && line="seg-main: $st objects=$tot dur=${dur}s elapsed=${el}s"
+  done
+  echo "[$ts +$((now-t0))s] complete=$done_n/$total_n | $line | RSS=${rss}MB /data=${dbsz}MB" | tee -a $OUT/monitor.log
+  [ "$done_n" -eq "$total_n" ] && { echo "ALL COMPLETE after $((now-t0))s" | tee -a $OUT/monitor.log; break; }
+  [ $((now-t0)) -ge $FOR ] && { echo "time budget reached" | tee -a $OUT/monitor.log; break; }
+  sleep $INT
+done
+echo "--- crawl summary lines from the pod log ---"
+kubectl -n $NS logs $(POD) 2>/dev/null | grep -E "Crawl complete|Resuming|interrupted|Sub-prefix|Expanded|Force-releasing|database is locked|Error" | tail -40 | tee -a $OUT/monitor.log

--- a/benchmark/prodlab/s3sim.py
+++ b/benchmark/prodlab/s3sim.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""s3sim — a deterministic S3 *listing* simulator for production-shaped crawler tests.
+
+Presents N buckets with millions of Druid-deep-storage-shaped keys without storing anything:
+keys are generated from a fixed (datasources × intervals × partitions) grid, so any position
+maps to a key in O(1) and any prefix maps to a position range by binary search. Implements
+exactly what the crawler needs (ListBuckets, HeadBucket, ListObjectsV2 with prefix /
+delimiter / max-keys / continuation-token / start-after) plus benign answers for the bucket
+metadata calls the UI makes. Latency, throttling (503 SlowDown) and mutations (add/delete
+keys, with a known truth count) are controlled through an admin API so delta/reconcile
+correctness can be checked against ground truth.
+
+Run:  python3 s3sim.py --spec spec.json --port 9000 --admin-port 9001 --latency-ms 40
+Spec: {"buckets": [{"name": "segments-a", "datasources": 40, "intervals": 2500, "partitions": 99}, ...]}
+      objects = datasources × intervals × partitions  (40 × 2500 × 99 = 9,900,000)
+"""
+import argparse, base64, bisect, datetime as dt, hashlib, json, random, threading, time
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, unquote, urlsplit
+from xml.sax.saxutils import escape
+
+EPOCH = dt.date(2024, 1, 1)
+VERSION = "2025-08-01T12:34:56.789Z"
+
+
+class Bucket:
+    def __init__(self, spec):
+        self.name = spec["name"]
+        self.ds, self.iv, self.pt = int(spec["datasources"]), int(spec["intervals"]), int(spec["partitions"])
+        self.n = self.ds * self.iv * self.pt
+        self.size_p50 = int(spec.get("size_p50", 17 * 1024 * 1024))
+        self.deleted = set()          # generated keys removed via admin
+        self.added = []               # sorted extra keys added via admin (key, size)
+        self.lock = threading.Lock()
+
+    # position <-> key (monotonic: zero-padded components keep nested-loop order == lexicographic)
+    def key(self, n):
+        i, r = divmod(n, self.iv * self.pt)
+        j, k = divmod(r, self.pt)
+        d0 = EPOCH + dt.timedelta(days=j)
+        d1 = d0 + dt.timedelta(days=1)
+        return (f"druid/segments/ds_{i:03d}/{d0.isoformat()}T00:00:00.000Z_{d1.isoformat()}T00:00:00.000Z/"
+                f"{VERSION}/{k:04d}/index.zip")
+
+    def first_ge(self, s):
+        """Smallest position whose key >= s (binary search over the monotonic key space)."""
+        lo, hi = 0, self.n
+        while lo < hi:
+            mid = (lo + hi) // 2
+            if self.key(mid) < s:
+                lo = mid + 1
+            else:
+                hi = mid
+        return lo
+
+    def obj(self, key):
+        h = hashlib.md5(key.encode()).hexdigest()
+        size = self.size_p50 // 2 + int(h[:6], 16) % self.size_p50  # 0.5x .. 1.5x p50
+        # LastModified follows the interval date so "recent" partitions look recent
+        try:
+            day = key.split("/")[3][:10]
+            lm = dt.datetime.fromisoformat(day).replace(tzinfo=dt.timezone.utc) + dt.timedelta(hours=6)
+        except Exception:
+            lm = dt.datetime(2025, 1, 1, tzinfo=dt.timezone.utc)
+        return key, size, lm.strftime("%Y-%m-%dT%H:%M:%S.000Z"), h
+
+    def truth_count(self):
+        with self.lock:
+            return self.n - len(self.deleted) + len(self.added)
+
+    def list_v2(self, prefix, delimiter, max_keys, token, start_after):
+        """Returns (contents, common_prefixes, next_token). Sorted, S3-exact semantics."""
+        upper = prefix[:-1] + chr(ord(prefix[-1]) + 1) if prefix else None
+        n = self.first_ge(prefix) if prefix else 0
+        if token:
+            n = max(n, int(base64.urlsafe_b64decode(token.encode()).decode()))
+        if start_after:
+            n = max(n, self.first_ge(start_after + "\x00"))
+        with self.lock:
+            added = [a for a in self.added if a[0].startswith(prefix)]
+            deleted = set(self.deleted)
+        ai = 0
+        if token or start_after:
+            floor = start_after or self.key(n - 1) if n > 0 else ""
+            ai = bisect.bisect_right([a[0] for a in added], floor)
+        contents, cps, count = [], [], 0
+        while count < max_keys:
+            gen_key = self.key(n) if n < self.n else None
+            if gen_key is not None and upper is not None and gen_key >= upper:
+                gen_key = None
+            add_key = added[ai][0] if ai < len(added) else None
+            if gen_key is None and add_key is None:
+                return contents, cps, None
+            # next key in merged order
+            if add_key is not None and (gen_key is None or add_key < gen_key):
+                key, size = added[ai]; ai += 1; src = "add"
+            else:
+                key = gen_key; n += 1; src = "gen"
+                if key in deleted:
+                    continue
+            rest = key[len(prefix):]
+            if delimiter and delimiter in rest:
+                cp = prefix + rest[: rest.index(delimiter) + 1]
+                if not cps or cps[-1] != cp:
+                    cps.append(cp); count += 1
+                # skip the whole common prefix in the generated space
+                cp_upper = cp[:-1] + chr(ord(cp[-1]) + 1)
+                n = max(n, self.first_ge(cp_upper))
+                while ai < len(added) and added[ai][0].startswith(cp):
+                    ai += 1
+                continue
+            o = self.obj(key)
+            if src == "add":
+                o = (key, size, o[2], o[3])
+            contents.append(o); count += 1
+        # more?
+        more_gen = n < self.n and (upper is None or self.key(n) < upper)
+        more_add = ai < len(added)
+        if not (more_gen or more_add):
+            return contents, cps, None
+        return contents, cps, base64.urlsafe_b64encode(str(n).encode()).decode()
+
+
+class State:
+    def __init__(self, spec, latency_ms, error_rate):
+        self.buckets = {b["name"]: Bucket(b) for b in spec["buckets"]}
+        self.latency_ms = latency_ms
+        self.error_rate = error_rate
+        self.requests = 0
+        self.lock = threading.Lock()
+
+
+def xml_list(bucket, prefix, delimiter, max_keys, contents, cps, next_token, token):
+    parts = ['<?xml version="1.0" encoding="UTF-8"?>',
+             '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/">',
+             f"<Name>{escape(bucket)}</Name><Prefix>{escape(prefix)}</Prefix><MaxKeys>{max_keys}</MaxKeys>",
+             f"<KeyCount>{len(contents) + len(cps)}</KeyCount>",
+             f"<IsTruncated>{'true' if next_token else 'false'}</IsTruncated>"]
+    if delimiter:
+        parts.append(f"<Delimiter>{escape(delimiter)}</Delimiter>")
+    if token:
+        parts.append(f"<ContinuationToken>{escape(token)}</ContinuationToken>")
+    if next_token:
+        parts.append(f"<NextContinuationToken>{escape(next_token)}</NextContinuationToken>")
+    for key, size, lm, etag in contents:
+        parts.append(f"<Contents><Key>{escape(key)}</Key><LastModified>{lm}</LastModified>"
+                     f'<ETag>"{etag}"</ETag><Size>{size}</Size><StorageClass>STANDARD</StorageClass></Contents>')
+    for cp in cps:
+        parts.append(f"<CommonPrefixes><Prefix>{escape(cp)}</Prefix></CommonPrefixes>")
+    parts.append("</ListBucketResult>")
+    return "".join(parts).encode()
+
+
+def make_handler(state):
+    class H(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        def log_message(self, *a): pass
+
+        def _send(self, code, body=b"", ctype="application/xml"):
+            self.send_response(code)
+            self.send_header("Content-Type", ctype)
+            self.send_header("Content-Length", str(len(body)))
+            self.send_header("x-amz-request-id", f"{state.requests:016x}")
+            self.end_headers()
+            if body and self.command != "HEAD":
+                self.wfile.write(body)
+
+        def _err(self, code, s3code, msg):
+            self._send(code, f'<?xml version="1.0"?><Error><Code>{s3code}</Code><Message>{msg}</Message></Error>'.encode())
+
+        def do_HEAD(self):
+            path = urlsplit(self.path).path.strip("/")
+            if path.split("/")[0] in state.buckets:
+                self._send(200)
+            else:
+                self._err(404, "NoSuchBucket", "no such bucket")
+
+        def do_GET(self):
+            with state.lock:
+                state.requests += 1
+            u = urlsplit(self.path); q = parse_qs(u.query, keep_blank_values=True)
+            path = unquote(u.path).strip("/")
+            if state.latency_ms:
+                time.sleep(state.latency_ms / 1000.0)
+            if state.error_rate and random.random() < state.error_rate:
+                return self._err(503, "SlowDown", "Please reduce your request rate.")
+            if path == "":
+                bl = "".join(f"<Bucket><Name>{escape(b)}</Name><CreationDate>2024-01-01T00:00:00.000Z</CreationDate></Bucket>" for b in state.buckets)
+                return self._send(200, f'<?xml version="1.0"?><ListAllMyBucketsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>sim</ID><DisplayName>sim</DisplayName></Owner><Buckets>{bl}</Buckets></ListAllMyBucketsResult>'.encode())
+            bucket, _, key = path.partition("/")
+            b = state.buckets.get(bucket)
+            if b is None:
+                return self._err(404, "NoSuchBucket", "no such bucket")
+            if key:
+                return self._err(404, "NoSuchKey", "listing-only simulator")
+            if q.get("list-type", [""])[0] == "2" or "prefix" in q or "delimiter" in q:
+                prefix = q.get("prefix", [""])[0]; delimiter = q.get("delimiter", [""])[0]
+                max_keys = min(int(q.get("max-keys", ["1000"])[0] or 1000), 1000)
+                token = q.get("continuation-token", [None])[0]; start_after = q.get("start-after", [None])[0]
+                contents, cps, nxt = b.list_v2(prefix, delimiter, max_keys, token, start_after)
+                return self._send(200, xml_list(bucket, prefix, delimiter, max_keys, contents, cps, nxt, token))
+            # benign bucket metadata for the UI's settings tabs
+            if "versioning" in q:
+                return self._send(200, b'<?xml version="1.0"?><VersioningConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"/>')
+            if "location" in q:
+                return self._send(200, b'<?xml version="1.0"?><LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">us-east-1</LocationConstraint>')
+            if "acl" in q:
+                return self._send(200, b'<?xml version="1.0"?><AccessControlPolicy xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Owner><ID>sim</ID></Owner><AccessControlList/></AccessControlPolicy>')
+            if "versions" in q:
+                return self._send(200, f'<?xml version="1.0"?><ListVersionsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Name>{escape(bucket)}</Name><IsTruncated>false</IsTruncated></ListVersionsResult>'.encode())
+            if "uploads" in q:
+                return self._send(200, f'<?xml version="1.0"?><ListMultipartUploadsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><Bucket>{escape(bucket)}</Bucket><IsTruncated>false</IsTruncated></ListMultipartUploadsResult>'.encode())
+            if "tagging" in q:
+                return self._err(404, "NoSuchTagSet", "no tags")
+            if "lifecycle" in q:
+                return self._err(404, "NoSuchLifecycleConfiguration", "none")
+            if "cors" in q:
+                return self._err(404, "NoSuchCORSConfiguration", "none")
+            if "object-lock" in q:
+                return self._err(404, "ObjectLockConfigurationNotFoundError", "none")
+            # bare GET /bucket == ListObjects (v1) — answer with v2 shape, boto handles it
+            contents, cps, nxt = b.list_v2(q.get("prefix", [""])[0], q.get("delimiter", [""])[0], 1000, None, None)
+            return self._send(200, xml_list(bucket, "", "", 1000, contents, cps, nxt, None))
+
+        def do_PUT(self):
+            self._err(501, "NotImplemented", "listing-only simulator")
+        def do_POST(self):
+            self._err(501, "NotImplemented", "listing-only simulator")
+        def do_DELETE(self):
+            self._err(501, "NotImplemented", "listing-only simulator")
+    return H
+
+
+def make_admin(state):
+    class A(BaseHTTPRequestHandler):
+        protocol_version = "HTTP/1.1"
+        def log_message(self, *a): pass
+        def _json(self, code, obj):
+            body = json.dumps(obj).encode()
+            self.send_response(code); self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body))); self.end_headers(); self.wfile.write(body)
+        def do_GET(self):
+            u = urlsplit(self.path); q = parse_qs(u.query)
+            if u.path == "/truth":
+                b = state.buckets.get(q.get("bucket", [""])[0])
+                if not b: return self._json(404, {"error": "no such bucket"})
+                return self._json(200, {"bucket": b.name, "count": b.truth_count(), "generated": b.n,
+                                        "deleted": len(b.deleted), "added": len(b.added)})
+            if u.path == "/stats":
+                return self._json(200, {"requests": state.requests, "latency_ms": state.latency_ms,
+                                        "error_rate": state.error_rate,
+                                        "buckets": {n: b.truth_count() for n, b in state.buckets.items()}})
+            self._json(404, {"error": "unknown"})
+        def do_POST(self):
+            u = urlsplit(self.path)
+            body = json.loads(self.rfile.read(int(self.headers.get("Content-Length", 0)) or 0) or b"{}")
+            if u.path == "/latency":
+                state.latency_ms = float(body.get("ms", 0)); return self._json(200, {"latency_ms": state.latency_ms})
+            if u.path == "/error_rate":
+                state.error_rate = float(body.get("rate", 0)); return self._json(200, {"error_rate": state.error_rate})
+            if u.path == "/mutate":
+                b = state.buckets.get(body.get("bucket", ""))
+                if not b: return self._json(404, {"error": "no such bucket"})
+                with b.lock:
+                    for k in body.get("delete", []):
+                        b.deleted.add(k)
+                    for k in body.get("add", []):
+                        if not any(a[0] == k for a in b.added):
+                            bisect.insort(b.added, (k, int(body.get("size", 1024))))
+                return self._json(200, {"count": b.truth_count()})
+            if u.path == "/delete_positions":  # delete N generated keys evenly spread (cheap way to create stale rows)
+                b = state.buckets.get(body.get("bucket", "")); n = int(body.get("n", 0))
+                if not b: return self._json(404, {"error": "no such bucket"})
+                step = max(1, b.n // max(1, n))
+                with b.lock:
+                    for pos in range(0, b.n, step):
+                        b.deleted.add(b.key(pos))
+                        if len(b.deleted) >= n: break
+                return self._json(200, {"deleted": len(b.deleted), "count": b.truth_count()})
+            self._json(404, {"error": "unknown"})
+    return A
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--spec", required=True); ap.add_argument("--port", type=int, default=9000)
+    ap.add_argument("--admin-port", type=int, default=9001); ap.add_argument("--latency-ms", type=float, default=0)
+    ap.add_argument("--error-rate", type=float, default=0.0)
+    a = ap.parse_args()
+    state = State(json.load(open(a.spec)), a.latency_ms, a.error_rate)
+    total = sum(b.n for b in state.buckets.values())
+    print(f"s3sim: {len(state.buckets)} buckets, {total:,} objects, latency {a.latency_ms} ms, port {a.port} (admin {a.admin_port})", flush=True)
+    threading.Thread(target=ThreadingHTTPServer(("0.0.0.0", a.admin_port), make_admin(state)).serve_forever, daemon=True).start()
+    ThreadingHTTPServer(("0.0.0.0", a.port), make_handler(state)).serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmark/prodlab/s3sim.yaml
+++ b/benchmark/prodlab/s3sim.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata: { name: s3sim }
+spec:
+  replicas: 1
+  selector: { matchLabels: { app: s3sim } }
+  template:
+    metadata: { labels: { app: s3sim } }
+    spec:
+      containers:
+        - name: s3sim
+          image: python:3.12-slim
+          command: ["python3", "/app/s3sim.py", "--spec", "/app/spec.json", "--port", "9000", "--admin-port", "9001", "--latency-ms", "40"]
+          ports: [{ containerPort: 9000 }, { containerPort: 9001 }]
+          volumeMounts: [{ name: app, mountPath: /app }]
+          resources: { requests: { cpu: "1", memory: 256Mi }, limits: { cpu: "3", memory: 512Mi } }
+      volumes: [{ name: app, configMap: { name: s3sim } }]
+---
+apiVersion: v1
+kind: Service
+metadata: { name: s3sim }
+spec:
+  selector: { app: s3sim }
+  ports:
+    - { name: s3, port: 9000, targetPort: 9000 }
+    - { name: admin, port: 9001, targetPort: 9001 }

--- a/benchmark/prodlab/spec-prod.json
+++ b/benchmark/prodlab/spec-prod.json
@@ -1,0 +1,21 @@
+{"buckets": [
+  {"name": "seg-main",  "datasources": 40, "intervals": 2500, "partitions": 99},
+  {"name": "seg-b1", "datasources": 10, "intervals": 1000, "partitions": 100},
+  {"name": "seg-b2", "datasources": 10, "intervals": 1000, "partitions": 100},
+  {"name": "seg-b3", "datasources": 10, "intervals": 1000, "partitions": 100},
+  {"name": "seg-c1", "datasources": 6, "intervals": 500, "partitions": 100},
+  {"name": "seg-c2", "datasources": 6, "intervals": 500, "partitions": 100},
+  {"name": "seg-c3", "datasources": 6, "intervals": 500, "partitions": 100},
+  {"name": "seg-c4", "datasources": 6, "intervals": 500, "partitions": 100},
+  {"name": "seg-c5", "datasources": 6, "intervals": 500, "partitions": 100},
+  {"name": "seg-d01", "datasources": 5, "intervals": 220, "partitions": 100},
+  {"name": "seg-d02", "datasources": 5, "intervals": 220, "partitions": 100},
+  {"name": "seg-d03", "datasources": 5, "intervals": 220, "partitions": 100},
+  {"name": "seg-d04", "datasources": 5, "intervals": 220, "partitions": 100},
+  {"name": "seg-d05", "datasources": 5, "intervals": 220, "partitions": 100},
+  {"name": "seg-d06", "datasources": 5, "intervals": 220, "partitions": 100},
+  {"name": "seg-d07", "datasources": 5, "intervals": 220, "partitions": 100},
+  {"name": "seg-d08", "datasources": 5, "intervals": 220, "partitions": 100},
+  {"name": "seg-d09", "datasources": 5, "intervals": 220, "partitions": 100},
+  {"name": "seg-d10", "datasources": 5, "intervals": 220, "partitions": 100}
+]}

--- a/benchmark/restart_harness/README.md
+++ b/benchmark/restart_harness/README.md
@@ -1,0 +1,14 @@
+# Restart harness (SAE-71)
+
+Reproduces the "restart mid-crawl leaves a partial index that reports `complete`" failure and asserts the Phase A exit gates.
+
+    docker compose up -d                      # MinIO :9000, toxiproxy :8474 / :19000
+    ./driver.sh                               # ~5 min; writes out/rca/REPORT.txt; exit 0 = all gates pass
+
+What it does: populates 30 prefixes × 4,000 objects, puts MinIO behind a 1 s latency proxy, starts the backend
+(`TELEMETRY=false`, pinned `JWT_SECRET`), kills it (SIGTERM → 30 s → SIGKILL, like a `Recreate` rollout) once
+`crawl_status.total_objects ≥ 56,000`, restarts it and watches the scheduler for 70 s, kills/restarts again, then
+lets it heal with `FULL_CRAWL_INTERVAL=30`.
+
+Gates: (1) objects reach 120,000 after restart; (2) `crawl-status` never `complete` while partial;
+(3) zero "Force-releasing" duplicate crawls; (4) no tracebacks. On `main` @ 64bdb2f gates 1–2 fail; on Phase A they pass.

--- a/benchmark/restart_harness/docker-compose.yml
+++ b/benchmark/restart_harness/docker-compose.yml
@@ -1,0 +1,10 @@
+# Restart harness infra: MinIO + toxiproxy (adds latency so a crawl is slow enough to interrupt).
+services:
+  minio:
+    image: minio/minio:latest
+    command: server /data
+    environment: { MINIO_ROOT_USER: minioadmin, MINIO_ROOT_PASSWORD: minioadmin }
+    ports: ["9000:9000"]
+  toxiproxy:
+    image: ghcr.io/shopify/toxiproxy:2.9.0
+    ports: ["8474:8474", "19000:19000"]

--- a/benchmark/restart_harness/driver.sh
+++ b/benchmark/restart_harness/driver.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+source "$(cd "$(dirname "$0")" && pwd)/lib.sh"
+R=$S/rca/REPORT.txt; : > $R
+say() { echo "[$(date +%T)] $*" | tee -a $R; }
+ensure_proxy() { # idempotent: create the toxiproxy route localhost:19000 -> minio:9000 with a latency toxic
+  curl -s -o /dev/null -X POST http://localhost:8474/proxies -d '{"name":"s3","listen":"0.0.0.0:19000","upstream":"'"${MINIO_UPSTREAM:-minio:9000}"'","enabled":true}'
+  curl -s -o /dev/null -X POST http://localhost:8474/proxies/s3/toxics -d '{"name":"lat","type":"latency","stream":"downstream","toxicity":1.0,"attributes":{"latency":1000,"jitter":0}}'
+  curl -sf http://localhost:8474/proxies/s3 >/dev/null || { echo "toxiproxy route missing"; exit 1; }
+}
+lat() { curl -s -X POST http://localhost:8474/proxies/s3/toxics/lat -d "{\"attributes\":{\"latency\":$1,\"jitter\":0}}" >/dev/null; say "proxy latency -> ${1}ms"; }
+logs() { grep -E "Queued crawl|Seeded schedule|Full recrawl queued|Full crawl queued|Delta crawl queued|Force-releasing|Crawl (complete|finished)|crawl.*complete|database is locked|Error|Traceback" $S/rca/backend_$1.log | sed 's/^/    | /' | tail -${2:-12} | tee -a $R; }
+
+# populate (idempotent: re-PUTs the same 120k keys)
+( cd $REPO/backend && ${PYTHON:-.venv/bin/python} "$(dirname "$0")/populate.py" ) > $S/rca/populate.log 2>&1 || ( cd $REPO && ${PYTHON:-backend/.venv/bin/python} benchmark/restart_harness/populate.py > $S/rca/populate.log 2>&1 )
+ensure_proxy
+say "S3 bucket 'rca' populated: $(grep '^DONE' $S/rca/populate.log)"
+S3_COUNT=$(cd $REPO/backend && .venv/bin/python -c "
+import boto3; from botocore.client import Config
+s3=boto3.client('s3',endpoint_url='http://localhost:9000',aws_access_key_id='minioadmin',aws_secret_access_key='minioadmin',config=Config(signature_version='s3v4'))
+n=0
+for p in s3.get_paginator('list_objects_v2').paginate(Bucket='rca'): n+=p.get('KeyCount',0)
+print(n)")
+say "ground truth: S3 holds $S3_COUNT objects in 30 top-level prefixes"
+
+############ PHASE 1: deploy #1 — fresh PVC, initial full crawl, then a rollout kills the pod mid-crawl
+say "================ PHASE 1: fresh index; rollout (SIGTERM->30s->SIGKILL) lands mid-crawl ================"
+rm -rf $DATA; mkdir -p $DATA; lat 1000
+start_backend p1
+t0=$(date +%s.%N)
+# wait until crawl_status.total_objects (updated per completed prefix) exceeds the 50k LARGE-bucket threshold, then kill mid-crawl
+while :; do c=$(q 'select total_objects from crawl_status where id=1'); st=$(q "select status from crawl_status where id=1"); [ "$st" = "complete" ] && { say "ABORT: crawl completed before the kill could land"; exit 1; }; [ -n "$c" ] && [ "$c" -ge 56000 ] && break; sleep 0.1; done
+say "after $(printf '%.1f' $(echo "$(date +%s.%N) - $t0" | bc))s crawl_status.total_objects=$c (>50k => this index will be seeded as a LARGE bucket); crawl still running for the remaining prefixes"
+lat 10000   # remaining prefixes now take >30s -> models a multi-hour prod crawl vs a 30s grace period
+say "rollout begins: SIGTERM to pod"
+k8s_stop | tee -a $R
+say "index state left on the PVC after the killed deploy:"; snapshot | tee -a $R
+say "backend log (deploy #1):"; logs p1 8
+lat 1000
+
+############ PHASE 2: deploy #2 — pod restarts on the partial index
+say "================ PHASE 2: restart on the partial index; watch the scheduler for 70s (RECRAWL_INTERVAL=15s, FULL_CRAWL_INTERVAL=3600s default) ================"
+start_backend p2
+sleep 8; say "startup decision:"; grep -E "Seeded schedule|Queued|Resuming" $S/rca/backend_p2.log | sed 's/^/    | /' | tee -a $R
+for i in 1 2 3 4 5; do sleep 14; say "t+$((i*14))s objects=$(q 'select count(*) from objects') status='$(q "select status from crawl_status where id=1")' | scheduler lines so far: full=$(grep -cE 'Full (re)?crawl queued|Queued crawl' $S/rca/backend_p2.log) delta=$(grep -c 'Delta crawl queued' $S/rca/backend_p2.log)"; done
+snapshot | tee -a $R
+login
+say "API view of the bucket while 'ready':"
+say "  crawl-status: $(api /api/buckets/rca/crawl-status | python3 -c 'import sys,json; d=json.load(sys.stdin); print({k:d.get(k) for k in ("status","total_objects","crawl_duration")})')"
+tr0=$(date +%s.%N); root=$(api "/api/buckets/rca/list?prefix=&limit=200"); say "  root listing: $(echo "$root" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d.get("folders",[])),"folders,",len(d.get("files",[])),"files")') in $(printf '%.2f' $(echo "$(date +%s.%N) - $tr0" | bc))s"
+for p in "ds=00/" "ds=29/"; do
+  idx=$(api "/api/buckets/rca/list?prefix=$p&limit=10000" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d.get("files",[])))')
+  s3=$(api "/api/buckets/rca/list?prefix=$p&fresh=true&limit=10000" | python3 -c 'import sys,json; d=json.load(sys.stdin); print(len(d.get("files",[])))')
+  say "  folder $p : index says $idx files | S3 (fresh=true) says $s3 files"
+done
+say "  search 'part-00001' : $(api '/api/buckets/rca/search?q=part-00001&limit=200' | python3 -c 'import sys,json; d=json.load(sys.stdin); print(d.get("count", d.get("detail")))') results (30 exist in S3)"
+say "backend log (deploy #2):"; logs p2 10
+
+############ PHASE 3: deploy #3 — another rollout within the hour resets the clock again
+say "================ PHASE 3: third rollout inside the same hour ================"
+k8s_stop | tee -a $R
+start_backend p3
+sleep 8; grep -E "Seeded schedule|Queued|Resuming" $S/rca/backend_p3.log | sed 's/^/    | /' | tee -a $R
+sleep 32; say "t+35s objects=$(q 'select count(*) from objects') | full=$(grep -cE 'Full (re)?crawl queued|Queued crawl' $S/rca/backend_p3.log) delta=$(grep -c 'Delta crawl queued' $S/rca/backend_p3.log)"
+
+############ PHASE 4: control — leave it alone past FULL_CRAWL_INTERVAL (shrunk to 30s so we don't wait an hour)
+say "================ PHASE 4 (control): no more rollouts; FULL_CRAWL_INTERVAL=30 to compress the 1h wait ================"
+k8s_stop | tee -a $R
+FULL_CRAWL_INTERVAL=30 start_backend p4
+t0=$(date +%s)
+for i in $(seq 1 60); do sleep 3; c=$(q 'select count(*) from objects'); fs=$(q 'select count(*) from folder_stats'); st=$(q "select status from crawl_status where id=1"); [ "$c" = "$S3_COUNT" ] && [ "${fs:-0}" -gt 0 ] && [ "$st" = "complete" ] && break; done
+say "healed after $(( $(date +%s)-t0 ))s of being left alone:"; snapshot | tee -a $R
+say "backend log (deploy #4):"; logs p4 8
+k8s_stop | tee -a $R
+# ---------- assertions (Phase A exit gates) ----------
+FAIL=0
+chk() { if eval "$2"; then say "PASS: $1"; else say "FAIL: $1"; FAIL=1; fi; }
+P2_OBJ=$(grep -E "t\+70s objects=" $R | tail -1 | sed -E 's/.*objects=([0-9]*).*/\1/')
+chk "gate 1: index reaches 120000 after restart (got ${P2_OBJ:-none})" '[ "${P2_OBJ:-0}" -eq 120000 ]'
+chk "gate 2: never complete while partial" '! grep -qE "objects=([0-9]{1,5}|1[01][0-9]{4}) status=.complete." $R'
+chk "gate 3: zero force-released duplicate crawls" '[ $(cat $S/rca/backend_p*.log | grep -c "Force-releasing") -eq 0 ]'
+chk "gate 4: no tracebacks in backend logs" '[ $(cat $S/rca/backend_p*.log | grep -c "Traceback" ) -le $(cat $S/rca/backend_p*.log | grep -c "bcrypt version") ]'
+say "DONE (exit $FAIL)"; exit $FAIL

--- a/benchmark/restart_harness/lib.sh
+++ b/benchmark/restart_harness/lib.sh
@@ -8,7 +8,7 @@ DB=$DATA/rca.db
 PORT=8765
 export TELEMETRY=false S3_ENDPOINT=http://localhost:19000 S3_ACCESS_KEY=minioadmin S3_SECRET_KEY=minioadmin \
        DB_DIR=$DATA ADMIN_USER=admin ADMIN_PASS=rcapass S3_PATH_STYLE=true S3_REGION=us-east-1 \
-       JWT_SECRET=rca-fixed-secret-0123456789abcdef0123456789abcdef RECRAWL_INTERVAL=${RECRAWL_INTERVAL:-15} FULL_CRAWL_INTERVAL=${FULL_CRAWL_INTERVAL:-3600}
+       JWT_SECRET=${JWT_SECRET:-$(openssl rand -hex 24)} RECRAWL_INTERVAL=${RECRAWL_INTERVAL:-15} FULL_CRAWL_INTERVAL=${FULL_CRAWL_INTERVAL:-3600}
 start_backend() { # $1 = tag  (exec => $! is uvicorn's real pid, so k8s_stop kills the real process)
   ( cd $REPO/backend && exec nohup .venv/bin/python -m uvicorn main:app --host 127.0.0.1 --port $PORT ) > $S/rca/backend_$1.log 2>&1 &
   echo $! > $S/rca/pid

--- a/benchmark/restart_harness/lib.sh
+++ b/benchmark/restart_harness/lib.sh
@@ -1,0 +1,29 @@
+# Shared helpers for the crawler-restart reproduction. Mirrors k8s: SIGTERM, 30s grace, SIGKILL.
+HERE=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+REPO=$(cd "$HERE/../.." && pwd)
+S=${HARNESS_OUT:-$HERE/out}
+mkdir -p "$S/rca"
+DATA=$S/rca/data
+DB=$DATA/rca.db
+PORT=8765
+export TELEMETRY=false S3_ENDPOINT=http://localhost:19000 S3_ACCESS_KEY=minioadmin S3_SECRET_KEY=minioadmin \
+       DB_DIR=$DATA ADMIN_USER=admin ADMIN_PASS=rcapass S3_PATH_STYLE=true S3_REGION=us-east-1 \
+       JWT_SECRET=rca-fixed-secret-0123456789abcdef0123456789abcdef RECRAWL_INTERVAL=${RECRAWL_INTERVAL:-15} FULL_CRAWL_INTERVAL=${FULL_CRAWL_INTERVAL:-3600}
+start_backend() { # $1 = tag  (exec => $! is uvicorn's real pid, so k8s_stop kills the real process)
+  ( cd $REPO/backend && exec nohup .venv/bin/python -m uvicorn main:app --host 127.0.0.1 --port $PORT ) > $S/rca/backend_$1.log 2>&1 &
+  echo $! > $S/rca/pid
+  for i in $(seq 1 60); do curl -sf http://127.0.0.1:$PORT/healthz >/dev/null 2>&1 && { echo "[$(date +%T)] backend '$1' up (pid $(cat $S/rca/pid), cmd: $(ps -o command= -p $(cat $S/rca/pid) | cut -c1-60)) after ~${i}s"; return; }; sleep 0.5; done
+  echo "backend failed to start"; tail -20 $S/rca/backend_$1.log; exit 1
+}
+k8s_stop() { # SIGTERM, wait <=30s, then SIGKILL — exactly what a Recreate rollout does
+  local pid=$(cat $S/rca/pid); kill -TERM $pid 2>/dev/null; local t0=$(date +%s)
+  for i in $(seq 1 60); do kill -0 $pid 2>/dev/null || { echo "[$(date +%T)] exited on SIGTERM after $(( $(date +%s)-t0 ))s"; (lsof -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1 && echo "  WARNING: something still listens on :$PORT") || echo "  verified: nothing listens on :$PORT"; return; }; sleep 0.5; done
+  kill -KILL $pid 2>/dev/null; sleep 0.5; echo "[$(date +%T)] did NOT exit within 30s of SIGTERM -> SIGKILL (this is what kubelet does)"
+  (lsof -iTCP:$PORT -sTCP:LISTEN >/dev/null 2>&1 && echo "  WARNING: something still listens on :$PORT") || echo "  verified: nothing listens on :$PORT"
+}
+q() { sqlite3 "$DB" "$1" 2>/dev/null; }
+snapshot() { # index state
+  echo "  objects=$(q 'select count(*) from objects')  status='$(q "select status from crawl_status where id=1")'  total_objects=$(q 'select total_objects from crawl_status where id=1')  crawl_duration=$(q 'select crawl_duration from crawl_status where id=1')  folder_stats=$(q 'select count(*) from folder_stats')  prefix_children=$(q 'select count(*) from prefix_children')  discovered_prefixes=$(q 'select count(*) from discovered_prefixes')  fts_rows=$(q 'select count(*) from objects_fts')"
+}
+login() { curl -s -c $S/rca/cj -X POST http://127.0.0.1:$PORT/api/auth/login -H 'Content-Type: application/json' -d '{"username":"admin","password":"rcapass"}' >/dev/null; }
+api() { curl -s -b $S/rca/cj "http://127.0.0.1:$PORT$1"; }

--- a/benchmark/restart_harness/populate.py
+++ b/benchmark/restart_harness/populate.py
@@ -1,0 +1,17 @@
+# Populate bucket 'rca' with 30 top-level prefixes x 4000 objects = 120,000 keys (via DIRECT minio port, fast).
+import boto3, concurrent.futures, time, sys
+from botocore.client import Config
+s3 = boto3.client("s3", endpoint_url="http://localhost:9000", aws_access_key_id="minioadmin",
+                  aws_secret_access_key="minioadmin", config=Config(signature_version="s3v4", max_pool_connections=64,
+                  retries={"max_attempts": 5}))
+try: s3.create_bucket(Bucket="rca")
+except Exception: pass
+PREFIXES, PER = 30, 4000
+keys = [f"ds={p:02d}/part-{i:05d}.parquet" for p in range(PREFIXES) for i in range(PER)]
+t0 = time.time(); done = 0
+def put(k): s3.put_object(Bucket="rca", Key=k, Body=b"x"); return 1
+with concurrent.futures.ThreadPoolExecutor(max_workers=48) as ex:
+    for _ in ex.map(put, keys):
+        done += 1
+        if done % 10000 == 0: print(f"{done:,}/{len(keys):,} in {time.time()-t0:.0f}s", flush=True)
+print(f"DONE {done:,} objects in {time.time()-t0:.0f}s", flush=True)

--- a/charts/sairo/templates/deployment.yaml
+++ b/charts/sairo/templates/deployment.yaml
@@ -86,6 +86,9 @@ spec:
               value: {{ .Values.crawler.recrawlInterval | quote }}
             # ── Telemetry: tell the app whether its storage is ephemeral, so anonymous
             #    telemetry can report id_persistence accurately (emptyDir → ephemeral). ──
+            # ── Telemetry (anonymous, aggregate-only heartbeat; set telemetry.enabled=false to opt out) ──
+            - name: TELEMETRY
+              value: {{ if and .Values.telemetry (eq (toString .Values.telemetry.enabled) "false") }}"false"{{ else }}"true"{{ end }}
             - name: SAIRO_STORAGE_EPHEMERAL
               value: {{ not .Values.persistence.enabled | quote }}
             # ── Rate Limiting ──

--- a/charts/sairo/templates/deployment.yaml
+++ b/charts/sairo/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
         app: {{ .Release.Name }}
     spec:
       serviceAccountName: {{ .Release.Name }}
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds | default 30 }}
       securityContext:
         runAsNonRoot: true
         runAsUser: 1000

--- a/charts/sairo/templates/pvc.yaml
+++ b/charts/sairo/templates/pvc.yaml
@@ -3,6 +3,11 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ .Release.Name }}-data
+  {{- if .Values.persistence.keep }}
+  annotations:
+    # Survive `helm uninstall`/reinstall: the index takes hours to rebuild at scale.
+    helm.sh/resource-policy: keep
+  {{- end }}
 spec:
   accessModes:
     {{- if gt (int .Values.replicaCount) 1 }}

--- a/charts/sairo/values.yaml
+++ b/charts/sairo/values.yaml
@@ -2,6 +2,9 @@
 
 replicaCount: 1
 
+# Time a pod gets to flush an in-flight crawl on SIGTERM before SIGKILL.
+terminationGracePeriodSeconds: 30
+
 image:
   repository: stephenjr002/sairo
   tag: "latest"
@@ -33,7 +36,8 @@ persistence:
   enabled: true
   storageClass: ""
   accessMode: ReadWriteOnce
-  size: 5Gi
+  size: 20Gi          # ~1 GB per 1M indexed objects (incl. search index)
+  keep: true          # helm.sh/resource-policy: keep on the PVC (survives uninstall)
 
 # S3 Configuration (required)
 s3:

--- a/charts/sairo/values.yaml
+++ b/charts/sairo/values.yaml
@@ -56,6 +56,10 @@ auth:
   sessionHours: 24
   secureCookie: true
 
+# Anonymous telemetry heartbeat (aggregate counts only; see docs). Set enabled: false to opt out.
+telemetry:
+  enabled: true
+
 # Crawler Configuration
 crawler:
   recrawlInterval: 120

--- a/charts/sairo/values.yaml
+++ b/charts/sairo/values.yaml
@@ -37,6 +37,8 @@ persistence:
   storageClass: ""
   accessMode: ReadWriteOnce
   size: 20Gi          # ~1 GB per 1M indexed objects (incl. search index)
+                      # Upgrading an existing release: a PVC can only grow in place if its StorageClass
+                      # has allowVolumeExpansion; otherwise keep your current value (e.g. --set persistence.size=5Gi).
   keep: true          # helm.sh/resource-policy: keep on the PVC (survives uninstall)
 
 # S3 Configuration (required)

--- a/docs/CORE_PROGRAM_RELIABILITY_SCALE_REALTIME.md
+++ b/docs/CORE_PROGRAM_RELIABILITY_SCALE_REALTIME.md
@@ -1,0 +1,56 @@
+# Sairo Core Program — Reliability, Scale and Near-Real-Time
+
+**Status:** Approved 2026-09-05; Phase A in progress
+**Baseline:** `64bdb2f` (v3.6.0)
+**Jira:** epics SAE-63 (A) → SAE-64 (B) → SAE-65 (C); stories SAE-66…SAE-82, label `core-reliability`
+**Confluence:** SED → "Sairo Core Program — Reliability, Scale and Near-Real-Time"
+**Sequencing:** runs before the Enterprise Migration V1 POCs (SAE-65 blocks SAE-34).
+
+## Decision
+
+Sairo is a control plane over existing buckets. Its growth variable is object cardinality and churn, not stored bytes. Before any new infrastructure the current tool must (1) work as intended, (2) scale to more objects on the same architecture, (3) update close to real time. No PostgreSQL, ClickHouse, Kafka, Redis, WebSockets or roles split; each has a named gate (one bucket past ~100M rows; a second pod required). Community single-container mode is unchanged.
+
+## POC results (2026-09-05)
+
+### Spike A — restart mid-crawl
+4-phase harness: 120,000 objects / 30 prefixes on MinIO behind a 1s latency proxy; kill after `total_objects ≥ 56,000`; restart; observe 70s; kill again; heal with `FULL_CRAWL_INTERVAL=30`.
+
+- Killed at 64,000/120,000: `status='crawling'`, `folder_stats=0`, `prefix_children=0`, `crawl_duration=0`.
+- Restart: `Seeded schedule for default:rca from existing index (64,000 objects)`; only delta crawls queued (full=0, delta=3 in 70s); count frozen at 64,000; status flipped to `complete`.
+- API while "complete": folder `ds=29/` listed 0 files, S3 held 4,000.
+- Third rollout re-seeded (clock reset). Control run healed to 120,000 in 61s once left alone.
+- Buckets ≤ 50k objects self-heal after one interval (different scheduler branch).
+- Process exits within 1s of SIGTERM; in-flight crawl dies without recording anything.
+
+### Spike B — write amplification and FTS (843,749 rows, identical schema/pragmas)
+| Path | Time | WAL written |
+|---|---|---|
+| Current: `crawl_gen` sweep, 0 changes | 15.8s | **541 MB** (≈6.3 GB at 9.9M rows) |
+| Proposed: per-prefix anti-join, 0 stale | 8.1s | **0.0 MB** |
+| Proposed: anti-join, 1% stale (8,437 deletes) | 12.9s | 15 MB |
+| FTS full trigram rebuild (runs after every crawl with ≥1 key change; triggers dropped at L1415) | 16.8s (≈200s at 9.9M) | — |
+| 10,000 upserts with FTS triggers on | 1.60s | — |
+
+### Spike C — S3 event webhook → SQLite (MinIO `notify_webhook`)
+- 240 mutations: PUT/DELETE → row visible **p50 2 ms, p95 2 ms, p99 5 ms, max 13 ms**.
+- Event shape (eventVersion 2.0): `eventName`, `eventTime`, `s3.bucket.name`, `s3.object.{key,size,eTag,sequencer}`.
+- Keys are URL-encoded (`ds=03/…` → `ds%3D03%2F…`): `unquote_plus` required.
+- `sequencer` present; per-key monotonic compare is the duplicate/out-of-order guard.
+- MinIO redelivers undelivered events (at-least-once confirmed in practice).
+- Binding via standard `PutBucketNotificationConfiguration` with `QueueArn arn:minio:sqs::PRIMARY:webhook`.
+
+## Phases
+
+**A — Crawler correctness (SAE-63, ~1 week):** A.1 resume via `crawl_progress` table (SAE-66); A.2 `interrupted` status, never `complete` on partial (SAE-67); A.3 force-release cancels instead of forking (SAE-68); A.4 graceful SIGTERM + `terminationGracePeriodSeconds` (SAE-69); A.5 PVC keep policy, 20Gi, disk guard (SAE-70); A.6 restart harness checked in as nightly test (SAE-71).
+Exit: harness passes — 120,000 within one interval after a mid-crawl kill; never `complete` while partial; zero duplicate crawls; `helm uninstall` keeps the PVC.
+
+**B — SQLite scale headroom (SAE-64, ~1–2 weeks):** B.1 anti-join stale detection (SAE-72); B.2 incremental FTS, rebuild only on empty index (SAE-73); B.3 single writer per bucket (SAE-74); B.4 global S3 list budget (SAE-75); B.5 prod-shaped benchmark + before/after record (SAE-76).
+Exit: 0-change crawl < 1 MB WAL; no rebuild on incremental; `database is locked` = 0; then the same on the real 9.9M bucket.
+
+**C — Near-real-time (SAE-65, ~2 weeks):** C.1 webhook endpoint with token, URL-decoding, sequencer guard (SAE-77); C.2 optional SQS poller (SAE-78); C.3 event-aware scheduler, reconcile stays (SAE-79); C.4 SSE push + EventSource with polling fallback (SAE-80); C.5 freshness disclosure (SAE-81); C.6 provider guides (SAE-82).
+Exit: PUT → visible in browser p95 < 5 s without reload; reconnect refetches; reconcile finds 0 mismatches after 1,000 random mutations.
+
+## Ceilings marked in code
+- `# ponytail: one writer per bucket; shard the bucket DB when one bucket passes ~100M rows`
+- `# ponytail: in-process pub/sub is single-pod; PostgreSQL LISTEN/NOTIFY when a second pod exists`
+- `# ponytail: providers without a sequencer get last-write-wins; the hourly reconcile repairs drift`

--- a/docs/CRAWLER_HOW_IT_WORKS_AND_PLAN.md
+++ b/docs/CRAWLER_HOW_IT_WORKS_AND_PLAN.md
@@ -1,0 +1,141 @@
+# The Sairo Crawler: How It Works Today, Where It Falls Short, and How It Gets Better
+
+**Audience:** anyone who needs to understand why data shows up (or doesn't) in Sairo, without reading `backend/main.py`.
+**Evidence date:** 2026-09-05, revision `64bdb2f` (v3.6.0). Every number below was measured today; nothing is estimated unless marked.
+
+---
+
+## 1. What the crawler is for
+
+Sairo never stores your objects. It keeps a **local catalogue** (one SQLite file per bucket on the `/data` volume) with one row per object: key, size, last-modified, ETag, and the folder it belongs to. Everything fast in the UI comes from that catalogue: folder listing, search, the storage dashboard, cost analytics. The crawler is the process that keeps the catalogue in sync with the bucket.
+
+Two things follow:
+
+- **Object count, not terabytes, is the scaling variable.** A 1 PB video archive with 2 million objects is easy. A 40 TB Parquet bucket with 10 million objects is the hard case. Your production instance holds 15.5 million objects across 19 buckets, and one bucket alone holds 9.9 million.
+- **The catalogue is a copy.** It can be behind the bucket, and it can be wrong after a crash. How far behind, and how it recovers, is the whole subject of this document.
+
+## 2. How a crawl works today, step by step
+
+1. **Discover folders.** List the bucket root with a delimiter to get the top-level prefixes (`ds=01/`, `logs/`, …). Prefixes seen in earlier crawls are remembered so discovery is cheap on repeat runs.
+2. **List every folder in parallel.** Up to **16 threads per bucket** each walk one prefix with `ListObjectsV2`, 1,000 keys per page. Up to **12 buckets** crawl at the same time. That is up to 192 simultaneous list calls against your provider.
+3. **Write in batches.** Each thread buffers up to 10,000 rows, then writes them into the bucket's SQLite file. New or changed rows (size or ETag differs) are inserted or replaced. Unchanged rows have a "generation" counter bumped so the crawler knows they were seen.
+4. **Prune what disappeared.** After all prefixes finish, rows whose generation counter was not bumped are deleted (they no longer exist in the bucket). This is skipped if any prefix failed, so a transient error never deletes real data.
+5. **Rebuild the derived tables.** Folder statistics and folder-children tables (what makes folder navigation instant) are rebuilt from scratch. The full-text search index is rebuilt if any key was added or removed.
+6. **Mark complete.** Status becomes `complete`, and the duration is recorded. That duration decides how the bucket is treated from then on.
+
+The search index deserves one note: during a crawl, the triggers that keep it in sync are switched off for speed and switched back on at the end. That is why step 5 needs a rebuild.
+
+## 3. Small buckets and large buckets are treated differently
+
+A background scheduler wakes every **120 seconds** (`RECRAWL_INTERVAL`) and decides, per bucket:
+
+| Bucket | Rule | What happens |
+|---|---|---|
+| Never crawled | no record | Full crawl now |
+| **Small**: last full crawl took **under 60 s** | `LARGE_BUCKET_SECONDS` | Full re-crawl every 120 s. Cheap and always fresh. |
+| **Large**: last full crawl took **over 60 s** | | **Delta crawl** every 120 s, plus a **full reconcile every hour** (`FULL_CRAWL_INTERVAL`) |
+
+A **delta crawl** does not walk the whole bucket. It looks at the 3,000 most recently modified objects already in the catalogue to find the "hot" prefixes where new data lands (for example today's `hour=14/` partition), re-lists only those (up to 40 of them), and also walks the top of each dataset to catch a brand-new partition. New objects in hot prefixes appear within one delta. Deletions and changes in cold prefixes wait for the hourly reconcile.
+
+**What "fresh" means today, in numbers:**
+
+| Situation | Time until it shows in the UI |
+|---|---|
+| New object in an active prefix of a large bucket | one scheduler tick (up to 120 s) + delta time (seconds to a minute) + UI poll (up to 30 s). **Typically 2 to 3 minutes.** |
+| New object anywhere in a small bucket | up to 120 s + UI poll. **Typically under 3 minutes.** |
+| Deleted object, or a change in a cold prefix of a large bucket | next hourly reconcile. **Up to an hour**, plus the time the full crawl itself takes. |
+| First crawl of a new 10M-object bucket | hours, bounded by provider list speed (round-trip latency dominates) |
+
+The browser refreshes the visible folder every 30 s only if a cheap status check says the index changed. There is no push.
+
+## 4. Where it falls short (measured)
+
+### 4.1 A restart during a crawl leaves a partial index that claims to be complete
+
+Every deploy restarts the single pod (the chart uses `Recreate`). If a crawl is running, the process dies within a second; the current batch is lost and nothing records that the crawl was cut off.
+
+On the next boot, the startup code sees rows in the catalogue and assumes a full crawl finished. For large buckets it goes straight to delta-only mode for an hour. Deltas only look at hot prefixes, so the folders the crawl never reached stay empty. The first delta then sets the status to `complete`.
+
+Reproduced today on a 120,000-object bucket: killed at 64,000 rows, restarted, and the catalogue stayed at **64,000 for the whole window**, reported **`complete`**, listed **0 files** in a folder that held 4,000, and every further restart inside the hour reset the clock. It healed only when left alone until the hourly reconcile.
+
+This is exactly what happened on July 13: three deploys in 54 minutes on top of a PVC change, on code that was identical to 3.6.0.
+
+### 4.2 A crawl over two hours spawns a second copy of itself
+
+If a crawl runs longer than 2 hours, the scheduler assumes the thread died, releases the lock, and starts another crawl of the same bucket while the first is still running. Two crawls then fight over one SQLite file and double the provider load. Whether the 9.9M bucket crosses two hours in production is not yet measured.
+
+### 4.3 Every full crawl rewrites the whole catalogue even when nothing changed
+
+Step 3's "bump the generation counter" is an UPDATE on every unchanged row. Measured on a production-shaped 844k-row catalogue: a full crawl with **zero changes writes 541 MB** to disk. At 9.9M rows that is roughly **6.3 GB written every hour** for nothing, on a persistent volume. The alternative (delete-missing per prefix using a temporary table) wrote **0 MB**.
+
+### 4.4 The search index is rebuilt far too often
+
+Because the sync triggers are switched off during every crawl, any single added key on the hourly reconcile forces a full rebuild of the search index: **16.8 s at 835k rows, about 200 s at 9.9M**. With the triggers left on, keeping the index in sync costs **1.6 s per 10,000 changed rows**, proportional to what changed rather than to the table size.
+
+### 4.5 Contention and herd effects
+
+Sixteen writer threads per bucket share one SQLite file, so writes wait on a 30-second busy timeout and the code has a retry path for "database is locked". After a volume reset all 19 buckets start at once, hammering the provider with up to 192 concurrent list calls.
+
+### 4.6 Operational hazards
+
+The Helm chart's PVC has no keep policy (a `helm uninstall` deletes every index), defaults to 5 GiB (the production index is larger), and a full disk silently turns the crawler into fake staleness because failed writes are swallowed.
+
+### 4.7 The UI cannot tell you how fresh anything is
+
+There is one spinner state, "Indexing…", and one completed state. Nothing says "updated 2 minutes ago" or "this index was interrupted and is partial".
+
+## 5. What we saw in production, explained
+
+- **"Crawler not firing"**: it was not supposed to; startup deliberately skips the full crawl when rows exist and trusts deltas.
+- **"Always showing indexing"**: interrupted crawls left `crawling` in the status table, and the hourly reconcile of a 9.9M bucket legitimately runs for hours.
+- **"Initial load too slow / data not showing"**: the folder-statistics tables are only rebuilt after a *completed* crawl, so after a kill they were empty and listings fell to slower paths or showed nothing for unreached folders.
+- **Recovery after the rollback**: not the version. The pod was left alone long enough for the hourly reconcile to run to completion.
+
+## 6. The plan, and what freshness becomes
+
+Three slices, no new infrastructure, community single-container mode unchanged. Full specifications: Confluence, "Sairo Core Program", pages 02 to 04. Jira epics SAE-63, SAE-64, SAE-65.
+
+### Slice A — make it correct (this week)
+
+- Record each prefix as it completes; on restart, **resume** the same crawl and skip finished prefixes instead of pretending it was complete.
+- Boot marks a cut-off crawl **`interrupted`**; the UI says so; deltas can no longer flip it to `complete`.
+- A crawl past its time limit is **asked to stop** and resumed, never duplicated.
+- On SIGTERM the crawl flushes its batch and records progress; the pod gets a 30 s grace period.
+- The PVC is kept on uninstall, defaults to 20 GiB, and a crawl refuses to start under 10 % free disk.
+- The restart reproduction becomes a nightly test.
+
+**Result:** after any deploy, the catalogue converges to complete on its own and never lies about it.
+
+### Slice B — remove the measured waste (next 1 to 2 weeks)
+
+- Stop rewriting unchanged rows: **0 MB instead of 541 MB per unchanged crawl** (measured).
+- Keep the search-index triggers on for incremental crawls; rebuild only on a brand-new index.
+- One writer thread per bucket and one provider-wide list budget, each kept only if the counters show they help.
+- A production-shaped benchmark with before/after numbers checked in.
+
+**Result:** hourly reconciles of the 9.9M bucket stop costing gigabytes of writes and minutes of search rebuild; "database is locked" disappears.
+
+### Slice C — near real time (following 2 weeks)
+
+- Providers that emit **S3 event notifications** (MinIO, Ceph, StorageGRID via its SNS-compatible platform service, Backblaze, AWS via SQS) post each PUT/DELETE to Sairo. Measured today: **PUT to catalogue row in 2 ms median, 13 ms worst** over 240 events.
+- The browser refreshes the visible folder within seconds using a revision counter (fast polling while the tab is visible; server push later only if measurement demands it).
+- Every bucket shows its mode: **Live** (events, seconds), **Adaptive** (deltas, minutes), **Full scan**, **Interrupted**, or **Events degraded**.
+- The hourly reconcile stays as the correctness guarantee; events only make it fast.
+
+**Result on event-capable providers:** a new hour partition is visible in the browser within seconds of upload, not minutes.
+
+| | Today | After Slice C (event-capable provider) |
+|---|---|---|
+| New object in an active prefix | 2 to 3 min | seconds (target p95 under 10 s) |
+| Delete or cold-prefix change | up to 1 h | seconds; reconcile still verifies hourly |
+| Index after a deploy mid-crawl | partial, labelled complete, for up to 1 h | resumed automatically, labelled honestly |
+| Disk written per unchanged hourly reconcile (9.9M bucket) | ≈ 6.3 GB | ≈ 0 |
+
+## 7. What changes for operators and other features
+
+- **No re-install.** Every schema change is additive. Existing indexes upgrade in place; buckets left in `crawling` from an old kill will be marked `interrupted` and resumed once after the upgrade.
+- **Helm upgrade** keeps the PVC and adds the grace period. To wipe an index you now delete the PVC deliberately.
+- **MCP and CLI** read the same status values; the MCP status labels gain `interrupted`. Nothing else switches on those strings.
+- **Rate limiting**: the event webhook must be exempted from the global per-IP limit (a provider sends one POST per event) and excluded from the telemetry request count.
+- **Search during a crawl**: once triggers stay on for incremental crawls, objects arriving by event during a reconcile are searchable immediately; only the very first crawl of an empty index still rebuilds at the end.
+- **Providers without events** (Wasabi, Hetzner, Scaleway, OVH, iDrive, Storj, R2 today) stay on Adaptive mode and the UI says so.

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -111,7 +111,8 @@ function MainApp() {
   const [loading, setLoading] = useState(false);
   const [done, setDone] = useState(false);
   const [indexed, setIndexed] = useState(false);
-  const [indexing, setIndexing] = useState(false); // current bucket's first crawl in progress (crawl-status === "crawling")
+  const [indexing, setIndexing] = useState(false); // current bucket's first crawl in progress (crawl-status === "crawling" | "interrupted")
+  const [indexInterrupted, setIndexInterrupted] = useState(false); // a previous crawl was cut off by a restart; the index is partial until it resumes
   const [indexCount, setIndexCount] = useState(0);  // objects indexed so far (drives the search-hint bar)
   const [hideSearchHint, setHideSearchHint] = useState(() => !!localStorage.getItem("sairo-search-hint-dismissed"));
   const [highlightKey, setHighlightKey] = useState(null); // file to scroll-to + highlight after "reveal in folder"
@@ -254,7 +255,7 @@ function MainApp() {
     setLoading(true);
     setDone(false);
     setIndexed(false);
-    getCrawlStatus(b).then((s) => { setIndexing(s?.status === "crawling"); setIndexCount(s?.total_objects || 0); }).catch(() => {});
+    getCrawlStatus(b).then((s) => { setIndexing(s?.status === "crawling" || s?.status === "interrupted"); setIndexInterrupted(s?.status === "interrupted"); setIndexCount(s?.total_objects || 0); }).catch(() => {});
     crawlFpRef.current = null;  // re-establish fingerprint for this view's background refresh
 
     let firstPage = true;
@@ -296,7 +297,7 @@ function MainApp() {
     // actually changed since the last load. Avoids re-downloading an unchanged folder
     // every 30s — the previous behavior re-streamed the whole listing each tick.
     getCrawlStatus(b).then((status) => {
-      setIndexing(status?.status === "crawling");
+      setIndexing(status?.status === "crawling" || status?.status === "interrupted"); setIndexInterrupted(status?.status === "interrupted");
       setIndexCount(status?.total_objects || 0);
       const fp = status ? `${status.total_objects}:${status.last_crawl_end}:${status.status}` : null;
       if (fp && crawlFpRef.current && fp === crawlFpRef.current) return;  // nothing changed
@@ -753,7 +754,7 @@ function MainApp() {
           {indexing ? (
             <span className="shb-text">
               <span className="spinner shb-spinner" />
-              Indexing your bucket{indexCount > 0 ? ` — ${indexCount.toLocaleString()} objects so far` : "…"} — search will be ready in a moment.
+              {indexInterrupted ? "Finishing an interrupted index" : "Indexing your bucket"}{indexCount > 0 ? ` — ${indexCount.toLocaleString()} objects so far` : "…"} — {indexInterrupted ? "some folders may be incomplete until it finishes." : "search will be ready in a moment."}
             </span>
           ) : (
             <>

--- a/frontend/src/components/CrawlStatus.jsx
+++ b/frontend/src/components/CrawlStatus.jsx
@@ -21,7 +21,8 @@ export default function CrawlStatus({ bucket }) {
 
   if (!status) return null;
 
-  const isCrawling = status.status === "crawling";
+  const isInterrupted = status.status === "interrupted";
+  const isCrawling = status.status === "crawling" || isInterrupted;
   const isComplete = status.status === "complete";
   const isError = status.status?.startsWith("error");
 
@@ -52,7 +53,7 @@ export default function CrawlStatus({ bucket }) {
       >
         {isCrawling && <span className="crawl-dot" />}
         {isCrawling
-          ? `Indexing... ${(status.total_objects || 0).toLocaleString()}`
+          ? `${isInterrupted ? "Resuming index..." : "Indexing..."} ${(status.total_objects || 0).toLocaleString()}`
           : isComplete
           ? `${(status.total_objects || 0).toLocaleString()} objects`
           : isError ? "Index error" : "Not indexed"}

--- a/mcp/tools/discovery.py
+++ b/mcp/tools/discovery.py
@@ -90,7 +90,7 @@ def register(mcp):
             lines = [f"Found {len(results)} bucket(s):\n"]
             for b in sorted(results, key=lambda x: x["name"]):
                 status = b.get("index_status", "unknown")
-                status_icon = {"complete": "ready", "crawling": "indexing...", "idle": "ready"}.get(
+                status_icon = {"complete": "ready", "crawling": "indexing...", "interrupted": "resuming index...", "idle": "ready"}.get(
                     status, status
                 )
                 objects = format_number(b.get("objects", 0))

--- a/mcp/tools/operations.py
+++ b/mcp/tools/operations.py
@@ -76,6 +76,7 @@ def register(mcp):
 
                     status_display = {
                         "crawling": "Currently indexing...",
+                        "interrupted": "Index interrupted by a restart — resuming (serving last valid index)",
                         "complete": "Up to date",
                         "idle": "Up to date",
                     }.get(status, status)


### PR DESCRIPTION
Core program, Phase A — epic SAE-63 (stories SAE-66 … SAE-71). Specs: Confluence "Sairo Core Program" pages 00–02.

## Problem (reproduced, not inferred)

A restart during a crawl left a partial index that reported itself complete. On a 120k-object harness at v3.6.0: killed at 64,000 rows → restart seeded the scheduler as "fully crawled" → delta-only for an hour → **frozen at 64,000, status `complete`, folder `ds=29/` listed 0 of 4,000 files**. Every rollout inside the hour reset the clock. This is the mechanism behind the July 13 incident (three rollouts in 54 minutes on code identical to 3.6.0).

## Changes

- **Resume, don't reseed** — `crawl_progress(prefix, gen)`; an unfinished crawl found at boot is marked `interrupted` and resumed with the same generation, skipping finished prefixes. Startup seeds the scheduler only from a completed full crawl.
- **Honest status** — deltas cannot relabel an interrupted index `complete`; `crawl-status` gains `full_crawl_complete` and `crawl_elapsed`; UI shows "Finishing an interrupted index"; MCP labels updated.
- **No duplicate crawls** — the 2h stale-lock path sets a cancel flag on the running `Future` instead of submitting a second `_run_crawl`; the version-purge lock (`True`) is never timed out.
- **Graceful SIGTERM** — stop flag checked between S3 pages; batch flushed; progress recorded; chart `terminationGracePeriodSeconds: 30`.
- **Chart safety** — PVC `helm.sh/resource-policy: keep` (`persistence.keep: true`), default `20Gi`; disk-free guard (`MIN_FREE_DISK_PCT`, default 10) with `disk_low` on `/healthz`.
- **Harness** — `benchmark/restart_harness/` (MinIO + toxiproxy, 4 phases, 4 asserted gates) plus a nightly workflow.

## Evidence

Harness on this branch:

| Gate | main @ 64bdb2f | this PR |
|---|---|---|
| Index reaches 120,000 after a mid-crawl restart | ✗ frozen at 64,000 | ✓ 120,000 within 14 s |
| Never `complete` while partial | ✗ | ✓ |
| Zero duplicate ("Force-releasing") crawls | ✓ | ✓ |
| Clean SIGTERM (no tracebacks) | ✓ | ✓ (exits in ≤10 s after flushing) |

Unit: 7 new tests in `TestCrawlerCorrectness`; backend suites 95 passed (the 2 remaining failures are pre-existing on `main` and only occur when `test_main` and `test_scaling` share a process). Frontend: 55/56 (pre-existing LDAP test) and build OK. `helm template` renders the keep annotation, 20Gi, and the grace period.

## Upgrade note

Buckets left in `crawling` by an earlier restart are marked `interrupted` on first boot and re-crawled once (resuming where progress exists). Existing PVCs keep their size; the 20Gi default applies to new installs. No data migration.