### PR TITLE
fix(crawler): truthful crawl states — no false complete, no faked freshness, visible rebuild (Core B, P0)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1232,6 +1232,7 @@ def _disk_low():
     except Exception:
         return False
 _rebuilding = set()  # crawl_keys whose post-crawl rebuild is in progress (blocks a colliding recrawl)
+_fts_rebuild_locks = {}  # crawl_key -> Lock: one FTS rebuild per bucket at a time (guarded by _crawl_lock)
 _crawl_lock = threading.Lock()
 _CRAWL_MAX_DURATION = 7200  # 2 hours — if a crawl exceeds this, force-release the lock
 
@@ -1348,8 +1349,23 @@ def _rebuild_fts(bucket, endpoint_id=None):
     """
     eid = endpoint_id or "default"
     t0 = time.monotonic()
+    # One rebuild per bucket at a time. The startup repair and the post-crawl rebuild can both decide
+    # to rebuild the same index; they shared one shadow-table name and the second's rename removed it
+    # under the first ("no such table: objects_fts_new", production read-only run). The late-comer
+    # waits, then finds the marker already current and leaves.
+    with _crawl_lock:
+        lock = _fts_rebuild_locks.setdefault(f"{eid}:{bucket}", threading.Lock())
+    with lock:
+        _rebuild_fts_locked(bucket, eid, t0)
+
+
+def _rebuild_fts_locked(bucket, eid, t0):
     try:
         with _get_db(bucket, eid) as db:
+            row = db.execute("SELECT fts_ready_gen, current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
+            if row and row[0] is not None and row[0] == (row[1] or 0) and _fts_healthy(db):
+                log.info("[%s:%s] FTS rebuild skipped — another rebuild already completed generation %s", eid, bucket, row[1])
+                return
             db.execute("DROP TABLE IF EXISTS objects_fts_new")
             db.execute("CREATE VIRTUAL TABLE objects_fts_new USING fts5(key, content='objects', content_rowid='rowid', tokenize='trigram')")
             db.commit()

--- a/backend/main.py
+++ b/backend/main.py
@@ -2387,6 +2387,7 @@ DELTA_NEWEST_K = int(os.environ.get("DELTA_NEWEST_K", "2"))             # partit
 DELTA_MAX_DEPTH = int(os.environ.get("DELTA_MAX_DEPTH", "12"))          # safety cap on walk depth
 DELTA_LIST_CONCURRENCY = int(os.environ.get("DELTA_LIST_CONCURRENCY", "16"))  # parallel S3 list calls per level
 DELTA_MAX_NODES = int(os.environ.get("DELTA_MAX_NODES", "2000"))        # safety cap on folders visited per delta
+DELTA_NODE_MAX_PAGES = int(os.environ.get("DELTA_NODE_MAX_PAGES", "2"))   # delimiter pages per discovery node before the node is left unvisited (partial)
 DELTA_ROOT_MAX_PAGES = int(os.environ.get("DELTA_ROOT_MAX_PAGES", "200"))  # root listing pages per delta before the delta is degraded (200k entries; production has 62k-prefix roots)
 
 
@@ -2452,9 +2453,15 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
                 frontier = sorted(frontier, key=_natural_key)[-budget:]
                 truncated = True
             visited += len(frontier)
-            listed = list(ex.map(lambda p: (p, _list_children(client, bucket, p)), frontier))
+            # Per-node bound too: the node budget alone did not bound remote work — one node with
+            # 20,000 children cost 20 LIST pages and 20,000 names in memory. A node wider than
+            # DELTA_NODE_MAX_PAGES pages is left unvisited and the walk is reported partial.
+            listed = list(ex.map(lambda p: (p, _list_children(client, bucket, p, max_pages=DELTA_NODE_MAX_PAGES)), frontier))
             nxt = []
             for cur, children in listed:
+                if children is None:
+                    truncated = True
+                    continue
                 if not children:
                     targets.add(cur)  # leaf: objects live directly under cur
                     continue

--- a/backend/main.py
+++ b/backend/main.py
@@ -2376,6 +2376,7 @@ DELTA_NEWEST_K = int(os.environ.get("DELTA_NEWEST_K", "2"))             # partit
 DELTA_MAX_DEPTH = int(os.environ.get("DELTA_MAX_DEPTH", "12"))          # safety cap on walk depth
 DELTA_LIST_CONCURRENCY = int(os.environ.get("DELTA_LIST_CONCURRENCY", "16"))  # parallel S3 list calls per level
 DELTA_MAX_NODES = int(os.environ.get("DELTA_MAX_NODES", "2000"))        # safety cap on folders visited per delta
+DELTA_ROOT_MAX_PAGES = int(os.environ.get("DELTA_ROOT_MAX_PAGES", "200"))  # root listing pages per delta before the delta is degraded (200k entries; production has 62k-prefix roots)
 
 
 def _natural_key(prefix):
@@ -2464,7 +2465,28 @@ def _delta_crawl(bucket, endpoint_id):
     eid = endpoint_id or "default"
     client = _s3_manager.get_client(eid)
     hot = _hot_target_prefixes(bucket, eid)
-    if not hot:
+    failed_targets = []
+
+    # One delimiter listing of the bucket root per delta. Hot prefixes are derived from what is
+    # already indexed, so without this a new root-level object or a brand-new top-level prefix stayed
+    # invisible until the hourly reconcile while last_crawl_end advanced (reproduced: a flat bucket
+    # returned "clean" without a single LIST call). Bounded: past DELTA_ROOT_MAX_PAGES the root is
+    # too big to vouch for in a delta, so the delta is degraded rather than silently partial.
+    root_objs = []
+    new_tops = set()
+    try:
+        kids = _list_children(client, bucket, "", max_pages=DELTA_ROOT_MAX_PAGES, contents=root_objs)
+        if kids is None:
+            failed_targets.append("root")   # oversized root listing: what we saw is ingested, but not certified
+        else:
+            with _get_db(bucket, eid) as db:
+                known = {r[0] for r in db.execute("SELECT prefix FROM discovered_prefixes")}
+            new_tops = set(kids) - known
+    except Exception as e:
+        log.warning("[%s:%s] delta root listing failed: %s", eid, bucket, e)
+        failed_targets.append("root")
+    root_objs = [o for o in root_objs if not o["Key"].endswith("/")]
+    if not hot and not root_objs and not new_tops and not failed_targets:
         return 0, []
 
     # Surface delta activity to the UI (status + last_crawl_start). The index stays
@@ -2484,7 +2506,6 @@ def _delta_crawl(bucket, endpoint_id):
         tops = [r[0] for r in db.execute("SELECT prefix FROM folder_stats WHERE prefix != ''").fetchall() if r[0]]
         row = db.execute("SELECT current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
         gen = (row[0] if row else 0) or 0
-    failed_targets = []
     try:
         discovered = _discover_delta_targets(client, bucket, eid, tops)  # opens its own per-thread connections
     except Exception as e:
@@ -2493,23 +2514,24 @@ def _delta_crawl(bucket, endpoint_id):
         log.warning("[%s:%s] delta target discovery failed: %s", eid, bucket, e)
         discovered = set()
         failed_targets.append("discovery")
-    targets = _minimal_prefixes(set(hot) | discovered)
+    targets = _minimal_prefixes(set(hot) | discovered | new_tops)   # new top-level prefixes are listed in full
 
     # List all targets in parallel (the hot set is small; this keeps a delta fast
     # even when several partitions are active).
-    all_objs = []
+    all_objs = list(root_objs)   # direct root-level objects from the root listing above
     def _list_or_fail(tp):
         try:
             return tp, _delta_list_prefix(client, bucket, tp)
         except Exception as e:   # one failed target degrades the delta; it must not fake a full refresh
             log.warning("[%s:%s] delta target '%s' failed: %s", eid, bucket, tp[:60], e)
             return tp, None
-    with ThreadPoolExecutor(max_workers=min(8, len(targets))) as ex:
-        for tp, objs in ex.map(_list_or_fail, targets):
-            if objs is None:
-                failed_targets.append(tp)
-            else:
-                all_objs.extend(objs)
+    if targets:
+        with ThreadPoolExecutor(max_workers=min(8, len(targets))) as ex:
+            for tp, objs in ex.map(_list_or_fail, targets):
+                if objs is None:
+                    failed_targets.append(tp)
+                else:
+                    all_objs.extend(objs)
 
     changed = 0
     with _get_db(bucket, eid) as db:
@@ -2530,6 +2552,8 @@ def _delta_crawl(bucket, endpoint_id):
             db.executemany(
                 "INSERT OR REPLACE INTO objects (key,size,last_modified,etag,prefix,depth,crawl_gen) "
                 "VALUES (?,?,?,?,?,?,?)", batch)
+        if new_tops:
+            db.executemany("INSERT OR IGNORE INTO discovered_prefixes (prefix) VALUES (?)", [(t,) for t in new_tops])
         db.commit()
 
     if changed:

--- a/backend/main.py
+++ b/backend/main.py
@@ -2353,9 +2353,14 @@ def _hot_target_prefixes(bucket, endpoint_id, sample=None, max_targets=None):
     return _minimal_prefixes({p for (p,) in rows})[:max_targets]
 
 
-def _delta_list_prefix(client, bucket, prefix):
-    """Recursively list every object under `prefix` (no delimiter). Returns raw S3 objects."""
+def _delta_list_prefix(client, bucket, prefix, sink=None, batch_size=5000):
+    """Recursively list every object under `prefix` (no delimiter).
+
+    Without `sink`, returns the raw S3 objects. With `sink`, hands them over in batches of at most
+    `batch_size` as pages arrive and returns the count — a brand-new dataset with millions of objects
+    must not be held in memory (that is the large-bucket OOM path)."""
     objs = []
+    total = 0
     token = None
     while True:
         params = {"Bucket": bucket, "Prefix": prefix, "MaxKeys": 1000}
@@ -2365,9 +2370,15 @@ def _delta_list_prefix(client, bucket, prefix):
         for o in resp.get("Contents", []):
             if o["Key"] != prefix:
                 objs.append(o)
+        if sink is not None and len(objs) >= batch_size:
+            total += len(objs); sink(objs); objs = []
         if not resp.get("IsTruncated", False):
             break
         token = resp.get("NextContinuationToken")
+    if sink is not None:
+        if objs:
+            total += len(objs); sink(objs)
+        return total
     return objs
 
 
@@ -2426,13 +2437,20 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
     brand-new hour folder — even when it sits beyond the first 1000 siblings and in a
     dataset that isn't the globally most-recently-modified one)."""
     if not tops:
-        return set()
-    targets, frontier, visited = set(), list(tops), 0
+        return set(), False
+    targets, frontier, visited, truncated = set(), list(tops), 0, False
     with _get_db(bucket, endpoint_id) as db, \
          ThreadPoolExecutor(max_workers=DELTA_LIST_CONCURRENCY) as ex:
         depth = 0
         while frontier and depth < DELTA_MAX_DEPTH and visited < DELTA_MAX_NODES:
             depth += 1
+            budget = DELTA_MAX_NODES - visited
+            if len(frontier) > budget:
+                # The cap must hold on the FIRST level too: a 20,000-prefix root walked in full is a
+                # full crawl (lab: 356 s against a 120 s target). Keep the newest names, and say the
+                # walk was partial so the delta is not certified as a complete refresh.
+                frontier = sorted(frontier, key=_natural_key)[-budget:]
+                truncated = True
             visited += len(frontier)
             listed = list(ex.map(lambda p: (p, _list_children(client, bucket, p)), frontier))
             nxt = []
@@ -2454,7 +2472,30 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
                         targets.add(c)    # brand-new partition (e.g. a fresh hour folder)
                     nxt.append(c)
             frontier = nxt
-    return targets
+        if frontier:
+            truncated = True   # depth or node budget exhausted with folders still unvisited
+    return targets, truncated
+
+
+def _delta_write(db, objs, gen):
+    """Upsert one batch of listed S3 objects; returns how many were new or changed."""
+    changed = 0
+    for i in range(0, len(objs), 5000):
+        chunk = objs[i:i + 5000]
+        keys = [o["Key"] for o in chunk]
+        ph = ",".join("?" * len(keys))
+        have = {r[0]: (r[1], r[2]) for r in
+                db.execute(f"SELECT key,size,etag FROM objects WHERE key IN ({ph})", keys)}
+        batch = []
+        for o in chunk:
+            k = o["Key"]; sz = o["Size"]; et = o.get("ETag", "").strip('"')
+            prev = have.get(k)
+            if not prev or prev[0] != sz or prev[1] != et:
+                changed += 1
+            batch.append((k, sz, o["LastModified"].isoformat(), et, _key_prefix(k), _key_depth(k), gen))
+        db.executemany(
+            "INSERT OR REPLACE INTO objects (key,size,last_modified,etag,prefix,depth,crawl_gen) VALUES (?,?,?,?,?,?,?)", batch)
+    return changed
 
 
 def _delta_crawl(bucket, endpoint_id):
@@ -2507,7 +2548,9 @@ def _delta_crawl(bucket, endpoint_id):
         row = db.execute("SELECT current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
         gen = (row[0] if row else 0) or 0
     try:
-        discovered = _discover_delta_targets(client, bucket, eid, tops)  # opens its own per-thread connections
+        discovered, partial = _discover_delta_targets(client, bucket, eid, tops)  # opens its own per-thread connections
+        if partial:
+            failed_targets.append("discovery:truncated")   # bounded walk did not cover every folder → not a clean delta
     except Exception as e:
         # Discovery is what finds brand-new partitions. Without it this delta cannot vouch for
         # freshness: keep the hot-prefix refresh, but report the delta as degraded.
@@ -2516,45 +2559,38 @@ def _delta_crawl(bucket, endpoint_id):
         failed_targets.append("discovery")
     targets = _minimal_prefixes(set(hot) | discovered | new_tops)   # new top-level prefixes are listed in full
 
-    # List all targets in parallel (the hot set is small; this keeps a delta fast
-    # even when several partitions are active).
-    all_objs = list(root_objs)   # direct root-level objects from the root listing above
+    # List all targets in parallel; every page batch is written as it arrives (bounded memory:
+    # at most batch_size objects per listing thread), serialised on the bucket's write lock.
+    changed = 0
+    wlock = _write_lock(f"{eid}:{bucket}")
+    def flush(objs):
+        nonlocal changed
+        with wlock, _get_db(bucket, eid) as db:
+            changed += _delta_write(db, objs, gen)
+            db.commit()
+    if root_objs:
+        flush(root_objs)
     def _list_or_fail(tp):
         try:
-            return tp, _delta_list_prefix(client, bucket, tp)
+            res = _delta_list_prefix(client, bucket, tp, sink=flush)
+            if isinstance(res, list):   # a listing helper that returns objects instead of streaming
+                flush(res)
+            return tp, True
         except Exception as e:   # one failed target degrades the delta; it must not fake a full refresh
             log.warning("[%s:%s] delta target '%s' failed: %s", eid, bucket, tp[:60], e)
-            return tp, None
+            return tp, False
     if targets:
         with ThreadPoolExecutor(max_workers=min(8, len(targets))) as ex:
-            for tp, objs in ex.map(_list_or_fail, targets):
-                if objs is None:
+            for tp, ok in ex.map(_list_or_fail, targets):
+                if not ok:
                     failed_targets.append(tp)
-                else:
-                    all_objs.extend(objs)
-
-    changed = 0
-    with _get_db(bucket, eid) as db:
-        for i in range(0, len(all_objs), 5000):
-            chunk = all_objs[i:i + 5000]
-            keys = [o["Key"] for o in chunk]
-            ph = ",".join("?" * len(keys))
-            have = {r[0]: (r[1], r[2]) for r in
-                    db.execute(f"SELECT key,size,etag FROM objects WHERE key IN ({ph})", keys)}
-            batch = []
-            for o in chunk:
-                k = o["Key"]; sz = o["Size"]; et = o.get("ETag", "").strip('"')
-                prev = have.get(k)
-                if not prev or prev[0] != sz or prev[1] != et:
-                    changed += 1
-                batch.append((k, sz, o["LastModified"].isoformat(), et,
-                              _key_prefix(k), _key_depth(k), gen))
-            db.executemany(
-                "INSERT OR REPLACE INTO objects (key,size,last_modified,etag,prefix,depth,crawl_gen) "
-                "VALUES (?,?,?,?,?,?,?)", batch)
-        if new_tops:
-            db.executemany("INSERT OR IGNORE INTO discovered_prefixes (prefix) VALUES (?)", [(t,) for t in new_tops])
-        db.commit()
+    # A new top-level prefix becomes "known" only once it has actually been listed: otherwise the
+    # next delta would skip it and report clean.
+    recorded = new_tops - set(failed_targets)
+    if recorded:
+        with wlock, _get_db(bucket, eid) as db:
+            db.executemany("INSERT OR IGNORE INTO discovered_prefixes (prefix) VALUES (?)", [(t,) for t in recorded])
+            db.commit()
 
     if changed:
         # cheap metadata refreshes; FTS already maintained incrementally by triggers

--- a/backend/main.py
+++ b/backend/main.py
@@ -940,6 +940,13 @@ def _init_db(bucket, endpoint_id=None):
         conn.execute("ALTER TABLE crawl_status ADD COLUMN current_crawl_gen INTEGER DEFAULT 0")
     except Exception:
         pass  # Column already exists
+    # Truthful state: last_crawl_end is stamped on SUCCESS only; a failed attempt records
+    # last_attempt_at + last_error instead, so freshness is never faked by a failure.
+    for col in ("last_error TEXT", "last_attempt_at TEXT"):
+        try:
+            conn.execute(f"ALTER TABLE crawl_status ADD COLUMN {col}")
+        except Exception:
+            pass
     # Migration: persist last full-crawl duration so the scheduler can classify a
     # bucket (small vs large) immediately after a restart, without re-crawling it.
     try:
@@ -1267,8 +1274,10 @@ def _crawl_prefix(bucket, prefix, max_retries=3, endpoint_id=None, batch_callbac
             else:
                 log.error("[%s] Prefix '%s' failed after %d retries", bucket, prefix[:40], max_retries)
                 if batch_callback is not None and batch:
-                    batch_callback(batch)
-                return total_count if batch_callback is not None else objects
+                    batch_callback(batch)   # rows listed so far are real; the prefix is NOT marked done
+                # Returning the partial count let the caller mark the prefix complete and prune the
+                # rows it never saw. A listing that did not reach its last page is a failure.
+                raise RuntimeError(f"listing '{prefix}' failed after {max_retries} retries: {e}")
 
         for obj in resp.get("Contents", []):
             key = obj["Key"]
@@ -1799,13 +1808,21 @@ def _run_crawl(bucket, endpoint_id=None):
             log.warning("[%s:%s] Skipping stale-key prune — %d prefix(es) still failed after retry; index kept intact",
                         eid, bucket, len(failed_prefixes))
 
-        # Final counts
+        # Final counts. With failed prefixes the index is intact but not fully reconciled: report
+        # 'degraded' (still served) instead of 'complete', keep the previous success timestamp,
+        # and record what went wrong.
+        now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ")
         with _get_db(bucket, eid) as db:
             row = db.execute("SELECT COUNT(*), COALESCE(SUM(size),0) FROM objects").fetchone()
             total_objects, total_size = row[0], row[1]
-            db.execute(
-                "UPDATE crawl_status SET status='complete', last_crawl_end=?, total_objects=?, total_size=? WHERE id=1",
-                (time.strftime("%Y-%m-%dT%H:%M:%SZ"), total_objects, total_size))
+            if failed_prefixes:
+                db.execute(
+                    "UPDATE crawl_status SET status='degraded', last_attempt_at=?, last_error=?, total_objects=?, total_size=? WHERE id=1",
+                    (now_iso, f"{len(failed_prefixes)} prefix(es) failed to list", total_objects, total_size))
+            else:
+                db.execute(
+                    "UPDATE crawl_status SET status='complete', last_crawl_end=?, last_attempt_at=?, last_error=NULL, total_objects=?, total_size=? WHERE id=1",
+                    (now_iso, now_iso, total_objects, total_size))
             db.commit()
             # FTS indexes the key only, so it is stale only when keys were ADDED or
             # DELETED — not when size/etag changed. Skip the O(all-rows) trigram
@@ -2183,7 +2200,7 @@ def _is_index_ready(bucket):
         return False
     with _get_db(bucket) as db:
         row = db.execute("SELECT status, total_objects FROM crawl_status WHERE id=1").fetchone()
-        if row and (row["status"] == "complete" or (row["total_objects"] or 0) > 0):
+        if row and (row["status"] in ("complete", "degraded") or (row["total_objects"] or 0) > 0):
             return True
         # Source of truth is the objects table. crawl_status counters can be
         # transiently 0/NULL during a crawl transition — never let that make a
@@ -2438,16 +2455,25 @@ def _queue_delta_crawl(bucket, endpoint_id=None):
             log.info("[%s:%s] Delta crawl: %d new/changed in %.1fs", eid, bucket, n, time.monotonic() - t0)
         except Exception as e:
             log.warning("[%s:%s] Delta crawl error: %s", eid, bucket, e)
+            delta_error = str(e)[:200]
+        else:
+            delta_error = None
         finally:
             with _crawl_lock:
                 _crawling.pop(crawl_key, None)
-            # Always return status to 'complete' and stamp last_crawl_end so the UI
-            # reflects that the index was just refreshed (even on a no-change delta).
+            # Success stamps the success time. A failed delta records the attempt and the error and
+            # leaves status and last_crawl_end alone: monitoring must not see freshness that did not happen.
             try:
+                now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ")
                 with _get_db(bucket, eid) as db:
-                    # A delta refreshes hot prefixes only; it must not relabel an interrupted full crawl as complete.
-                    db.execute("UPDATE crawl_status SET status='complete', last_crawl_end=? WHERE id=1 AND status <> 'interrupted'",
-                               (time.strftime("%Y-%m-%dT%H:%M:%SZ"),))
+                    if delta_error is None:
+                        # A delta refreshes hot prefixes only; it must not relabel an interrupted or degraded full crawl as complete.
+                        db.execute("UPDATE crawl_status SET status='complete', last_crawl_end=?, last_attempt_at=?, last_error=NULL "
+                                   "WHERE id=1 AND status NOT IN ('interrupted', 'degraded')", (now_iso, now_iso))
+                        db.execute("UPDATE crawl_status SET last_crawl_end=?, last_attempt_at=? WHERE id=1 AND status IN ('interrupted', 'degraded')",
+                                   (now_iso, now_iso))
+                    else:
+                        db.execute("UPDATE crawl_status SET last_attempt_at=?, last_error=? WHERE id=1", (now_iso, delta_error))
                     db.commit()
             except Exception:
                 pass
@@ -2516,7 +2542,10 @@ def _auto_recrawl():
     the whole bucket every cycle, and avoids crawl/rebuild lock collisions."""
     while True:
         try:
-            time.sleep(RECRAWL_INTERVAL)
+            # Tick at a quarter of the interval: the per-bucket cooldown checks below still enforce
+            # RECRAWL_INTERVAL since the last finish, but a coarse tick made a 120 s setting behave
+            # like ~240 s (wake just before the cooldown boundary → skip → wait another full interval).
+            time.sleep(max(5, RECRAWL_INTERVAL // 4))
             now = time.time()
             for eid in _s3_manager.get_all_ids():
                 try:
@@ -5577,8 +5606,13 @@ def crawl_status(bucket: str, user: dict = Depends(get_current_user)):
     st = d.get("status") or ""
     # True only when a full crawl has finished and nothing since has interrupted one.
     d["full_crawl_complete"] = bool(d.get("crawl_duration")) and st != "interrupted" and not st.startswith("error")
-    started = _crawling.get(f"{_current_endpoint_id()}:{bucket}")
+    crawl_key = f"{_current_endpoint_id()}:{bucket}"
+    started = _crawling.get(crawl_key)
     d["crawl_elapsed"] = round(time.time() - started, 1) if isinstance(started, float) else None
+    # 'complete' means the catalogue rows are in; folder stats and the search index are rebuilt
+    # afterwards (minutes at 10M keys). Say so instead of letting clients infer it.
+    d["rebuilding"] = crawl_key in _rebuilding
+    d["search_ready"] = st in ("complete", "degraded") and not d["rebuilding"]
     return d
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -942,7 +942,7 @@ def _init_db(bucket, endpoint_id=None):
         pass  # Column already exists
     # Truthful state: last_crawl_end is stamped on SUCCESS only; a failed attempt records
     # last_attempt_at + last_error instead, so freshness is never faked by a failure.
-    for col in ("last_error TEXT", "last_attempt_at TEXT"):
+    for col in ("last_error TEXT", "last_attempt_at TEXT", "fts_ready_gen INTEGER"):
         try:
             conn.execute(f"ALTER TABLE crawl_status ADD COLUMN {col}")
         except Exception:
@@ -1374,6 +1374,8 @@ def _rebuild_fts(bucket, endpoint_id=None):
             db.execute("DROP TABLE IF EXISTS objects_fts")
             db.execute("ALTER TABLE objects_fts_new RENAME TO objects_fts")
             _create_fts_triggers(db)
+            # Persisted readiness: the search index now covers this generation (survives restarts).
+            db.execute("UPDATE crawl_status SET fts_ready_gen = current_crawl_gen WHERE id=1")
             db.commit()
         log.info("[%s:%s] FTS index rebuilt in %.1fs (shadow table, %d-row chunks)", eid, bucket, time.monotonic() - t0, FTS_REBUILD_CHUNK)
     except Exception as e:
@@ -1414,7 +1416,13 @@ def _fts_should_rebuild(bucket, endpoint_id, keys_changed):
             obj = db.execute("SELECT COUNT(*) FROM objects").fetchone()[0]
             if obj == 0:
                 return False
-            return _fts_is_empty(db)
+            if _fts_is_empty(db):
+                return True
+            # The index is only known-good if the previous generation's rebuild committed
+            # (a process killed mid-rebuild leaves the old index, still valid for its own generation).
+            row = db.execute("SELECT fts_ready_gen, current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
+            ready, gen = (row[0] if row else None), ((row[1] if row else 0) or 0)
+            return ready is None or ready < gen - 1
     except Exception:
         return True  # if we can't tell, rebuild to be safe
 
@@ -1470,6 +1478,7 @@ def _run_crawl(bucket, endpoint_id=None):
     # Set thread-local so _db_path picks up the right endpoint
     _s3_context.endpoint_id = eid
     client = _s3_manager.get_client(eid)
+    failed_prefixes = []   # read in `finally`: a degraded finish must not be scheduled as a success
 
     _init_db(bucket, eid)
 
@@ -1483,7 +1492,8 @@ def _run_crawl(bucket, endpoint_id=None):
         # Resume: an interrupted crawl left per-prefix progress for its generation. Keep that
         # generation and skip the prefixes it already completed instead of starting over.
         done_prefixes = set()
-        if prev_status in ("crawling", "interrupted") and prev_gen:
+        if prev_status in ("crawling", "interrupted", "degraded") and prev_gen:
+            # 'degraded' = last attempt finished with failed prefixes: retry only those.
             done_prefixes = {r[0] for r in db.execute("SELECT prefix FROM crawl_progress WHERE gen=?", (prev_gen,))}
         if done_prefixes:
             db.execute("UPDATE crawl_status SET status='crawling', last_crawl_start=? WHERE id=1",
@@ -1666,9 +1676,10 @@ def _run_crawl(bucket, endpoint_id=None):
                     db.execute("DELETE FROM objects WHERE crawl_gen > 0 AND crawl_gen < ?", (crawl_gen,))
                     log.info("[%s:%s] Removed %s stale keys", eid, bucket, f"{stale_count:,}")
                 row = db.execute("SELECT COUNT(*), COALESCE(SUM(size),0) FROM objects").fetchone()
+                now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ")
                 db.execute(
-                    "UPDATE crawl_status SET status='complete', last_crawl_end=?, total_objects=?, total_size=? WHERE id=1",
-                    (time.strftime("%Y-%m-%dT%H:%M:%SZ"), row[0], row[1]))
+                    "UPDATE crawl_status SET status='complete', last_crawl_end=?, last_attempt_at=?, last_error=NULL, total_objects=?, total_size=? WHERE id=1",
+                    (now_iso, now_iso, row[0], row[1]))
                 db.commit()
             # Re-enable FTS triggers (instant)
             with _get_db(bucket, eid) as db:
@@ -1847,7 +1858,8 @@ def _run_crawl(bucket, endpoint_id=None):
         try:
             with _get_db(bucket, eid) as db:
                 _enable_fts_triggers(db)
-                db.execute("UPDATE crawl_status SET status='interrupted' WHERE id=1")
+                db.execute("UPDATE crawl_status SET status='interrupted', last_attempt_at=? WHERE id=1",
+                           (time.strftime("%Y-%m-%dT%H:%M:%SZ"),))
                 db.commit()
         except Exception:
             pass
@@ -1859,7 +1871,8 @@ def _run_crawl(bucket, endpoint_id=None):
         try:
             with _get_db(bucket, eid) as db:
                 _enable_fts_triggers(db)  # Always re-enable even on error
-                db.execute("UPDATE crawl_status SET status=? WHERE id=1", (f"error: {e}",))
+                db.execute("UPDATE crawl_status SET status=?, last_attempt_at=?, last_error=? WHERE id=1",
+                           (f"error: {e}", time.strftime("%Y-%m-%dT%H:%M:%SZ"), str(e)[:200]))
                 db.commit()
         except Exception as inner_e:
             log.warning("Failed to write crawl error status for %s: %s", bucket, inner_e)
@@ -1880,8 +1893,15 @@ def _run_crawl(bucket, endpoint_id=None):
                 # Record full-crawl timing so the scheduler can decide between a
                 # cheap full recrawl (small buckets) and fast delta crawls (large).
                 m = _crawl_meta.setdefault(crawl_key, {})
-                m["last_full"] = time.time()
                 m["duration"] = time.monotonic() - crawl_start
+                if failed_prefixes:
+                    # Degraded: not a success. No last_full (so no delta-only period), a cooldown
+                    # instead, after which the scheduler resumes the unfinished prefixes.
+                    m.pop("last_full", None)
+                    m["degraded_at"] = time.time()
+                else:
+                    m.pop("degraded_at", None)
+                    m["last_full"] = time.time()
                 try:
                     with _get_db(bucket, eid) as _db:
                         _db.execute("UPDATE crawl_status SET crawl_duration=? WHERE id=1", (m["duration"],))
@@ -1921,6 +1941,9 @@ def _run_crawl(bucket, endpoint_id=None):
                     _rebuild_fts_async(bucket, eid, done=_release)
                     handed_off = True
                 else:
+                    with _get_db(bucket, eid) as db:   # unchanged index is valid for this generation too
+                        db.execute("UPDATE crawl_status SET fts_ready_gen = current_crawl_gen WHERE id=1")
+                        db.commit()
                     log.info("[%s:%s] FTS rebuild skipped — no key changes this crawl", eid, bucket)
             finally:
                 if not handed_off:
@@ -2367,12 +2390,12 @@ def _delta_crawl(bucket, endpoint_id):
     """Fast incremental crawl: re-list ONLY the narrow hot prefixes (where new data
     lands) plus any brand-new sibling partitions, in PARALLEL, and incremental-upsert.
     FTS triggers stay enabled so search updates per row (no full trigram rebuild).
-    Avoids re-listing the whole bucket. Returns #new/changed objects."""
+    Avoids re-listing the whole bucket. Returns (#new/changed objects, [targets whose listing failed])."""
     eid = endpoint_id or "default"
     client = _s3_manager.get_client(eid)
     hot = _hot_target_prefixes(bucket, eid)
     if not hot:
-        return 0
+        return 0, []
 
     # Surface delta activity to the UI (status + last_crawl_start). The index stays
     # queryable throughout because _is_index_ready treats any bucket with
@@ -2400,10 +2423,19 @@ def _delta_crawl(bucket, endpoint_id):
 
     # List all targets in parallel (the hot set is small; this keeps a delta fast
     # even when several partitions are active).
-    all_objs = []
+    all_objs, failed_targets = [], []
+    def _list_or_fail(tp):
+        try:
+            return tp, _delta_list_prefix(client, bucket, tp)
+        except Exception as e:   # one failed target degrades the delta; it must not fake a full refresh
+            log.warning("[%s:%s] delta target '%s' failed: %s", eid, bucket, tp[:60], e)
+            return tp, None
     with ThreadPoolExecutor(max_workers=min(8, len(targets))) as ex:
-        for objs in ex.map(lambda tp: _delta_list_prefix(client, bucket, tp), targets):
-            all_objs.extend(objs)
+        for tp, objs in ex.map(_list_or_fail, targets):
+            if objs is None:
+                failed_targets.append(tp)
+            else:
+                all_objs.extend(objs)
 
     changed = 0
     with _get_db(bucket, eid) as db:
@@ -2433,7 +2465,7 @@ def _delta_crawl(bucket, endpoint_id):
                 step(bucket, eid)
             except Exception as e:
                 log.warning("[%s:%s] delta post-step %s failed: %s", eid, bucket, getattr(step, "__name__", step), e)
-    return changed
+    return changed, failed_targets
 
 
 def _queue_delta_crawl(bucket, endpoint_id=None):
@@ -2447,33 +2479,43 @@ def _queue_delta_crawl(bucket, endpoint_id=None):
 
     def _run():
         t0 = time.monotonic()
+        delta_error = None
+        try:
+            with _get_db(bucket, eid) as db:   # _delta_crawl shows 'crawling' meanwhile; restore this afterwards
+                row = db.execute("SELECT status FROM crawl_status WHERE id=1").fetchone()
+                prev_status = (row[0] if row else None) or "complete"
+        except Exception:
+            prev_status = "complete"
         try:
             _s3_context.endpoint_id = eid
-            n = _delta_crawl(bucket, eid)
+            n, failed_targets = _delta_crawl(bucket, eid)
             with _crawl_lock:
                 _crawl_meta.setdefault(crawl_key, {})["last_delta"] = time.time()
-            log.info("[%s:%s] Delta crawl: %d new/changed in %.1fs", eid, bucket, n, time.monotonic() - t0)
+            if failed_targets:
+                delta_error = f"{len(failed_targets)} delta target(s) failed to list"
+                log.warning("[%s:%s] Delta crawl degraded: %d new/changed, %s in %.1fs", eid, bucket, n, delta_error, time.monotonic() - t0)
+            else:
+                log.info("[%s:%s] Delta crawl: %d new/changed in %.1fs", eid, bucket, n, time.monotonic() - t0)
         except Exception as e:
             log.warning("[%s:%s] Delta crawl error: %s", eid, bucket, e)
             delta_error = str(e)[:200]
-        else:
-            delta_error = None
         finally:
             with _crawl_lock:
                 _crawling.pop(crawl_key, None)
-            # Success stamps the success time. A failed delta records the attempt and the error and
-            # leaves status and last_crawl_end alone: monitoring must not see freshness that did not happen.
+            # Only a clean delta on a complete index stamps last_crawl_end. A degraded or failed delta,
+            # or a delta over an interrupted/degraded index, records the attempt (and the error) and
+            # restores the previous status: monitoring must not see freshness that did not happen.
             try:
                 now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ")
                 with _get_db(bucket, eid) as db:
-                    if delta_error is None:
-                        # A delta refreshes hot prefixes only; it must not relabel an interrupted or degraded full crawl as complete.
-                        db.execute("UPDATE crawl_status SET status='complete', last_crawl_end=?, last_attempt_at=?, last_error=NULL "
-                                   "WHERE id=1 AND status NOT IN ('interrupted', 'degraded')", (now_iso, now_iso))
-                        db.execute("UPDATE crawl_status SET last_crawl_end=?, last_attempt_at=? WHERE id=1 AND status IN ('interrupted', 'degraded')",
+                    if delta_error is None and prev_status not in ("interrupted", "degraded"):
+                        db.execute("UPDATE crawl_status SET status='complete', last_crawl_end=?, last_attempt_at=?, last_error=NULL WHERE id=1",
                                    (now_iso, now_iso))
+                    elif delta_error is None:
+                        db.execute("UPDATE crawl_status SET status=?, last_attempt_at=? WHERE id=1", (prev_status, now_iso))
                     else:
-                        db.execute("UPDATE crawl_status SET last_attempt_at=?, last_error=? WHERE id=1", (now_iso, delta_error))
+                        db.execute("UPDATE crawl_status SET status=?, last_attempt_at=?, last_error=? WHERE id=1",
+                                   (prev_status if prev_status != "crawling" else "complete", now_iso, delta_error))
                     db.commit()
             except Exception:
                 pass
@@ -2556,8 +2598,11 @@ def _auto_recrawl():
                         key = f"{eid}:{name}"
                         meta = _crawl_meta.get(key)
                         if not meta or "last_full" not in meta:
+                            degraded_at = (meta or {}).get("degraded_at")
+                            if degraded_at and now - degraded_at < RECRAWL_INTERVAL:
+                                continue   # degraded: retry the unfinished prefixes after the cooldown
                             if _queue_crawl(name, eid):
-                                log.info("Full crawl queued for %s (initial)", key)
+                                log.info("Full crawl queued for %s (%s)", key, "retry of unfinished prefixes" if degraded_at else "initial")
                             continue
                         if (now - meta["last_full"]) > FULL_CRAWL_INTERVAL:
                             if _queue_crawl(name, eid):
@@ -2638,7 +2683,7 @@ def startup():
                         # Seed only from a COMPLETED full crawl (one that recorded a duration). Seeding
                         # an interrupted index marked it "fresh" and left large buckets delta-only for
                         # FULL_CRAWL_INTERVAL while a third of the data was missing.
-                        if total > 0 and dur > 0 and prev_status != "interrupted":
+                        if total > 0 and dur > 0 and prev_status not in ("interrupted", "degraded"):
                             _crawl_meta[f"{eid}:{name}"] = {"last_full": time.time(), "duration": dur}
                             seeded = True
                             log.info("Seeded schedule for %s:%s from existing index (%s objects); will keep fresh via scheduler",
@@ -2648,7 +2693,7 @@ def startup():
                     if not seeded:
                         _queue_crawl(name, eid)
                         log.info("Queued %s crawl for %s:%s",
-                                 "resume of interrupted" if prev_status == "interrupted" else "initial", eid, name)
+                                 f"resume of {prev_status}" if prev_status in ("interrupted", "degraded") else "initial", eid, name)
             except Exception as e:
                 log.error("Failed to list buckets on startup (endpoint=%s): %s", eid, e)
     threading.Thread(target=_startup_crawl, daemon=True).start()
@@ -5609,10 +5654,13 @@ def crawl_status(bucket: str, user: dict = Depends(get_current_user)):
     crawl_key = f"{_current_endpoint_id()}:{bucket}"
     started = _crawling.get(crawl_key)
     d["crawl_elapsed"] = round(time.time() - started, 1) if isinstance(started, float) else None
-    # 'complete' means the catalogue rows are in; folder stats and the search index are rebuilt
-    # afterwards (minutes at 10M keys). Say so instead of letting clients infer it.
-    d["rebuilding"] = crawl_key in _rebuilding
-    d["search_ready"] = st in ("complete", "degraded") and not d["rebuilding"]
+    # 'complete' means the catalogue rows are in; the search index is rebuilt afterwards (minutes at
+    # 10M keys). Readiness is the persisted fts_ready_gen (stamped when a rebuild commits or is
+    # skipped as unnecessary) compared with the current generation — not an in-memory flag that a
+    # restart would lose.
+    served = st in ("complete", "degraded")
+    d["search_ready"] = served and d.get("fts_ready_gen") is not None and d["fts_ready_gen"] == (d.get("current_crawl_gen") or 0)
+    d["rebuilding"] = served and not d["search_ready"]
     return d
 
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1383,14 +1383,66 @@ def _rebuild_fts(bucket, endpoint_id=None):
 
 
 def _rebuild_fts_async(bucket, endpoint_id=None, done=None):
-    """Run _rebuild_fts on a daemon thread; `done()` runs when it finishes, success or not."""
+    """Run _rebuild_fts on a daemon thread; `done()` runs when it finishes, success or not. Returns the thread."""
     def _run():
         try:
             _rebuild_fts(bucket, endpoint_id)
         finally:
             if done is not None:
                 done()
-    threading.Thread(target=_run, name=f"fts-{bucket[:12]}", daemon=True).start()
+    t = threading.Thread(target=_run, name=f"fts-{bucket[:12]}", daemon=True)
+    t.start()
+    return t
+
+
+def _ensure_fts_ready(bucket, endpoint_id=None):
+    """Startup repair for a served index whose search generation is absent or stale.
+
+    Databases from before fts_ready_gen existed have NULL: if their index is healthy it was built by the
+    previous release's post-crawl rebuild, so the marker is backfilled (verified, not assumed). A
+    marker behind the current generation, or an unhealthy index, means a rebuild never committed:
+    repair it now instead of reporting `rebuilding` until the next full reconcile. Returns the
+    rebuild thread when one was started, else None."""
+    eid = endpoint_id or "default"
+    crawl_key = f"{eid}:{bucket}"
+    try:
+        with _get_db(bucket, eid) as db:
+            row = db.execute("SELECT status, fts_ready_gen, current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
+            if not row or row["status"] not in ("complete", "degraded"):
+                return None
+            ready, gen = row["fts_ready_gen"], (row["current_crawl_gen"] or 0)
+            healthy = _fts_healthy(db)
+            if ready == gen and healthy:
+                return None
+            if ready is None and healthy:
+                db.execute("UPDATE crawl_status SET fts_ready_gen=? WHERE id=1", (gen,))
+                db.commit()
+                log.info("[%s:%s] Search index verified; readiness marker backfilled for generation %d", eid, bucket, gen)
+                return None
+    except Exception as e:
+        log.warning("[%s:%s] Could not check search readiness: %s", eid, bucket, e)
+        return None
+    log.info("[%s:%s] Search index generation %s behind catalogue generation %d (or unhealthy) — repairing now", eid, bucket, ready, gen)
+    with _crawl_lock:
+        _rebuilding.add(crawl_key)
+    def _release():
+        with _crawl_lock:
+            _rebuilding.discard(crawl_key)
+    return _rebuild_fts_async(bucket, eid, done=_release)
+
+
+def _fts_healthy(db):
+    """The search index exists, is readable and is not empty while objects exist. A generation
+    marker alone is not proof: a missing or unreadable FTS table must never read as ready."""
+    try:
+        if not db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='objects_fts'").fetchone():
+            return False
+        db.execute("SELECT rowid FROM objects_fts LIMIT 1").fetchall()
+        if db.execute("SELECT COUNT(*) FROM objects").fetchone()[0] == 0:
+            return True
+        return not _fts_is_empty(db)
+    except Exception:
+        return False
 
 
 def _fts_is_empty(db):
@@ -1416,7 +1468,7 @@ def _fts_should_rebuild(bucket, endpoint_id, keys_changed):
             obj = db.execute("SELECT COUNT(*) FROM objects").fetchone()[0]
             if obj == 0:
                 return False
-            if _fts_is_empty(db):
+            if not _fts_healthy(db):
                 return True
             # The index is only known-good if the previous generation's rebuild committed
             # (a process killed mid-rebuild leaves the old index, still valid for its own generation).
@@ -2508,14 +2560,17 @@ def _queue_delta_crawl(bucket, endpoint_id=None):
             try:
                 now_iso = time.strftime("%Y-%m-%dT%H:%M:%SZ")
                 with _get_db(bucket, eid) as db:
-                    if delta_error is None and prev_status not in ("interrupted", "degraded"):
+                    # Only an already-complete catalogue is promotable by a delta: a hot-prefix refresh
+                    # cannot make a degraded, interrupted or errored full crawl whole.
+                    restore = prev_status if prev_status != "crawling" else "complete"
+                    if delta_error is None and prev_status == "complete":
                         db.execute("UPDATE crawl_status SET status='complete', last_crawl_end=?, last_attempt_at=?, last_error=NULL WHERE id=1",
                                    (now_iso, now_iso))
                     elif delta_error is None:
-                        db.execute("UPDATE crawl_status SET status=?, last_attempt_at=? WHERE id=1", (prev_status, now_iso))
+                        db.execute("UPDATE crawl_status SET status=?, last_attempt_at=? WHERE id=1", (restore, now_iso))
                     else:
                         db.execute("UPDATE crawl_status SET status=?, last_attempt_at=?, last_error=? WHERE id=1",
-                                   (prev_status if prev_status != "crawling" else "complete", now_iso, delta_error))
+                                   (restore, now_iso, delta_error))
                     db.commit()
             except Exception:
                 pass
@@ -2686,6 +2741,7 @@ def startup():
                         if total > 0 and dur > 0 and prev_status not in ("interrupted", "degraded"):
                             _crawl_meta[f"{eid}:{name}"] = {"last_full": time.time(), "duration": dur}
                             seeded = True
+                            _ensure_fts_ready(name, eid)   # legacy NULL marker → verify and backfill; stale → repair now
                             log.info("Seeded schedule for %s:%s from existing index (%s objects); will keep fresh via scheduler",
                                      eid, name, f"{total:,}")
                     except Exception:
@@ -5645,12 +5701,13 @@ def crawl_status(bucket: str, user: dict = Depends(get_current_user)):
         return {"status": "not_indexed", "total_objects": 0, "total_size": 0}
     with _get_db(bucket) as db:
         row = db.execute("SELECT * FROM crawl_status WHERE id=1").fetchone()
+        fts_ok = _fts_healthy(db) if row else False
     if not row:
         return {"status": "unknown"}
     d = dict(row)
     st = d.get("status") or ""
-    # True only when a full crawl has finished and nothing since has interrupted one.
-    d["full_crawl_complete"] = bool(d.get("crawl_duration")) and st != "interrupted" and not st.startswith("error")
+    # 4. the name means what it says: the last full crawl finished whole.
+    d["full_crawl_complete"] = st == "complete"
     crawl_key = f"{_current_endpoint_id()}:{bucket}"
     started = _crawling.get(crawl_key)
     d["crawl_elapsed"] = round(time.time() - started, 1) if isinstance(started, float) else None
@@ -5659,7 +5716,8 @@ def crawl_status(bucket: str, user: dict = Depends(get_current_user)):
     # skipped as unnecessary) compared with the current generation — not an in-memory flag that a
     # restart would lose.
     served = st in ("complete", "degraded")
-    d["search_ready"] = served and d.get("fts_ready_gen") is not None and d["fts_ready_gen"] == (d.get("current_crawl_gen") or 0)
+    d["search_ready"] = (served and fts_ok and d.get("fts_ready_gen") is not None
+                         and d["fts_ready_gen"] == (d.get("current_crawl_gen") or 0))
     d["rebuilding"] = served and not d["search_ready"]
     return d
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -1395,14 +1395,32 @@ def _rebuild_fts_async(bucket, endpoint_id=None, done=None):
     return t
 
 
+def _fts_consistent(db):
+    """SQLite's own check that the FTS index matches the content table (external-content tables compare
+    every row). Slow on a big index — used once, for databases that predate the readiness marker."""
+    try:
+        # rank=1: also compare against the external content table (the plain form checks only the
+        # index's internal structure and passed with an unindexed row — verified on SQLite 3.53).
+        db.execute("INSERT INTO objects_fts(objects_fts, rank) VALUES('integrity-check', 1)")
+        return True
+    except Exception:
+        return False
+
+
+def _seed_from_existing(prev_status, total, dur):
+    """Startup trusts an existing index as fresh only when its last full crawl finished COMPLETE.
+    Interrupted/degraded resume from their checkpoints; an error is retried; anything else is a first crawl."""
+    return total > 0 and dur > 0 and prev_status == "complete"
+
+
 def _ensure_fts_ready(bucket, endpoint_id=None):
     """Startup repair for a served index whose search generation is absent or stale.
 
-    Databases from before fts_ready_gen existed have NULL: if their index is healthy it was built by the
-    previous release's post-crawl rebuild, so the marker is backfilled (verified, not assumed). A
-    marker behind the current generation, or an unhealthy index, means a rebuild never committed:
-    repair it now instead of reporting `rebuilding` until the next full reconcile. Returns the
-    rebuild thread when one was started, else None."""
+    Databases from before fts_ready_gen existed have NULL: the marker is backfilled only after SQLite's
+    integrity check proves the index matches the catalogue (a readable, non-empty but STALE index must
+    not be certified). A marker behind the current generation, an unhealthy index or a failed check
+    means a rebuild never committed: repair it now instead of reporting `rebuilding` until the next
+    full reconcile. Returns the rebuild thread when one was started, else None."""
     eid = endpoint_id or "default"
     crawl_key = f"{eid}:{bucket}"
     try:
@@ -1414,10 +1432,10 @@ def _ensure_fts_ready(bucket, endpoint_id=None):
             healthy = _fts_healthy(db)
             if ready == gen and healthy:
                 return None
-            if ready is None and healthy:
+            if ready is None and healthy and _fts_consistent(db):
                 db.execute("UPDATE crawl_status SET fts_ready_gen=? WHERE id=1", (gen,))
                 db.commit()
-                log.info("[%s:%s] Search index verified; readiness marker backfilled for generation %d", eid, bucket, gen)
+                log.info("[%s:%s] Search index verified against the catalogue; readiness marker backfilled for generation %d", eid, bucket, gen)
                 return None
     except Exception as e:
         log.warning("[%s:%s] Could not check search readiness: %s", eid, bucket, e)
@@ -2466,16 +2484,20 @@ def _delta_crawl(bucket, endpoint_id):
         tops = [r[0] for r in db.execute("SELECT prefix FROM folder_stats WHERE prefix != ''").fetchall() if r[0]]
         row = db.execute("SELECT current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
         gen = (row[0] if row else 0) or 0
+    failed_targets = []
     try:
         discovered = _discover_delta_targets(client, bucket, eid, tops)  # opens its own per-thread connections
     except Exception as e:
+        # Discovery is what finds brand-new partitions. Without it this delta cannot vouch for
+        # freshness: keep the hot-prefix refresh, but report the delta as degraded.
         log.warning("[%s:%s] delta target discovery failed: %s", eid, bucket, e)
         discovered = set()
+        failed_targets.append("discovery")
     targets = _minimal_prefixes(set(hot) | discovered)
 
     # List all targets in parallel (the hot set is small; this keeps a delta fast
     # even when several partitions are active).
-    all_objs, failed_targets = [], []
+    all_objs = []
     def _list_or_fail(tp):
         try:
             return tp, _delta_list_prefix(client, bucket, tp)
@@ -2517,6 +2539,7 @@ def _delta_crawl(bucket, endpoint_id):
                 step(bucket, eid)
             except Exception as e:
                 log.warning("[%s:%s] delta post-step %s failed: %s", eid, bucket, getattr(step, "__name__", step), e)
+                failed_targets.append(f"post-step:{getattr(step, '__name__', step)}")   # counters/stats not refreshed → not a clean delta
     return changed, failed_targets
 
 
@@ -2535,9 +2558,9 @@ def _queue_delta_crawl(bucket, endpoint_id=None):
         try:
             with _get_db(bucket, eid) as db:   # _delta_crawl shows 'crawling' meanwhile; restore this afterwards
                 row = db.execute("SELECT status FROM crawl_status WHERE id=1").fetchone()
-                prev_status = (row[0] if row else None) or "complete"
+                prev_status = (row[0] if row else None) or "unknown"
         except Exception:
-            prev_status = "complete"
+            prev_status = "unknown"   # never assume complete when the status could not be read
         try:
             _s3_context.endpoint_id = eid
             n, failed_targets = _delta_crawl(bucket, eid)
@@ -2563,7 +2586,11 @@ def _queue_delta_crawl(bucket, endpoint_id=None):
                     # Only an already-complete catalogue is promotable by a delta: a hot-prefix refresh
                     # cannot make a degraded, interrupted or errored full crawl whole.
                     restore = prev_status if prev_status != "crawling" else "complete"
-                    if delta_error is None and prev_status == "complete":
+                    if prev_status == "unknown":
+                        # status could not be read before the delta: record the attempt, touch nothing else
+                        db.execute("UPDATE crawl_status SET last_attempt_at=?, last_error=COALESCE(?, last_error) WHERE id=1",
+                                   (now_iso, delta_error))
+                    elif delta_error is None and prev_status == "complete":
                         db.execute("UPDATE crawl_status SET status='complete', last_crawl_end=?, last_attempt_at=?, last_error=NULL WHERE id=1",
                                    (now_iso, now_iso))
                     elif delta_error is None:
@@ -2738,10 +2765,12 @@ def startup():
                         # Seed only from a COMPLETED full crawl (one that recorded a duration). Seeding
                         # an interrupted index marked it "fresh" and left large buckets delta-only for
                         # FULL_CRAWL_INTERVAL while a third of the data was missing.
-                        if total > 0 and dur > 0 and prev_status not in ("interrupted", "degraded"):
+                        if _seed_from_existing(prev_status, total, dur):
                             _crawl_meta[f"{eid}:{name}"] = {"last_full": time.time(), "duration": dur}
                             seeded = True
-                            _ensure_fts_ready(name, eid)   # legacy NULL marker → verify and backfill; stale → repair now
+                            # legacy NULL marker → verify and backfill; stale → repair now. Off the startup
+                            # thread and bounded by the rebuild pool (the check reads the whole index).
+                            _rebuild_pool.submit(_ensure_fts_ready, name, eid)
                             log.info("Seeded schedule for %s:%s from existing index (%s objects); will keep fresh via scheduler",
                                      eid, name, f"{total:,}")
                     except Exception:
@@ -2749,7 +2778,8 @@ def startup():
                     if not seeded:
                         _queue_crawl(name, eid)
                         log.info("Queued %s crawl for %s:%s",
-                                 f"resume of {prev_status}" if prev_status in ("interrupted", "degraded") else "initial", eid, name)
+                                 f"resume of {prev_status}" if prev_status in ("interrupted", "degraded")
+                                 else ("retry after error" if prev_status.startswith("error") else "initial"), eid, name)
             except Exception as e:
                 log.error("Failed to list buckets on startup (endpoint=%s): %s", eid, e)
     threading.Thread(target=_startup_crawl, daemon=True).start()

--- a/backend/main.py
+++ b/backend/main.py
@@ -2634,7 +2634,7 @@ def _queue_delta_crawl(bucket, endpoint_id=None):
             with _crawl_lock:
                 _crawl_meta.setdefault(crawl_key, {})["last_delta"] = time.time()
             if failed_targets:
-                delta_error = f"{len(failed_targets)} delta target(s) failed to list"
+                delta_error = f"{len(failed_targets)} delta target(s) failed to list: " + ", ".join(t[:60] for t in failed_targets[:5])
                 log.warning("[%s:%s] Delta crawl degraded: %d new/changed, %s in %.1fs", eid, bucket, n, delta_error, time.monotonic() - t0)
             else:
                 log.info("[%s:%s] Delta crawl: %d new/changed in %.1fs", eid, bucket, n, time.monotonic() - t0)

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1137,6 +1137,7 @@ class TestTruthfulStates:
                 raise ConnectionError("provider went away")
             return [{"Key": f"{tp}new", "Size": 1, "LastModified": lm, "ETag": '"n"'}]
         with patch.object(m, "_hot_target_prefixes", return_value=["a/", "b/"]), patch.object(m, "_discover_delta_targets", return_value=set()), \
+             patch.object(m, "_list_children", return_value=[]), \
              patch.object(m, "_delta_list_prefix", side_effect=listing), patch.object(m._s3_manager, "get_client", return_value=object()):
             changed, failed = m._delta_crawl(bucket, "default")
         assert (changed, failed) == (1, ["b/"])
@@ -1316,6 +1317,7 @@ class TestTruthfulStates:
         lm = datetime(2026, 1, 1, tzinfo=timezone.utc)
         def boom(*a, **k): raise RuntimeError("SlowDown")
         with patch.object(m, "_hot_target_prefixes", return_value=["a/"]), patch.object(m, "_discover_delta_targets", side_effect=boom), \
+             patch.object(m, "_list_children", return_value=[]), \
              patch.object(m, "_delta_list_prefix", return_value=[{"Key": "a/new", "Size": 1, "LastModified": lm, "ETag": '"n"'}]), \
              patch.object(m._s3_manager, "get_client", return_value=object()):
             changed, failed = m._delta_crawl(bucket, "default")
@@ -1390,4 +1392,74 @@ class TestTruthfulStates:
         with m._get_db(bucket, "default") as db:
             after = dict(db.execute("SELECT status, last_crawl_end, last_error FROM crawl_status").fetchone())
         assert after["last_crawl_end"] > end0 and after["last_error"] is None and after["status"] == "complete", after
+
+    # ── review round 4: the delta must look at the bucket root ───────────────────────────
+
+    def _root_client(self, m, root_objs, tops, fail_root=False, prefix_objs=None):
+        from unittest.mock import MagicMock
+        from datetime import datetime, timezone
+        lm = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        calls = []
+        def list_objects_v2(**p):
+            pre, delim = p.get("Prefix", ""), p.get("Delimiter")
+            calls.append((pre, bool(delim)))
+            if delim and pre == "":
+                if fail_root: raise ConnectionError("root listing failed")
+                return {"CommonPrefixes": [{"Prefix": t} for t in tops],
+                        "Contents": [{"Key": k, "Size": 1, "LastModified": lm, "ETag": '"r"'} for k in root_objs], "IsTruncated": False}
+            objs = (prefix_objs or {}).get(pre, [])
+            return {"Contents": [{"Key": k, "Size": 1, "LastModified": lm, "ETag": '"p"'} for k in objs], "CommonPrefixes": [], "IsTruncated": False}
+        client = MagicMock(); client.list_objects_v2.side_effect = list_objects_v2
+        return client, calls
+
+    def test_delta_sees_new_root_objects_in_a_flat_bucket(self):
+        import sys
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-delta-root"
+        m._init_db(bucket, "default")
+        client, calls = self._root_client(m, root_objs=["fresh.bin"], tops=[])
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=set()), \
+             patch.object(m._s3_manager, "get_client", return_value=client):
+            changed, failed = m._delta_crawl(bucket, "default")
+        assert calls and calls[0] == ("", True), "a delta must issue the root LIST even with no hot prefixes"
+        assert (changed, failed) == (1, []), (changed, failed)
+        with m._get_db(bucket, "default") as db:
+            assert db.execute("SELECT COUNT(*) FROM objects WHERE key='fresh.bin'").fetchone()[0] == 1
+
+    def test_delta_ingests_a_brand_new_top_level_prefix_and_records_it(self):
+        import sys
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-delta-newtop"
+        m._init_db(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            db.execute("INSERT OR IGNORE INTO discovered_prefixes (prefix) VALUES ('old/')"); db.commit()
+        client, calls = self._root_client(m, root_objs=[], tops=["old/", "brandnew/"], prefix_objs={"brandnew/": ["brandnew/part-1.zip", "brandnew/part-2.zip"]})
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=set()), \
+             patch.object(m._s3_manager, "get_client", return_value=client):
+            changed, failed = m._delta_crawl(bucket, "default")
+        assert (changed, failed) == (2, []), (changed, failed)
+        assert ("brandnew/", False) in calls, "the new top-level prefix must be listed in full"
+        assert ("old/", False) not in calls, "already-known prefixes are not re-listed by the root check"
+        with m._get_db(bucket, "default") as db:
+            assert db.execute("SELECT COUNT(*) FROM objects WHERE key LIKE 'brandnew/%'").fetchone()[0] == 2
+            assert db.execute("SELECT COUNT(*) FROM discovered_prefixes WHERE prefix='brandnew/'").fetchone()[0] == 1
+
+    def test_failed_root_listing_degrades_the_delta(self):
+        import sys
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-delta-rootfail"
+        m._init_db(bucket, "default")
+        client, calls = self._root_client(m, root_objs=[], tops=[], fail_root=True, prefix_objs={"hot/": ["hot/x"]})
+        with patch.object(m, "_hot_target_prefixes", return_value=["hot/"]), patch.object(m, "_discover_delta_targets", return_value=set()), \
+             patch.object(m._s3_manager, "get_client", return_value=client):
+            changed, failed = m._delta_crawl(bucket, "default")
+        assert changed == 1 and failed == ["root"], (changed, failed)   # hot prefix still refreshed, delta not certified
+        # oversized root (page bound) is reported the same way
+        client2, _ = self._root_client(m, root_objs=[], tops=[])
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=set()), \
+             patch.object(m, "_list_children", return_value=None), patch.object(m._s3_manager, "get_client", return_value=client2):
+            assert m._delta_crawl(bucket, "default") == (0, ["root"])
 

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -977,3 +977,90 @@ class TestSplitKeepsDirectObjects:
             keys = sorted(r[0] for r in db.execute("SELECT key FROM objects"))
         assert keys == ["druid/README.md", "druid/segments/part-1.zip"], keys
 
+
+class TestTruthfulStates:
+    """P0: a crawl that did not see every page must not look complete, and a failed delta must not fake freshness."""
+
+    def _mk(self, m, bucket, fail_prefix=None):
+        from unittest.mock import MagicMock
+        from datetime import datetime, timezone
+        lm = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        calls = {"n": 0}
+        def list_objects_v2(**p):
+            pre, delim = p.get("Prefix", ""), p.get("Delimiter")
+            if delim:
+                if pre == "":
+                    return {"CommonPrefixes": [{"Prefix": "a/"}, {"Prefix": "b/"}, {"Prefix": "c/"}, {"Prefix": "d/"}], "Contents": [], "IsTruncated": False}
+                return {"CommonPrefixes": [], "Contents": [], "IsTruncated": False}
+            if pre == fail_prefix:
+                calls["n"] += 1
+                if calls["n"] == 1:   # first page succeeds, every later page fails
+                    return {"Contents": [{"Key": f"{pre}k1", "Size": 1, "LastModified": lm, "ETag": '"e"'}], "IsTruncated": True, "NextContinuationToken": "t"}
+                raise ConnectionError("provider went away")
+            return {"Contents": [{"Key": f"{pre}k1", "Size": 1, "LastModified": lm, "ETag": '"e"'}, {"Key": f"{pre}k2", "Size": 1, "LastModified": lm, "ETag": '"e"'}], "IsTruncated": False}
+        client = MagicMock(); client.list_objects_v2.side_effect = list_objects_v2
+        return client
+
+    def test_terminal_page_failure_marks_degraded_and_never_prunes(self):
+        import sys, time
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-degraded"
+        m._init_db(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")     # healthy full crawl: 4 prefixes × 2 objects
+        with m._get_db(bucket, "default") as db:
+            assert db.execute("SELECT status FROM crawl_status").fetchone()[0] == "complete"
+            ok_end = db.execute("SELECT last_crawl_end FROM crawl_status").fetchone()[0]
+        time.sleep(1.1)
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket, fail_prefix="c/")), patch.object(m._rebuild_pool, "submit"), patch.object(m.time, "sleep"):
+            m._run_crawl(bucket, "default")     # recrawl where c/ fails after its first page
+        with m._get_db(bucket, "default") as db:
+            row = dict(db.execute("SELECT * FROM crawl_status").fetchone())
+            keys = sorted(r[0] for r in db.execute("SELECT key FROM objects"))
+        assert row["status"] == "degraded", row
+        assert row["last_crawl_end"] == ok_end, "a failed attempt must not move the success timestamp"
+        assert row["last_error"] and "1 prefix" in row["last_error"]
+        assert row["last_attempt_at"] and row["last_attempt_at"] >= ok_end
+        assert "c/k2" in keys, "the row the failed listing never reached must NOT be pruned"
+        assert m._is_index_ready(bucket)
+
+    def test_failed_delta_does_not_fake_freshness(self):
+        import sys, time
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-delta"
+        m._init_db(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        with m._crawl_lock:
+            m._rebuilding.discard(f"default:{bucket}")   # the rebuild pool was mocked, so release the post-crawl marker by hand
+        with m._get_db(bucket, "default") as db:
+            before = dict(db.execute("SELECT status, last_crawl_end FROM crawl_status").fetchone())
+        def boom(*a, **k): raise RuntimeError("SlowDown")
+        with patch.object(m, "_delta_crawl", side_effect=boom), patch.object(m._crawl_pool, "submit", side_effect=lambda fn: fn()):
+            assert m._queue_delta_crawl(bucket, "default") is True
+        with m._get_db(bucket, "default") as db:
+            after = dict(db.execute("SELECT status, last_crawl_end, last_error, last_attempt_at FROM crawl_status").fetchone())
+        assert after["status"] == before["status"] == "complete"
+        assert after["last_crawl_end"] == before["last_crawl_end"], "a failed delta must not stamp a success time"
+        assert after["last_error"] == "SlowDown" and after["last_attempt_at"]
+
+    def test_crawl_status_reports_rebuilding_and_search_readiness(self):
+        import sys
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-status"
+        m._init_db(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        key = f"default:{bucket}"
+        try:
+            d = m.crawl_status(bucket, user={})
+            assert d["status"] == "complete" and d["rebuilding"] is True and d["search_ready"] is False, d   # rebuild pool was mocked: still marked rebuilding
+        finally:
+            with m._crawl_lock:
+                m._rebuilding.discard(key)
+        d = m.crawl_status(bucket, user={})
+        assert d["rebuilding"] is False and d["search_ready"] is True, d
+

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1046,7 +1046,8 @@ class TestTruthfulStates:
         assert after["last_crawl_end"] == before["last_crawl_end"], "a failed delta must not stamp a success time"
         assert after["last_error"] == "SlowDown" and after["last_attempt_at"]
 
-    def test_crawl_status_reports_rebuilding_and_search_readiness(self):
+    def test_search_readiness_is_persisted_per_generation(self):
+        """search_ready comes from fts_ready_gen == current_crawl_gen in the DB, never from an in-memory set."""
         import sys
         from unittest.mock import patch
         m = sys.modules.get("backend.main") or sys.modules["main"]
@@ -1054,13 +1055,114 @@ class TestTruthfulStates:
         m._init_db(bucket, "default")
         with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
             m._run_crawl(bucket, "default")
-        key = f"default:{bucket}"
-        try:
-            d = m.crawl_status(bucket, user={})
-            assert d["status"] == "complete" and d["rebuilding"] is True and d["search_ready"] is False, d   # rebuild pool was mocked: still marked rebuilding
-        finally:
-            with m._crawl_lock:
-                m._rebuilding.discard(key)
+        with m._crawl_lock:
+            m._rebuilding.discard(f"default:{bucket}")
         d = m.crawl_status(bucket, user={})
-        assert d["rebuilding"] is False and d["search_ready"] is True, d
+        assert d["status"] == "complete" and d["fts_ready_gen"] is None and d["rebuilding"] is True and d["search_ready"] is False, d
+        assert m._fts_should_rebuild(bucket, "default", False) is True, "no committed rebuild for this generation → rebuild"
+        m._rebuild_fts(bucket, "default")
+        d = m.crawl_status(bucket, user={})
+        assert d["fts_ready_gen"] == d["current_crawl_gen"] and d["search_ready"] is True and d["rebuilding"] is False, d
+        assert m._fts_should_rebuild(bucket, "default", False) is False
+        with m._get_db(bucket, "default") as db:   # a rebuild lost two generations ago must be redone even with no key changes
+            db.execute("UPDATE crawl_status SET fts_ready_gen = current_crawl_gen - 2"); db.commit()
+        assert m._fts_should_rebuild(bucket, "default", False) is True
+        with m._get_db(bucket, "default") as db:   # the previous generation's rebuild is enough when keys did not change
+            db.execute("UPDATE crawl_status SET fts_ready_gen = current_crawl_gen - 1"); db.commit()
+        assert m._fts_should_rebuild(bucket, "default", False) is False
+
+    def test_degraded_is_resumed_and_retries_only_unfinished_prefixes(self):
+        import sys, time
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-resume"
+        key = f"default:{bucket}"
+        m._init_db(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket, fail_prefix="c/")), patch.object(m._rebuild_pool, "submit"), patch.object(m.time, "sleep"):
+            m._run_crawl(bucket, "default")
+        meta = m._crawl_meta.get(key, {})
+        assert "last_full" not in meta and meta.get("degraded_at"), meta   # scheduler retries after RECRAWL_INTERVAL, no delta-only period
+        with m._crawl_lock:
+            m._rebuilding.discard(key)
+        healthy = self._mk(m, bucket)
+        with patch.object(m._s3_manager, "get_client", return_value=healthy), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        listed = [c.kwargs.get("Prefix") for c in healthy.list_objects_v2.call_args_list if not c.kwargs.get("Delimiter")]
+        assert listed == ["c/"], f"only the unfinished prefix must be re-listed, got {listed}"
+        with m._get_db(bucket, "default") as db:
+            row = dict(db.execute("SELECT status, last_error FROM crawl_status").fetchone())
+        assert row["status"] == "complete" and row["last_error"] is None, row
+        assert "last_full" in m._crawl_meta[key] and "degraded_at" not in m._crawl_meta[key]
+
+    def test_degraded_delta_and_delta_over_degraded_index_do_not_advance_last_crawl_end(self):
+        import sys
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-delta2"
+        key = f"default:{bucket}"
+        m._init_db(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        with m._crawl_lock:
+            m._rebuilding.discard(key)
+        with m._get_db(bucket, "default") as db:
+            end0 = db.execute("SELECT last_crawl_end FROM crawl_status").fetchone()[0]
+        # degraded delta: one target failed
+        with patch.object(m, "_delta_crawl", return_value=(3, ["a/"])), patch.object(m._crawl_pool, "submit", side_effect=lambda fn: fn()):
+            assert m._queue_delta_crawl(bucket, "default") is True
+        with m._get_db(bucket, "default") as db:
+            row = dict(db.execute("SELECT status, last_crawl_end, last_error FROM crawl_status").fetchone())
+        assert row == {"status": "complete", "last_crawl_end": end0, "last_error": "1 delta target(s) failed to list"}, row
+        # clean delta over a degraded index: status stays degraded, no success stamp
+        with m._get_db(bucket, "default") as db:
+            db.execute("UPDATE crawl_status SET status='degraded', last_error='2 prefix(es) failed to list'"); db.commit()
+        with patch.object(m, "_delta_crawl", return_value=(0, [])), patch.object(m._crawl_pool, "submit", side_effect=lambda fn: fn()):
+            assert m._queue_delta_crawl(bucket, "default") is True
+        with m._get_db(bucket, "default") as db:
+            row = dict(db.execute("SELECT status, last_crawl_end, last_attempt_at FROM crawl_status").fetchone())
+        assert row["status"] == "degraded" and row["last_crawl_end"] == end0 and row["last_attempt_at"], row
+
+    def test_delta_crawl_reports_failed_targets_and_keeps_good_ones(self):
+        import sys
+        from unittest.mock import patch
+        from datetime import datetime, timezone
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-delta3"
+        m._init_db(bucket, "default")
+        lm = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        def listing(client, b, tp):
+            if tp == "b/":
+                raise ConnectionError("provider went away")
+            return [{"Key": f"{tp}new", "Size": 1, "LastModified": lm, "ETag": '"n"'}]
+        with patch.object(m, "_hot_target_prefixes", return_value=["a/", "b/"]), patch.object(m, "_discover_delta_targets", return_value=set()), \
+             patch.object(m, "_delta_list_prefix", side_effect=listing), patch.object(m._s3_manager, "get_client", return_value=object()):
+            changed, failed = m._delta_crawl(bucket, "default")
+        assert (changed, failed) == (1, ["b/"])
+        with m._get_db(bucket, "default") as db:
+            assert db.execute("SELECT COUNT(*) FROM objects WHERE key='a/new'").fetchone()[0] == 1
+
+    def test_fatal_and_simple_paths_record_attempt_and_error(self):
+        import sys
+        from unittest.mock import MagicMock, patch
+        from datetime import datetime, timezone
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        lm = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        # fatal: the root listing itself explodes
+        bucket = "truth-fatal"; m._init_db(bucket, "default")
+        client = MagicMock(); client.list_objects_v2.side_effect = RuntimeError("AccessDenied")
+        with patch.object(m._s3_manager, "get_client", return_value=client), patch.object(m._rebuild_pool, "submit"), patch.object(m.time, "sleep"):
+            m._run_crawl(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            row = dict(db.execute("SELECT status, last_error, last_attempt_at, last_crawl_end FROM crawl_status").fetchone())
+        assert row["status"].startswith("error") and "AccessDenied" in row["last_error"] and row["last_attempt_at"] and row["last_crawl_end"] is None, row
+        # simple path: root-level files only
+        bucket = "truth-simple"; m._init_db(bucket, "default")
+        client = MagicMock(); client.list_objects_v2.side_effect = lambda **p: {"Contents": [{"Key": "root.txt", "Size": 1, "LastModified": lm, "ETag": '"e"'}], "CommonPrefixes": [], "IsTruncated": False}
+        with patch.object(m._s3_manager, "get_client", return_value=client), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            row = dict(db.execute("SELECT status, last_error, last_attempt_at, last_crawl_end FROM crawl_status").fetchone())
+        assert row["status"] == "complete" and row["last_error"] is None and row["last_attempt_at"] and row["last_crawl_end"], row
 

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1264,3 +1264,74 @@ class TestTruthfulStates:
         d = m.crawl_status(bucket, user={})
         assert d["status"] == "degraded" and d["full_crawl_complete"] is False and d["crawl_duration"], d
 
+    # ── review round 3: three remaining freshness-without-evidence paths ─────────────────
+
+    def test_stale_legacy_fts_is_rebuilt_not_certified(self):
+        """Pre-upgrade DB: readable, non-empty FTS that is missing a newer object. NULL marker must not be
+        backfilled; SQLite's integrity check catches the mismatch and a rebuild runs."""
+        import sys
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-legacy-stale"
+        m._init_db(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        with m._crawl_lock:
+            m._rebuilding.discard(f"default:{bucket}")
+        m._rebuild_fts(bucket, "default")   # generation N fully indexed
+        with m._get_db(bucket, "default") as db:
+            # catalogue moves to N+1 behind the index's back (triggers off, as during a crawl); marker NULL like a legacy DB
+            m._disable_fts_triggers(db)
+            db.execute("INSERT INTO objects (key,size,last_modified,etag,prefix,depth,crawl_gen) VALUES ('z/uniqueneedle.bin',1,'2026-01-01T00:00:00+00:00','e','z/',1,2)")
+            db.execute("UPDATE crawl_status SET fts_ready_gen=NULL, current_crawl_gen=current_crawl_gen+1")
+            db.commit()
+            m._enable_fts_triggers(db)
+            assert m._fts_healthy(db), "readable and non-empty — the health probe alone cannot see the staleness"
+            assert not m._fts_consistent(db), "SQLite's integrity check must see the missing row"
+            assert db.execute("SELECT COUNT(*) FROM objects_fts WHERE objects_fts MATCH 'uniqueneedle'").fetchone()[0] == 0
+        t = m._ensure_fts_ready(bucket, "default")
+        assert t is not None, "a stale legacy index must be rebuilt, never certified"
+        t.join(30)
+        d = m.crawl_status(bucket, user={})
+        assert d["fts_ready_gen"] == d["current_crawl_gen"] and d["search_ready"] is True, d
+        with m._get_db(bucket, "default") as db:
+            assert db.execute("SELECT COUNT(*) FROM objects_fts WHERE objects_fts MATCH 'uniqueneedle'").fetchone()[0] == 1
+            assert m._fts_consistent(db)
+
+    def test_startup_seeds_only_a_complete_full_crawl(self):
+        import sys
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        assert m._seed_from_existing("complete", 120, 12.0) is True
+        for st in ("error: fatal listing failure", "degraded", "interrupted", "crawling", ""):
+            assert m._seed_from_existing(st, 120, 12.0) is False, st
+        assert m._seed_from_existing("complete", 0, 12.0) is False and m._seed_from_existing("complete", 120, 0) is False
+
+    def test_delta_discovery_failure_degrades_the_delta(self):
+        import sys
+        from unittest.mock import patch
+        from datetime import datetime, timezone
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-delta-discovery"
+        m._init_db(bucket, "default")
+        lm = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        def boom(*a, **k): raise RuntimeError("SlowDown")
+        with patch.object(m, "_hot_target_prefixes", return_value=["a/"]), patch.object(m, "_discover_delta_targets", side_effect=boom), \
+             patch.object(m, "_delta_list_prefix", return_value=[{"Key": "a/new", "Size": 1, "LastModified": lm, "ETag": '"n"'}]), \
+             patch.object(m._s3_manager, "get_client", return_value=object()):
+            changed, failed = m._delta_crawl(bucket, "default")
+        assert changed == 1 and failed == ["discovery"], (changed, failed)   # hot prefixes still refreshed, but not a clean delta
+        with m._get_db(bucket, "default") as db:
+            assert db.execute("SELECT COUNT(*) FROM objects WHERE key='a/new'").fetchone()[0] == 1
+        # and the caller treats it as degraded: no success stamp
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        with m._crawl_lock:
+            m._rebuilding.discard(f"default:{bucket}")
+        with m._get_db(bucket, "default") as db:
+            end0 = db.execute("SELECT last_crawl_end FROM crawl_status").fetchone()[0]
+        with patch.object(m, "_delta_crawl", return_value=(1, ["discovery"])), patch.object(m._crawl_pool, "submit", side_effect=lambda fn: fn()):
+            m._queue_delta_crawl(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            row = dict(db.execute("SELECT status, last_crawl_end, last_error FROM crawl_status").fetchone())
+        assert row["last_crawl_end"] == end0 and row["status"] == "complete" and "1 delta target" in row["last_error"], row
+

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1540,3 +1540,21 @@ class TestTruthfulStates:
         with m._get_db(bucket, "default") as db:
             assert db.execute("SELECT COUNT(*) FROM objects WHERE key LIKE 'big/%'").fetchone()[0] == 7000
 
+    def test_discovery_bounds_remote_work_per_node(self):
+        """DELTA_MAX_NODES=1 must not let one node cost 20 LIST pages and 20,000 names: the node is
+        left unvisited after DELTA_NODE_MAX_PAGES and the walk is reported partial."""
+        import sys
+        from unittest.mock import MagicMock, patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-discovery-node"
+        m._init_db(bucket, "default")
+        def list_objects_v2(**p):
+            tok = int(p.get("ContinuationToken") or 0)
+            return {"CommonPrefixes": [{"Prefix": f"{p['Prefix']}c{tok:02d}-{i:04d}/"} for i in range(1000)],
+                    "Contents": [], "IsTruncated": tok + 1 < 20, "NextContinuationToken": str(tok + 1)}
+        client = MagicMock(); client.list_objects_v2.side_effect = list_objects_v2
+        with patch.object(m, "DELTA_MAX_NODES", 1), patch.object(m, "DELTA_NODE_MAX_PAGES", 2):
+            targets, partial = m._discover_delta_targets(client, bucket, "default", ["wide/"])
+        assert partial is True and targets == set()
+        assert client.list_objects_v2.call_count == 2, client.list_objects_v2.call_count
+

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1335,3 +1335,59 @@ class TestTruthfulStates:
             row = dict(db.execute("SELECT status, last_crawl_end, last_error FROM crawl_status").fetchone())
         assert row["last_crawl_end"] == end0 and row["status"] == "complete" and "1 delta target" in row["last_error"], row
 
+    def test_unreadable_status_before_delta_is_never_promoted(self):
+        """If the status cannot be read before a delta, nothing is promoted: only the attempt is recorded."""
+        import sys
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-delta-unknown"
+        m._init_db(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        with m._crawl_lock:
+            m._rebuilding.discard(f"default:{bucket}")
+        with m._get_db(bucket, "default") as db:
+            db.execute("UPDATE crawl_status SET status='degraded', last_error='x'"); db.commit()
+            before = dict(db.execute("SELECT status, last_crawl_end, last_error FROM crawl_status").fetchone())
+        real_get_db = m._get_db
+        calls = {"n": 0}
+        from contextlib import contextmanager
+        @contextmanager
+        def flaky_get_db(b, e=None):
+            calls["n"] += 1
+            if calls["n"] == 1:          # the status read right before the delta fails
+                raise RuntimeError("disk hiccup")
+            with real_get_db(b, e) as db:
+                yield db
+        with patch.object(m, "_get_db", flaky_get_db), patch.object(m, "_delta_crawl", return_value=(4, [])), \
+             patch.object(m._crawl_pool, "submit", side_effect=lambda fn: fn()):
+            assert m._queue_delta_crawl(bucket, "default") is True
+        with m._get_db(bucket, "default") as db:
+            after = dict(db.execute("SELECT status, last_crawl_end, last_error, last_attempt_at FROM crawl_status").fetchone())
+        assert after["status"] == before["status"] == "degraded" and after["last_crawl_end"] == before["last_crawl_end"], (before, after)
+        assert after["last_error"] == "x" and after["last_attempt_at"], after
+
+    def test_recovery_after_failed_discovery_advances_success_only_on_the_clean_retry(self):
+        import sys, time
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-delta-recover"
+        m._init_db(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        with m._crawl_lock:
+            m._rebuilding.discard(f"default:{bucket}")
+        with m._get_db(bucket, "default") as db:
+            end0 = db.execute("SELECT last_crawl_end FROM crawl_status").fetchone()[0]
+        time.sleep(1.1)
+        with patch.object(m, "_delta_crawl", return_value=(2, ["discovery"])), patch.object(m._crawl_pool, "submit", side_effect=lambda fn: fn()):
+            m._queue_delta_crawl(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            mid = dict(db.execute("SELECT status, last_crawl_end, last_error FROM crawl_status").fetchone())
+        assert mid["last_crawl_end"] == end0 and mid["last_error"] and mid["status"] == "complete", mid
+        with patch.object(m, "_delta_crawl", return_value=(0, [])), patch.object(m._crawl_pool, "submit", side_effect=lambda fn: fn()):
+            m._queue_delta_crawl(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            after = dict(db.execute("SELECT status, last_crawl_end, last_error FROM crawl_status").fetchone())
+        assert after["last_crawl_end"] > end0 and after["last_error"] is None and after["status"] == "complete", after
+

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1114,7 +1114,7 @@ class TestTruthfulStates:
             assert m._queue_delta_crawl(bucket, "default") is True
         with m._get_db(bucket, "default") as db:
             row = dict(db.execute("SELECT status, last_crawl_end, last_error FROM crawl_status").fetchone())
-        assert row == {"status": "complete", "last_crawl_end": end0, "last_error": "1 delta target(s) failed to list"}, row
+        assert row == {"status": "complete", "last_crawl_end": end0, "last_error": "1 delta target(s) failed to list: a/"}, row
         # clean delta over a degraded index: status stays degraded, no success stamp
         with m._get_db(bucket, "default") as db:
             db.execute("UPDATE crawl_status SET status='degraded', last_error='2 prefix(es) failed to list'"); db.commit()

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -475,7 +475,7 @@ class TestAsyncFTSRebuild:
         source = inspect.getsource(_rebuild_fts_async)
         assert "Thread" in source
         assert "daemon=True" in source
-        body = inspect.getsource(sys.modules["main"]._rebuild_fts)
+        body = inspect.getsource(sys.modules["main"]._rebuild_fts_locked)
         assert "objects_fts_new" in body and "RENAME TO objects_fts" in body and "FTS_REBUILD_CHUNK" in body   # shadow-table, bounded-memory rebuild
 
     def test_fts_rebuild_runs_in_background(self):
@@ -1557,4 +1557,37 @@ class TestTruthfulStates:
             targets, partial = m._discover_delta_targets(client, bucket, "default", ["wide/"])
         assert partial is True and targets == set()
         assert client.list_objects_v2.call_count == 2, client.list_objects_v2.call_count
+
+    def test_concurrent_fts_rebuilds_of_one_bucket_are_serialised(self):
+        """Startup repair and the post-crawl rebuild may both start a rebuild; they must not share the
+        shadow table. Live failure: "no such table: objects_fts_new"."""
+        import sys, threading, logging
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-fts-concurrent"
+        m._init_db(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            m._disable_fts_triggers(db)
+            db.executemany("INSERT INTO objects (key,size,last_modified,etag,prefix,depth,crawl_gen) VALUES (?,?,?,?,?,?,?)",
+                           [(f"a/{i:05d}/needle.bin", 1, "2026-01-01T00:00:00+00:00", "e", f"a/{i:05d}/", 2, 1) for i in range(3000)])
+            db.execute("UPDATE crawl_status SET current_crawl_gen=1"); db.commit()
+            m._enable_fts_triggers(db)
+        failures = []
+        class Catch(logging.Handler):
+            def emit(self, r):
+                if "FTS rebuild failed" in r.getMessage(): failures.append(r.getMessage())
+        h = Catch(); m.log.addHandler(h)
+        try:
+            with patch.object(m, "FTS_REBUILD_CHUNK", 200):
+                ts = [threading.Thread(target=m._rebuild_fts, args=(bucket, "default")) for _ in range(3)]
+                for t in ts: t.start()
+                for t in ts: t.join(60)
+        finally:
+            m.log.removeHandler(h)
+        assert failures == [], failures
+        with m._get_db(bucket, "default") as db:
+            assert m._fts_healthy(db) and m._fts_consistent(db)
+            assert db.execute("SELECT COUNT(*) FROM objects_fts WHERE objects_fts MATCH 'needle'").fetchone()[0] == 3000
+            assert tuple(db.execute("SELECT fts_ready_gen, current_crawl_gen FROM crawl_status").fetchone()) == (1, 1)
+            assert db.execute("SELECT COUNT(*) FROM sqlite_master WHERE name='objects_fts_new'").fetchone()[0] == 0
 

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1132,11 +1132,11 @@ class TestTruthfulStates:
         bucket = "truth-delta3"
         m._init_db(bucket, "default")
         lm = datetime(2026, 1, 1, tzinfo=timezone.utc)
-        def listing(client, b, tp):
+        def listing(client, b, tp, **kw):
             if tp == "b/":
                 raise ConnectionError("provider went away")
             return [{"Key": f"{tp}new", "Size": 1, "LastModified": lm, "ETag": '"n"'}]
-        with patch.object(m, "_hot_target_prefixes", return_value=["a/", "b/"]), patch.object(m, "_discover_delta_targets", return_value=set()), \
+        with patch.object(m, "_hot_target_prefixes", return_value=["a/", "b/"]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
              patch.object(m, "_list_children", return_value=[]), \
              patch.object(m, "_delta_list_prefix", side_effect=listing), patch.object(m._s3_manager, "get_client", return_value=object()):
             changed, failed = m._delta_crawl(bucket, "default")
@@ -1419,7 +1419,7 @@ class TestTruthfulStates:
         bucket = "truth-delta-root"
         m._init_db(bucket, "default")
         client, calls = self._root_client(m, root_objs=["fresh.bin"], tops=[])
-        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=set()), \
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
              patch.object(m._s3_manager, "get_client", return_value=client):
             changed, failed = m._delta_crawl(bucket, "default")
         assert calls and calls[0] == ("", True), "a delta must issue the root LIST even with no hot prefixes"
@@ -1436,7 +1436,7 @@ class TestTruthfulStates:
         with m._get_db(bucket, "default") as db:
             db.execute("INSERT OR IGNORE INTO discovered_prefixes (prefix) VALUES ('old/')"); db.commit()
         client, calls = self._root_client(m, root_objs=[], tops=["old/", "brandnew/"], prefix_objs={"brandnew/": ["brandnew/part-1.zip", "brandnew/part-2.zip"]})
-        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=set()), \
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
              patch.object(m._s3_manager, "get_client", return_value=client):
             changed, failed = m._delta_crawl(bucket, "default")
         assert (changed, failed) == (2, []), (changed, failed)
@@ -1453,13 +1453,90 @@ class TestTruthfulStates:
         bucket = "truth-delta-rootfail"
         m._init_db(bucket, "default")
         client, calls = self._root_client(m, root_objs=[], tops=[], fail_root=True, prefix_objs={"hot/": ["hot/x"]})
-        with patch.object(m, "_hot_target_prefixes", return_value=["hot/"]), patch.object(m, "_discover_delta_targets", return_value=set()), \
+        with patch.object(m, "_hot_target_prefixes", return_value=["hot/"]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
              patch.object(m._s3_manager, "get_client", return_value=client):
             changed, failed = m._delta_crawl(bucket, "default")
         assert changed == 1 and failed == ["root"], (changed, failed)   # hot prefix still refreshed, delta not certified
         # oversized root (page bound) is reported the same way
         client2, _ = self._root_client(m, root_objs=[], tops=[])
-        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=set()), \
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
              patch.object(m, "_list_children", return_value=None), patch.object(m._s3_manager, "get_client", return_value=client2):
             assert m._delta_crawl(bucket, "default") == (0, ["root"])
+
+    # ── review round 5: new-prefix bookkeeping, bounded discovery, streaming writes ──────
+
+    def test_new_prefix_is_recorded_only_after_a_successful_listing(self):
+        import sys
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-delta-newtop-fail"
+        m._init_db(bucket, "default")
+        client, calls = self._root_client(m, root_objs=[], tops=["brandnew/"])
+        orig = client.list_objects_v2.side_effect
+        def failing(**p):
+            if p.get("Prefix") == "brandnew/" and not p.get("Delimiter"):
+                raise ConnectionError("provider went away")
+            return orig(**p)
+        client.list_objects_v2.side_effect = failing
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
+             patch.object(m._s3_manager, "get_client", return_value=client):
+            changed, failed = m._delta_crawl(bucket, "default")
+        assert failed == ["brandnew/"], failed
+        with m._get_db(bucket, "default") as db:
+            assert db.execute("SELECT COUNT(*) FROM discovered_prefixes WHERE prefix='brandnew/'").fetchone()[0] == 0, "must stay unknown until listed"
+        # next delta: the prefix is still new, gets listed, and only then recorded
+        client2, calls2 = self._root_client(m, root_objs=[], tops=["brandnew/"], prefix_objs={"brandnew/": ["brandnew/a"]})
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
+             patch.object(m._s3_manager, "get_client", return_value=client2):
+            assert m._delta_crawl(bucket, "default") == (1, [])
+        assert ("brandnew/", False) in calls2
+        with m._get_db(bucket, "default") as db:
+            assert db.execute("SELECT COUNT(*) FROM discovered_prefixes WHERE prefix='brandnew/'").fetchone()[0] == 1
+
+    def test_discovery_frontier_is_bounded_on_the_first_level_and_reported(self):
+        import sys
+        from unittest.mock import MagicMock, patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-discovery-cap"
+        m._init_db(bucket, "default")
+        tops = [f"p{i:05d}/" for i in range(2037)]
+        client = MagicMock(); client.list_objects_v2.side_effect = lambda **p: {"CommonPrefixes": [], "Contents": [], "IsTruncated": False}
+        with patch.object(m, "DELTA_MAX_NODES", 2000):
+            targets, partial = m._discover_delta_targets(client, bucket, "default", tops)
+        assert partial is True
+        assert client.list_objects_v2.call_count == 2000, client.list_objects_v2.call_count
+        assert len(targets) == 2000 and "p02036/" in targets and "p00000/" not in targets, "newest names are kept"
+        # and the delta reports the partial walk instead of certifying itself
+        with patch.object(m, "_hot_target_prefixes", return_value=["hot/"]), patch.object(m, "_list_children", return_value=[]), \
+             patch.object(m, "_delta_list_prefix", return_value=[]), \
+             patch.object(m, "_discover_delta_targets", return_value=(set(), True)), patch.object(m._s3_manager, "get_client", return_value=object()):
+            assert m._delta_crawl(bucket, "default") == (0, ["discovery:truncated"])
+
+    def test_delta_streams_a_large_new_prefix_in_bounded_batches(self):
+        import sys
+        from unittest.mock import MagicMock, patch
+        from datetime import datetime, timezone
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-delta-stream"
+        m._init_db(bucket, "default")
+        lm = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        pages = 7   # 7,000 objects → must be flushed in ≤ 5,000-object batches, never held whole
+        def list_objects_v2(**p):
+            pre, delim, tok = p.get("Prefix", ""), p.get("Delimiter"), int(p.get("ContinuationToken") or 0)
+            if delim:
+                return {"CommonPrefixes": [{"Prefix": "big/"}] if pre == "" else [], "Contents": [], "IsTruncated": False}
+            return {"Contents": [{"Key": f"big/{tok:02d}-{i:04d}", "Size": 1, "LastModified": lm, "ETag": '"e"'} for i in range(1000)],
+                    "IsTruncated": tok + 1 < pages, "NextContinuationToken": str(tok + 1)}
+        client = MagicMock(); client.list_objects_v2.side_effect = list_objects_v2
+        sizes = []
+        real = m._delta_write
+        def spy(db, objs, gen):
+            sizes.append(len(objs)); return real(db, objs, gen)
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
+             patch.object(m, "_delta_write", side_effect=spy), patch.object(m._s3_manager, "get_client", return_value=client):
+            changed, failed = m._delta_crawl(bucket, "default")
+        assert (changed, failed) == (7000, []), (changed, failed)
+        assert sizes and max(sizes) <= 5000 and len(sizes) >= 2, sizes
+        with m._get_db(bucket, "default") as db:
+            assert db.execute("SELECT COUNT(*) FROM objects WHERE key LIKE 'big/%'").fetchone()[0] == 7000
 

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1166,3 +1166,101 @@ class TestTruthfulStates:
             row = dict(db.execute("SELECT status, last_error, last_attempt_at, last_crawl_end FROM crawl_status").fetchone())
         assert row["status"] == "complete" and row["last_error"] is None and row["last_attempt_at"] and row["last_crawl_end"], row
 
+    # ── review round 2: the four remaining blockers ──────────────────────────────────────
+
+    def test_delta_cannot_promote_an_errored_full_crawl(self):
+        import sys
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-delta-error"
+        m._init_db(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        with m._crawl_lock:
+            m._rebuilding.discard(f"default:{bucket}")
+        with m._get_db(bucket, "default") as db:
+            end0 = db.execute("SELECT last_crawl_end FROM crawl_status").fetchone()[0]
+            db.execute("UPDATE crawl_status SET status='error: AccessDenied', last_error='AccessDenied'"); db.commit()
+        with patch.object(m, "_delta_crawl", return_value=(5, [])), patch.object(m._crawl_pool, "submit", side_effect=lambda fn: fn()):
+            assert m._queue_delta_crawl(bucket, "default") is True
+        with m._get_db(bucket, "default") as db:
+            row = dict(db.execute("SELECT status, last_error, last_crawl_end, last_attempt_at FROM crawl_status").fetchone())
+        assert row["status"] == "error: AccessDenied" and row["last_error"] == "AccessDenied", row
+        assert row["last_crawl_end"] == end0 and row["last_attempt_at"], row
+        assert m.crawl_status(bucket, user={})["full_crawl_complete"] is False
+
+    def test_startup_repairs_absent_or_stale_search_generation(self):
+        import sys
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-startup-fts"
+        m._init_db(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        with m._crawl_lock:
+            m._rebuilding.discard(f"default:{bucket}")
+        # legacy database: the previous release built the index at completion but knew no marker.
+        # Simulate: healthy index, fts_ready_gen NULL → verified backfill, no rebuild.
+        m._rebuild_fts(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            db.execute("UPDATE crawl_status SET fts_ready_gen = NULL"); db.commit()
+            assert m._fts_healthy(db)
+        assert m._ensure_fts_ready(bucket, "default") is None
+        d = m.crawl_status(bucket, user={})
+        assert d["fts_ready_gen"] == d["current_crawl_gen"] and d["search_ready"] is True and d["rebuilding"] is False, d
+        # stale marker (a rebuild that never committed) → repaired immediately, readiness restored
+        with m._get_db(bucket, "default") as db:
+            db.execute("UPDATE crawl_status SET fts_ready_gen = current_crawl_gen - 2"); db.commit()
+        t = m._ensure_fts_ready(bucket, "default")
+        assert t is not None
+        t.join(30)
+        d = m.crawl_status(bucket, user={})
+        assert d["fts_ready_gen"] == d["current_crawl_gen"] and d["search_ready"] is True, d
+        assert f"default:{bucket}" not in m._rebuilding
+
+    def test_generation_marker_alone_never_reports_search_ready(self):
+        import sys
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-fts-invalid"
+        m._init_db(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        with m._crawl_lock:
+            m._rebuilding.discard(f"default:{bucket}")
+        m._rebuild_fts(bucket, "default")
+        assert m.crawl_status(bucket, user={})["search_ready"] is True
+        # marker says ready, but the index has been emptied underneath it
+        with m._get_db(bucket, "default") as db:
+            db.execute("INSERT INTO objects_fts(objects_fts) VALUES('delete-all')"); db.commit()
+            assert not m._fts_healthy(db)
+        d = m.crawl_status(bucket, user={})
+        assert d["fts_ready_gen"] == d["current_crawl_gen"] and d["search_ready"] is False and d["rebuilding"] is True, d
+        assert m._fts_should_rebuild(bucket, "default", False) is True
+        # marker says ready, but the table is gone
+        with m._get_db(bucket, "default") as db:
+            for trg in ("objects_fts_ai", "objects_fts_ad", "objects_fts_au"):
+                db.execute(f"DROP TRIGGER IF EXISTS {trg}")
+            db.execute("DROP TABLE objects_fts"); db.commit()
+            assert not m._fts_healthy(db)
+        assert m.crawl_status(bucket, user={})["search_ready"] is False
+        assert m._fts_should_rebuild(bucket, "default", False) is True
+        m._rebuild_fts(bucket, "default")   # and the rebuild recreates the table + triggers
+        with m._get_db(bucket, "default") as db:
+            assert m._fts_healthy(db)
+        assert m.crawl_status(bucket, user={})["search_ready"] is True
+
+    def test_full_crawl_complete_is_false_for_degraded(self):
+        import sys
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        bucket = "truth-fcc"
+        m._init_db(bucket, "default")
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
+            m._run_crawl(bucket, "default")
+        assert m.crawl_status(bucket, user={})["full_crawl_complete"] is True
+        with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket, fail_prefix="c/")), patch.object(m._rebuild_pool, "submit"), patch.object(m.time, "sleep"):
+            m._run_crawl(bucket, "default")
+        d = m.crawl_status(bucket, user={})
+        assert d["status"] == "degraded" and d["full_crawl_complete"] is False and d["crawl_duration"], d
+

--- a/benchmark/prodlab/RESULTS.md
+++ b/benchmark/prodlab/RESULTS.md
@@ -171,3 +171,19 @@ A Python-level thread dump (temporary local patch, never committed — the fault
 | Process RSS after | 345 MB |
 | Index size | 10.06 GB (the shadow table needs the old index's space only until the swap) |
 
+## Run 9 — PR #32 (truthful states), final image `phase-b22`: layouts re-timed + three-cycle reconcile gate
+
+Layouts (four buckets concurrently, 40 ms/page, 1 CPU): druid **19.3 s**, flat **27.9 s**, hive **33.0 s**, wide **222.8 s**; the wide layout's first delta with bounded discovery **42.4 s** (356 s before the `DELTA_MAX_NODES` frontier cap; it is reported `degraded: discovery:truncated`, so it never claims a full refresh).
+
+`reconcile_gate.sh` (1M-object druid bucket, `FULL_CRAWL_INTERVAL=240`, `RECRAWL_INTERVAL=60`, verified in the pod) — **RESULT: 0 failure(s)**:
+
+| Step | Observed |
+|---|---|
+| Initial crawl | 1,000,000 rows in 40–42 s, `complete`, rows == simulator truth |
+| Cycle 1: 1,000 keys deleted at the provider + 5 % injected LIST failures | reconcile 192.9–228.7 s → `complete`, **999,000 rows == truth** (per-page retries absorbed the injected failures; a terminal failure would have ended `degraded`) |
+| Cycle 2: clean reconcile | `complete`, rows == truth, `last_crawl_end` advanced, `last_error` cleared, search generation == catalogue generation |
+| Cycle 3: pod killed mid-reconcile (after the generation bumped) | `interrupted` after restart, resumed from checkpoints, `last_crawl_end` unchanged across the kill, then `complete`, rows == truth, timestamp advanced only after the resumed crawl finished |
+| Whole run | 0 unplanned restarts; 0 lock errors, crawl/delta errors, rebuild failures or unexpected tracebacks |
+
+Gate-script lessons recorded on the way: the search marker is stamped by the post-crawl step seconds after `complete` (wait for it, do not race it); a clean delta legitimately advances `last_crawl_end` between cycles (baseline immediately before the kill); Kubernetes rejects duplicate env names, so chart-managed variables must be set through their values, not `extraEnv`.
+

--- a/benchmark/prodlab/RESULTS.md
+++ b/benchmark/prodlab/RESULTS.md
@@ -187,3 +187,17 @@ Layouts (four buckets concurrently, 40 ms/page, 1 CPU): druid **19.3 s**, flat *
 
 Gate-script lessons recorded on the way: the search marker is stamped by the post-crawl step seconds after `complete` (wait for it, do not race it); a clean delta legitimately advances `last_crawl_end` between cycles (baseline immediately before the kill); Kubernetes rejects duplicate env names, so chart-managed variables must be set through their values, not `extraEnv`.
 
+## Run 10 — PR #32 current head (3324384 product code, image `phase-b23`): reconcile gate ×2, both **0 failures**
+
+Same three-cycle gate as Run 9, on the head that adds per-bucket FTS rebuild serialisation. Two runs: one with the post-kill state read at pod-Ready, one with the completion-aware check (a finished resume is accepted only with a strictly advanced success timestamp).
+
+| Step | Observed (both runs) |
+|---|---|
+| Initial crawl | 1,000,000 rows in 40–42 s, complete, == truth |
+| Cycle 1: 1,000 deletions + 5 % injected LIST failures | 999,000 == truth in 200–238 s |
+| Cycle 2: clean | complete, == truth, timestamp advanced, error cleared, search generation == catalogue generation |
+| Cycle 3: kill during the gen-4 reconcile | replacement Ready in 11–12 s reading `crawling` with `last_crawl_end` unchanged; "Resuming interrupted crawl"; complete 30 s later, == truth, timestamp advanced only then |
+| Whole run | 0 unplanned restarts; 0 lock errors, crawl/delta errors, rebuild failures, unexpected tracebacks |
+
+Three consecutive zero-failure gate runs on the PR #32 product code (Runs 9, 10a, 10b). The earlier "failures" were all gate-script timing: racing the post-crawl marker stamp, baselining before a legitimate clean delta, and a fixed 45 s pause that the checkpoint resume (39 s) beat.
+

--- a/benchmark/prodlab/reconcile_gate.sh
+++ b/benchmark/prodlab/reconcile_gate.sh
@@ -75,10 +75,18 @@ kubectl -n lab delete pod -l app=sairo --wait=false >/dev/null
 # fast enough that a 45 s pause let the resumed crawl finish before the "still interrupted" check.
 kubectl -n lab rollout status deploy/sairo --timeout=180s >/dev/null 2>&1
 say "after restart: $(snapshot)"
-S3=$(field status)
-check '[ "$S3" = interrupted ] || [ "$S3" = crawling ]' "after the kill the state is interrupted/crawling, not complete" '$S3'
+S3=$(field status); END_NOW=$(field last_crawl_end)
 check 'kubectl -n lab logs deploy/sairo --tail=2000 2>/dev/null | grep -q "Resuming interrupted crawl"' "resumed from checkpoints" ''
-check '[ "$(field last_crawl_end)" = "$END_PRE" ]' "kill did not advance last_crawl_end" '$(field last_crawl_end) vs $END_PRE'
+# Completion-aware: checkpoint resume can finish before this check runs. Either the crawl is still
+# running (state interrupted/crawling, success timestamp untouched) or it has already completed
+# (timestamp advanced past the pre-kill value). What is never acceptable: 'complete' with an
+# unchanged or earlier timestamp, or any state that pretends the kill itself was a success.
+if [ "$S3" = complete ]; then
+  check '[[ "$END_NOW" > "$END_PRE" ]]' "resume completed before the check; last_crawl_end advanced only via the resumed crawl" '$END_NOW vs $END_PRE'
+else
+  check '[ "$S3" = interrupted ] || [ "$S3" = crawling ]' "after the kill the state is interrupted/crawling, not complete" '$S3'
+  check '[ "$END_NOW" = "$END_PRE" ]' "kill did not advance last_crawl_end" '$END_NOW vs $END_PRE'
+fi
 wait_for '[ "$(field status)" = complete ]' 900 "cycle 3 completion after resume"
 say "after cycle 3: $(snapshot)"
 check '[ "$(field rows)" = "$(truth)" ]' "cycle 3 rows == truth after kill+resume" '$(field rows) vs $(truth)'

--- a/benchmark/prodlab/reconcile_gate.sh
+++ b/benchmark/prodlab/reconcile_gate.sh
@@ -59,23 +59,27 @@ check '[ "$(field status)" = complete ]' "cycle 2 complete" '$(field status)'
 check '[ "$(field rows)" = "$(truth)" ]' "cycle 2 rows == truth (deletions pruned)" '$(field rows) vs $(truth)'
 check '[[ "$(field last_crawl_end)" > "$END0" ]]' "cycle 2 advanced last_crawl_end" '$(field last_crawl_end) vs $END0'
 check '[ "$(field last_error)" = None ]' "cycle 2 cleared last_error" '$(field last_error)'
+# The search marker is stamped by the post-crawl rebuild step seconds after 'complete' (search_ready is
+# honestly false meanwhile): wait for it, bounded, instead of racing it.
+wait_for '[ "$(field fts_gen)" = "$(field gen)" ]' 300 "search generation catching up to catalogue generation"
 check '[ "$(field fts_gen)" = "$(field gen)" ]' "search generation matches catalogue generation" '$(field fts_gen) vs $(field gen)'
-END2=$(field last_crawl_end); GEN2=$(field gen)
+GEN2=$(field gen)
 
 # ── cycle 3: kill the pod mid-RECONCILE (a full crawl bumps current_crawl_gen; deltas do not, and both
 #    show status=crawling, so the generation is the only reliable signal) ──
 wait_for '[ "$(field gen)" -gt '$GEN2' ]' 600 "cycle 3 full reconcile start (generation > $GEN2)"
-sleep 15; say "killing pod mid-reconcile: $(snapshot)"
+sleep 15; END_PRE=$(field last_crawl_end)   # baseline immediately before the kill (a clean delta may have advanced it since cycle 2)
+say "killing pod mid-reconcile: $(snapshot)"
 kubectl -n lab delete pod -l app=sairo --wait=false >/dev/null; sleep 45
 say "after restart: $(snapshot)"
 S3=$(field status)
 check '[ "$S3" = interrupted ] || [ "$S3" = crawling ]' "after the kill the state is interrupted/crawling, not complete" '$S3'
 check 'kubectl -n lab logs deploy/sairo --tail=2000 2>/dev/null | grep -q "Resuming interrupted crawl"' "resumed from checkpoints" ''
-check '[ "$(field last_crawl_end)" = "$END2" ]' "kill did not advance last_crawl_end" '$(field last_crawl_end)'
+check '[ "$(field last_crawl_end)" = "$END_PRE" ]' "kill did not advance last_crawl_end" '$(field last_crawl_end) vs $END_PRE'
 wait_for '[ "$(field status)" = complete ]' 900 "cycle 3 completion after resume"
 say "after cycle 3: $(snapshot)"
 check '[ "$(field rows)" = "$(truth)" ]' "cycle 3 rows == truth after kill+resume" '$(field rows) vs $(truth)'
-check '[[ "$(field last_crawl_end)" > "$END2" ]]' "cycle 3 advanced last_crawl_end only after the resumed crawl completed" '$(field last_crawl_end)'
+check '[[ "$(field last_crawl_end)" > "$END_PRE" ]]' "cycle 3 advanced last_crawl_end only after the resumed crawl completed" '$(field last_crawl_end) vs $END_PRE'
 check '[ "$(kubectl -n lab get pod -l app=sairo -o jsonpath="{.items[0].status.containerStatuses[0].restartCount}")" = 0 ]' "no unplanned container restarts (OOM/crash)" '$(kubectl -n lab get pod -l app=sairo -o jsonpath="{.items[0].status.containerStatuses[0].restartCount}")'
 # Operational failures only. "Prefix ... failed after N retries" (ERROR level) is the EXPECTED outcome of the injected
 # LIST failures in cycle 1, and every pod logs one trapped passlib/bcrypt version traceback at startup.

--- a/benchmark/prodlab/reconcile_gate.sh
+++ b/benchmark/prodlab/reconcile_gate.sh
@@ -12,10 +12,12 @@ kubectl config use-context kind-sairo-lab >/dev/null
 # Set the intervals BEFORE the variant deploy (which reuses release values). No --wait here: a pod
 # still terminating from a previous run made the waited upgrade time out and the settings were
 # silently dropped, so cycle 2/3 waited on a 3600 s reconcile interval.
+# RECRAWL_INTERVAL is chart-managed → its value; FULL_CRAWL_INTERVAL is not → extraEnv (a duplicate env name
+# is rejected by the API server, which is how two earlier gate runs lost their intervals).
 helm upgrade sairo "$HERE/../../charts/sairo" -n lab --reuse-values \
   --set-string 'extraEnv[0].name=SUBPREFIX_SPLIT_MIN_OBJECTS,extraEnv[0].value=50000' \
   --set-string 'extraEnv[1].name=FULL_CRAWL_INTERVAL,extraEnv[1].value=240' \
-  --set-string 'extraEnv[2].name=RECRAWL_INTERVAL,extraEnv[2].value=60' >/dev/null || { echo "helm upgrade (intervals) failed"; exit 1; }
+  --set crawler.recrawlInterval=60 || { echo "helm upgrade (intervals) failed"; exit 1; }
 "$HERE/run_variant.sh" "$TAG" "$HERE/spec-1m.json" --for 900 >/dev/null 2>&1
 ENVS=$(kubectl -n lab exec deploy/sairo -- sh -c 'echo "$FULL_CRAWL_INTERVAL/$RECRAWL_INTERVAL"' 2>/dev/null)
 [ "$ENVS" = "240/60" ] || { echo "FAIL: pod intervals are '$ENVS', expected 240/60 — gate cannot time its cycles"; exit 1; }

--- a/benchmark/prodlab/reconcile_gate.sh
+++ b/benchmark/prodlab/reconcile_gate.sh
@@ -70,7 +70,10 @@ GEN2=$(field gen)
 wait_for '[ "$(field gen)" -gt '$GEN2' ]' 600 "cycle 3 full reconcile start (generation > $GEN2)"
 sleep 15; END_PRE=$(field last_crawl_end)   # baseline immediately before the kill (a clean delta may have advanced it since cycle 2)
 say "killing pod mid-reconcile: $(snapshot)"
-kubectl -n lab delete pod -l app=sairo --wait=false >/dev/null; sleep 45
+kubectl -n lab delete pod -l app=sairo --wait=false >/dev/null
+# Check the state the moment the replacement is Ready, not after a fixed pause: checkpoint resume is
+# fast enough that a 45 s pause let the resumed crawl finish before the "still interrupted" check.
+kubectl -n lab rollout status deploy/sairo --timeout=180s >/dev/null 2>&1
 say "after restart: $(snapshot)"
 S3=$(field status)
 check '[ "$S3" = interrupted ] || [ "$S3" = crawling ]' "after the kill the state is interrupted/crawling, not complete" '$S3'

--- a/benchmark/prodlab/reconcile_gate.sh
+++ b/benchmark/prodlab/reconcile_gate.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Truthful-state gate: three full reconciles of a 1M-object bucket with injected LIST failures, a
+# deletion (stale rows), and one pod kill mid-crawl. Asserts: final count == simulator truth, status
+# transitions are honest (degraded/interrupted never look complete), last_crawl_end advances only on
+# clean completes, 0 restarts other than the deliberate kill.
+#   ./reconcile_gate.sh <image-tag>        (FULL_CRAWL_INTERVAL is set to 240 s via extraEnv)
+set -u
+TAG=$1; HERE=$(cd "$(dirname "$0")" && pwd); B=rec-1m
+kubectl config use-context kind-sairo-lab >/dev/null
+helm upgrade sairo "$HERE/../../charts/sairo" -n lab --reuse-values \
+  --set-string 'extraEnv[0].name=SUBPREFIX_SPLIT_MIN_OBJECTS,extraEnv[0].value=50000' \
+  --set-string 'extraEnv[1].name=FULL_CRAWL_INTERVAL,extraEnv[1].value=240' \
+  --set-string 'extraEnv[2].name=RECRAWL_INTERVAL,extraEnv[2].value=60' --wait --timeout 180s >/dev/null
+"$HERE/run_variant.sh" "$TAG" "$HERE/spec-1m.json" --for 900 >/dev/null 2>&1
+say(){ echo "[$(date +%T)] $*"; }
+sim(){ kubectl -n lab exec deploy/s3sim -- python3 -c "import json,urllib.request as u; r=u.Request('http://127.0.0.1:9001$1', data=json.dumps($2).encode() if '$2' else None, headers={'Content-Type':'application/json'}); print(u.urlopen(r).read().decode())" 2>/dev/null; }
+st(){ kubectl -n lab exec -i deploy/sairo -- python3 - <<PY 2>/dev/null
+import sqlite3; c=sqlite3.connect("/data/$B.db")
+r=c.execute("SELECT status,total_objects,last_crawl_end,last_attempt_at,last_error,current_crawl_gen,fts_ready_gen FROM crawl_status").fetchone()
+print("status=%s objects=%s end=%s attempt=%s err=%s gen=%s fts=%s rows=%s" % (r+ (c.execute("SELECT COUNT(*) FROM objects").fetchone()[0],)))
+PY
+}
+completes(){ kubectl -n lab logs deploy/sairo --tail=20000 2>/dev/null | grep -c "\[default:$B\] Crawl complete"; }
+say "initial crawl done: $(st)"; say "truth: $(sim /truth?bucket=$B '')"
+END0=$(st | sed -E 's/.*end=([^ ]+).*/\1/')
+# ── cycle 1: delete 1,000 keys at the provider, then 5 % LIST failures during the reconcile ──
+say "cycle 1: delete 1000 keys + error_rate 0.05"; sim /delete_positions '{"bucket":"'$B'","n":1000}' >/dev/null; sim /error_rate '{"rate":0.05}' >/dev/null
+N=$(completes); for i in $(seq 1 60); do [ "$(completes)" -gt "$N" ] && break; sleep 10; done
+say "after cycle 1: $(st)"; sim /error_rate '{"rate":0}' >/dev/null
+# ── cycle 2: clean reconcile — must reach complete and match truth ──
+N=$(completes); for i in $(seq 1 60); do [ "$(completes)" -gt "$N" ] && break; sleep 10; done
+say "after cycle 2: $(st)"; say "truth: $(sim /truth?bucket=$B '')"
+# ── cycle 3: kill the pod mid-reconcile, let it resume ──
+N=$(completes); for i in $(seq 1 60); do kubectl -n lab logs deploy/sairo --tail=200 2>/dev/null | grep -q "Crawl started for default:$B" && break; sleep 5; done; sleep 20
+say "killing pod mid-reconcile: $(st)"; kubectl -n lab delete pod -l app=sairo --wait=false >/dev/null; sleep 40
+say "after restart: $(st)"; kubectl -n lab logs deploy/sairo --tail=400 2>/dev/null | grep -E "Resuming|interrupted|backfilled|repairing" | cut -c1-120 | head -4
+for i in $(seq 1 60); do st | grep -q "status=complete" && break; sleep 10; done
+say "after cycle 3: $(st)"; say "truth: $(sim /truth?bucket=$B '')"
+say "restarts=$(kubectl -n lab get pod -l app=sairo -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}') lock/errors=$(kubectl -n lab logs deploy/sairo --tail=50000 2>/dev/null | grep -cE 'database is locked|Traceback' )"

--- a/benchmark/prodlab/reconcile_gate.sh
+++ b/benchmark/prodlab/reconcile_gate.sh
@@ -53,10 +53,11 @@ check '[ "$(field rows)" = "$(truth)" ]' "cycle 2 rows == truth (deletions prune
 check '[[ "$(field last_crawl_end)" > "$END0" ]]' "cycle 2 advanced last_crawl_end" '$(field last_crawl_end) vs $END0'
 check '[ "$(field last_error)" = None ]' "cycle 2 cleared last_error" '$(field last_error)'
 check '[ "$(field fts_gen)" = "$(field gen)" ]' "search generation matches catalogue generation" '$(field fts_gen) vs $(field gen)'
-END2=$(field last_crawl_end)
+END2=$(field last_crawl_end); GEN2=$(field gen)
 
-# ── cycle 3: kill the pod mid-reconcile; must resume, never look complete while partial ──
-wait_for 'kubectl -n lab logs deploy/sairo --tail=300 2>/dev/null | grep -q "Crawl started for default:'$B'.*incremental=True" && [ "$(field status)" = crawling ]' 600 "cycle 3 reconcile start"
+# ── cycle 3: kill the pod mid-RECONCILE (a full crawl bumps current_crawl_gen; deltas do not, and both
+#    show status=crawling, so the generation is the only reliable signal) ──
+wait_for '[ "$(field gen)" -gt '$GEN2' ]' 600 "cycle 3 full reconcile start (generation > $GEN2)"
 sleep 15; say "killing pod mid-reconcile: $(snapshot)"
 kubectl -n lab delete pod -l app=sairo --wait=false >/dev/null; sleep 45
 say "after restart: $(snapshot)"

--- a/benchmark/prodlab/reconcile_gate.sh
+++ b/benchmark/prodlab/reconcile_gate.sh
@@ -9,11 +9,16 @@ pass(){ say "PASS: $*"; }
 fail(){ say "FAIL: $*"; FAILS=$((FAILS+1)); }
 check(){ if eval "$1"; then pass "$2"; else fail "$2 (got: $(eval "echo $3" 2>/dev/null))"; fi; }
 kubectl config use-context kind-sairo-lab >/dev/null
+# Set the intervals BEFORE the variant deploy (which reuses release values). No --wait here: a pod
+# still terminating from a previous run made the waited upgrade time out and the settings were
+# silently dropped, so cycle 2/3 waited on a 3600 s reconcile interval.
 helm upgrade sairo "$HERE/../../charts/sairo" -n lab --reuse-values \
   --set-string 'extraEnv[0].name=SUBPREFIX_SPLIT_MIN_OBJECTS,extraEnv[0].value=50000' \
   --set-string 'extraEnv[1].name=FULL_CRAWL_INTERVAL,extraEnv[1].value=240' \
-  --set-string 'extraEnv[2].name=RECRAWL_INTERVAL,extraEnv[2].value=60' --wait --timeout 180s >/dev/null
+  --set-string 'extraEnv[2].name=RECRAWL_INTERVAL,extraEnv[2].value=60' >/dev/null || { echo "helm upgrade (intervals) failed"; exit 1; }
 "$HERE/run_variant.sh" "$TAG" "$HERE/spec-1m.json" --for 900 >/dev/null 2>&1
+ENVS=$(kubectl -n lab exec deploy/sairo -- sh -c 'echo "$FULL_CRAWL_INTERVAL/$RECRAWL_INTERVAL"' 2>/dev/null)
+[ "$ENVS" = "240/60" ] || { echo "FAIL: pod intervals are '$ENVS', expected 240/60 — gate cannot time its cycles"; exit 1; }
 sim(){ kubectl -n lab exec deploy/s3sim -- python3 -c "import json,urllib.request as u; r=u.Request('http://127.0.0.1:9001$1', data=json.dumps($2).encode() if '$2' else None, headers={'Content-Type':'application/json'}); print(u.urlopen(r).read().decode())" 2>/dev/null; }
 truth(){ sim "/truth?bucket=$B" '' | python3 -c "import sys,json; print(json.load(sys.stdin)['count'])"; }
 field(){ kubectl -n lab exec -i deploy/sairo -- python3 - <<PY 2>/dev/null

--- a/benchmark/prodlab/reconcile_gate.sh
+++ b/benchmark/prodlab/reconcile_gate.sh
@@ -1,39 +1,73 @@
 #!/usr/bin/env bash
-# Truthful-state gate: three full reconciles of a 1M-object bucket with injected LIST failures, a
-# deletion (stale rows), and one pod kill mid-crawl. Asserts: final count == simulator truth, status
-# transitions are honest (degraded/interrupted never look complete), last_crawl_end advances only on
-# clean completes, 0 restarts other than the deliberate kill.
-#   ./reconcile_gate.sh <image-tag>        (FULL_CRAWL_INTERVAL is set to 240 s via extraEnv)
+# Truthful-state gate: three full reconciles of a 1M-object bucket with 1,000 deletions, 5 % injected
+# LIST failures and one pod kill mid-reconcile. Every step is ASSERTED; exit code = number of failures.
+#   ./reconcile_gate.sh <image-tag>      (FULL_CRAWL_INTERVAL=240, RECRAWL_INTERVAL=60 via extraEnv)
 set -u
-TAG=$1; HERE=$(cd "$(dirname "$0")" && pwd); B=rec-1m
+TAG=$1; HERE=$(cd "$(dirname "$0")" && pwd); B=rec-1m; FAILS=0
+say(){ echo "[$(date +%T)] $*"; }
+pass(){ say "PASS: $*"; }
+fail(){ say "FAIL: $*"; FAILS=$((FAILS+1)); }
+check(){ if eval "$1"; then pass "$2"; else fail "$2 (got: $(eval "echo $3" 2>/dev/null))"; fi; }
 kubectl config use-context kind-sairo-lab >/dev/null
 helm upgrade sairo "$HERE/../../charts/sairo" -n lab --reuse-values \
   --set-string 'extraEnv[0].name=SUBPREFIX_SPLIT_MIN_OBJECTS,extraEnv[0].value=50000' \
   --set-string 'extraEnv[1].name=FULL_CRAWL_INTERVAL,extraEnv[1].value=240' \
   --set-string 'extraEnv[2].name=RECRAWL_INTERVAL,extraEnv[2].value=60' --wait --timeout 180s >/dev/null
 "$HERE/run_variant.sh" "$TAG" "$HERE/spec-1m.json" --for 900 >/dev/null 2>&1
-say(){ echo "[$(date +%T)] $*"; }
 sim(){ kubectl -n lab exec deploy/s3sim -- python3 -c "import json,urllib.request as u; r=u.Request('http://127.0.0.1:9001$1', data=json.dumps($2).encode() if '$2' else None, headers={'Content-Type':'application/json'}); print(u.urlopen(r).read().decode())" 2>/dev/null; }
-st(){ kubectl -n lab exec -i deploy/sairo -- python3 - <<PY 2>/dev/null
+truth(){ sim "/truth?bucket=$B" '' | python3 -c "import sys,json; print(json.load(sys.stdin)['count'])"; }
+field(){ kubectl -n lab exec -i deploy/sairo -- python3 - <<PY 2>/dev/null
 import sqlite3; c=sqlite3.connect("/data/$B.db")
-r=c.execute("SELECT status,total_objects,last_crawl_end,last_attempt_at,last_error,current_crawl_gen,fts_ready_gen FROM crawl_status").fetchone()
-print("status=%s objects=%s end=%s attempt=%s err=%s gen=%s fts=%s rows=%s" % (r+ (c.execute("SELECT COUNT(*) FROM objects").fetchone()[0],)))
+r=dict(zip(("status","total_objects","last_crawl_end","last_attempt_at","last_error","gen","fts_gen"), c.execute("SELECT status,total_objects,last_crawl_end,last_attempt_at,last_error,current_crawl_gen,fts_ready_gen FROM crawl_status").fetchone()))
+r["rows"]=c.execute("SELECT COUNT(*) FROM objects").fetchone()[0]
+print(r["$1"])
 PY
 }
-completes(){ kubectl -n lab logs deploy/sairo --tail=20000 2>/dev/null | grep -c "\[default:$B\] Crawl complete"; }
-say "initial crawl done: $(st)"; say "truth: $(sim /truth?bucket=$B '')"
-END0=$(st | sed -E 's/.*end=([^ ]+).*/\1/')
-# ── cycle 1: delete 1,000 keys at the provider, then 5 % LIST failures during the reconcile ──
-say "cycle 1: delete 1000 keys + error_rate 0.05"; sim /delete_positions '{"bucket":"'$B'","n":1000}' >/dev/null; sim /error_rate '{"rate":0.05}' >/dev/null
-N=$(completes); for i in $(seq 1 60); do [ "$(completes)" -gt "$N" ] && break; sleep 10; done
-say "after cycle 1: $(st)"; sim /error_rate '{"rate":0}' >/dev/null
-# ── cycle 2: clean reconcile — must reach complete and match truth ──
-N=$(completes); for i in $(seq 1 60); do [ "$(completes)" -gt "$N" ] && break; sleep 10; done
-say "after cycle 2: $(st)"; say "truth: $(sim /truth?bucket=$B '')"
-# ── cycle 3: kill the pod mid-reconcile, let it resume ──
-N=$(completes); for i in $(seq 1 60); do kubectl -n lab logs deploy/sairo --tail=200 2>/dev/null | grep -q "Crawl started for default:$B" && break; sleep 5; done; sleep 20
-say "killing pod mid-reconcile: $(st)"; kubectl -n lab delete pod -l app=sairo --wait=false >/dev/null; sleep 40
-say "after restart: $(st)"; kubectl -n lab logs deploy/sairo --tail=400 2>/dev/null | grep -E "Resuming|interrupted|backfilled|repairing" | cut -c1-120 | head -4
-for i in $(seq 1 60); do st | grep -q "status=complete" && break; sleep 10; done
-say "after cycle 3: $(st)"; say "truth: $(sim /truth?bucket=$B '')"
-say "restarts=$(kubectl -n lab get pod -l app=sairo -o jsonpath='{.items[0].status.containerStatuses[0].restartCount}') lock/errors=$(kubectl -n lab logs deploy/sairo --tail=50000 2>/dev/null | grep -cE 'database is locked|Traceback' )"
+snapshot(){ echo "status=$(field status) rows=$(field rows) end=$(field last_crawl_end) attempt=$(field last_attempt_at) err=$(field last_error) gen=$(field gen) fts=$(field fts_gen)"; }
+completes(){ kubectl -n lab logs deploy/sairo --tail=50000 2>/dev/null | grep -c "\[default:$B\] Crawl complete"; }
+wait_for(){ # wait_for "<cmd returning 0 when done>" <seconds> <label>
+  local t=0; while [ $t -lt $2 ]; do eval "$1" && return 0; sleep 10; t=$((t+10)); done; fail "$3 timed out after $2 s"; return 1; }
+
+say "initial: $(snapshot)"
+check '[ "$(field status)" = complete ]' "initial crawl complete" '$(field status)'
+check '[ "$(field rows)" = "$(truth)" ]' "initial rows == truth" '$(field rows) vs $(truth)'
+END0=$(field last_crawl_end)
+
+# ── cycle 1: 1,000 keys deleted at the provider + 5 % LIST failures during the reconcile ──
+say "cycle 1: delete 1000 keys, error_rate 0.05"; sim /delete_positions '{"bucket":"'$B'","n":1000}' >/dev/null; sim /error_rate '{"rate":0.05}' >/dev/null
+N=$(completes); wait_for '[ "$(completes)" -gt '$N' ]' 900 "cycle 1 reconcile"
+say "after cycle 1: $(snapshot)"; sim /error_rate '{"rate":0}' >/dev/null
+S1=$(field status)
+check '[ "$S1" = degraded ] || [ "$S1" = complete ]' "cycle 1 ends degraded (failed prefixes) or complete, never anything else" '$S1'
+if [ "$S1" = degraded ]; then
+  check '[ "$(field last_crawl_end)" = "$END0" ]' "degraded did not advance last_crawl_end" '$(field last_crawl_end)'
+  check '[ -n "$(field last_error)" ] && [ "$(field last_error)" != None ]' "degraded recorded last_error" '$(field last_error)'
+  check '[ "$(field rows)" -ge "$(truth)" ]' "degraded pruned nothing it could not vouch for (rows >= truth)" '$(field rows) vs $(truth)'
+fi
+
+# ── cycle 2: clean reconcile → complete, rows == truth, success timestamp advanced ──
+N=$(completes); wait_for '[ "$(field status)" = complete ] && [ "$(completes)" -gt '$N' ]' 900 "cycle 2 clean reconcile"
+say "after cycle 2: $(snapshot)"
+check '[ "$(field status)" = complete ]' "cycle 2 complete" '$(field status)'
+check '[ "$(field rows)" = "$(truth)" ]' "cycle 2 rows == truth (deletions pruned)" '$(field rows) vs $(truth)'
+check '[[ "$(field last_crawl_end)" > "$END0" ]]' "cycle 2 advanced last_crawl_end" '$(field last_crawl_end) vs $END0'
+check '[ "$(field last_error)" = None ]' "cycle 2 cleared last_error" '$(field last_error)'
+check '[ "$(field fts_gen)" = "$(field gen)" ]' "search generation matches catalogue generation" '$(field fts_gen) vs $(field gen)'
+END2=$(field last_crawl_end)
+
+# ── cycle 3: kill the pod mid-reconcile; must resume, never look complete while partial ──
+wait_for 'kubectl -n lab logs deploy/sairo --tail=300 2>/dev/null | grep -q "Crawl started for default:'$B'.*incremental=True" && [ "$(field status)" = crawling ]' 600 "cycle 3 reconcile start"
+sleep 15; say "killing pod mid-reconcile: $(snapshot)"
+kubectl -n lab delete pod -l app=sairo --wait=false >/dev/null; sleep 45
+say "after restart: $(snapshot)"
+S3=$(field status)
+check '[ "$S3" = interrupted ] || [ "$S3" = crawling ]' "after the kill the state is interrupted/crawling, not complete" '$S3'
+check 'kubectl -n lab logs deploy/sairo --tail=2000 2>/dev/null | grep -q "Resuming interrupted crawl"' "resumed from checkpoints" ''
+check '[ "$(field last_crawl_end)" = "$END2" ]' "kill did not advance last_crawl_end" '$(field last_crawl_end)'
+wait_for '[ "$(field status)" = complete ]' 900 "cycle 3 completion after resume"
+say "after cycle 3: $(snapshot)"
+check '[ "$(field rows)" = "$(truth)" ]' "cycle 3 rows == truth after kill+resume" '$(field rows) vs $(truth)'
+check '[[ "$(field last_crawl_end)" > "$END2" ]]' "cycle 3 advanced last_crawl_end only after the resumed crawl completed" '$(field last_crawl_end)'
+check '[ "$(kubectl -n lab get pod -l app=sairo -o jsonpath="{.items[0].status.containerStatuses[0].restartCount}")" = 0 ]' "no unplanned container restarts (OOM/crash)" '$(kubectl -n lab get pod -l app=sairo -o jsonpath="{.items[0].status.containerStatuses[0].restartCount}")'
+check '[ "$(kubectl -n lab logs deploy/sairo --tail=50000 2>/dev/null | grep -cE "database is locked|Traceback" )" = 0 ]' "zero lock errors / tracebacks" ''
+say "RESULT: $FAILS failure(s)"; exit $FAILS

--- a/benchmark/prodlab/reconcile_gate.sh
+++ b/benchmark/prodlab/reconcile_gate.sh
@@ -70,5 +70,10 @@ say "after cycle 3: $(snapshot)"
 check '[ "$(field rows)" = "$(truth)" ]' "cycle 3 rows == truth after kill+resume" '$(field rows) vs $(truth)'
 check '[[ "$(field last_crawl_end)" > "$END2" ]]' "cycle 3 advanced last_crawl_end only after the resumed crawl completed" '$(field last_crawl_end)'
 check '[ "$(kubectl -n lab get pod -l app=sairo -o jsonpath="{.items[0].status.containerStatuses[0].restartCount}")" = 0 ]' "no unplanned container restarts (OOM/crash)" '$(kubectl -n lab get pod -l app=sairo -o jsonpath="{.items[0].status.containerStatuses[0].restartCount}")'
-check '[ "$(kubectl -n lab logs deploy/sairo --tail=50000 2>/dev/null | grep -cE "database is locked|Traceback" )" = 0 ]' "zero lock errors / tracebacks" ''
+# Operational failures only. "Prefix ... failed after N retries" (ERROR level) is the EXPECTED outcome of the injected
+# LIST failures in cycle 1, and every pod logs one trapped passlib/bcrypt version traceback at startup.
+LOGS=$(kubectl -n lab logs deploy/sairo --tail=50000 2>/dev/null)
+OPS=$(echo "$LOGS" | grep -cE "database is locked|Crawl error:|Delta crawl error|FTS rebuild failed|Post-crawl .* failed")
+TB=$(( $(echo "$LOGS" | grep -c "^Traceback") - $(echo "$LOGS" | grep -A3 "^Traceback" | grep -c "module 'bcrypt'") ))
+check '[ "$OPS" = 0 ] && [ "$TB" -le 0 ]' "zero lock errors, crawl/delta errors, rebuild failures, or unexpected tracebacks" '"ops=$OPS tracebacks=$TB"'
 say "RESULT: $FAILS failure(s)"; exit $FAILS

--- a/benchmark/prodlab/reconcile_gate.sh
+++ b/benchmark/prodlab/reconcile_gate.sh
@@ -74,6 +74,6 @@ check '[ "$(kubectl -n lab get pod -l app=sairo -o jsonpath="{.items[0].status.c
 # LIST failures in cycle 1, and every pod logs one trapped passlib/bcrypt version traceback at startup.
 LOGS=$(kubectl -n lab logs deploy/sairo --tail=50000 2>/dev/null)
 OPS=$(echo "$LOGS" | grep -cE "database is locked|Crawl error:|Delta crawl error|FTS rebuild failed|Post-crawl .* failed")
-TB=$(( $(echo "$LOGS" | grep -c "^Traceback") - $(echo "$LOGS" | grep -A3 "^Traceback" | grep -c "module 'bcrypt'") ))
+TB=$(( $(echo "$LOGS" | grep -c "^Traceback") - $(echo "$LOGS" | grep -A5 "^Traceback" | grep -c "module 'bcrypt'") ))
 check '[ "$OPS" = 0 ] && [ "$TB" -le 0 ]' "zero lock errors, crawl/delta errors, rebuild failures, or unexpected tracebacks" '"ops=$OPS tracebacks=$TB"'
 say "RESULT: $FAILS failure(s)"; exit $FAILS

--- a/benchmark/prodlab/spec-1m.json
+++ b/benchmark/prodlab/spec-1m.json
@@ -1,0 +1,3 @@
+{"buckets": [
+  {"name": "rec-1m", "layout": "druid", "datasources": 4, "intervals": 500, "partitions": 500}
+]}

--- a/charts/sairo/templates/deployment.yaml
+++ b/charts/sairo/templates/deployment.yaml
@@ -204,7 +204,15 @@ spec:
             - name: LOGIN_MESSAGE
               value: {{ .Values.branding.loginMessage | quote }}
             {{- end }}
-            # extraEnv last so operator values override anything the chart sets above (k8s: last duplicate wins)
+            # extraEnv: variables the chart does NOT manage. The API server rejects a duplicate env name
+            # (server-side apply: "duplicate entries for key [name=...]"), so a chart-managed variable must be
+            # set through its value (e.g. crawler.recrawlInterval); fail at render time with a clear message.
+            {{- $managed := list "S3_ENDPOINT" "S3_REGION" "S3_PATH_STYLE" "S3_ACCESS_KEY" "S3_SECRET_KEY" "AUTH_MODE" "ADMIN_USER" "ADMIN_PASS" "JWT_SECRET" "SESSION_HOURS" "SECURE_COOKIE" "RECRAWL_INTERVAL" "TELEMETRY" "SAIRO_STORAGE_EPHEMERAL" "RATE_LIMIT" "UPLOAD_RATE_LIMIT" "LDAP_ENABLED" "LDAP_SERVER" "LDAP_BASE_DN" "LDAP_USER_FILTER" "LDAP_BIND_DN" "LDAP_BIND_PASSWORD" "LDAP_ADMIN_GROUP" "LDAP_DEFAULT_ROLE" "OAUTH_GOOGLE_CLIENT_ID" "OAUTH_GOOGLE_CLIENT_SECRET" "OAUTH_GITHUB_CLIENT_ID" "OAUTH_GITHUB_CLIENT_SECRET" "OAUTH_DEFAULT_ROLE" "OAUTH_ALLOWED_DOMAINS" "OIDC_ISSUER" "OIDC_CLIENT_ID" "OIDC_CLIENT_SECRET" "OIDC_PROVIDER_NAME" "OIDC_USERNAME_CLAIM" "OIDC_SCOPES" "OIDC_DEFAULT_ROLE" "OIDC_ALLOWED_DOMAINS" "OIDC_ADMIN_GROUP" "OIDC_GROUPS_CLAIM" "OIDC_REQUIRE_VERIFIED_EMAIL" "OIDC_RP_LOGOUT" "APP_NAME" "APP_LOGO" "PRIMARY_COLOR" "LOGIN_MESSAGE" }}
+            {{- range .Values.extraEnv }}
+            {{- if has .name $managed }}
+            {{- fail (printf "extraEnv: %s is managed by the chart; set it through its value instead (duplicate env names are rejected by the API server)" .name) }}
+            {{- end }}
+            {{- end }}
             {{- with .Values.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/sairo/values.yaml
+++ b/charts/sairo/values.yaml
@@ -62,8 +62,11 @@ auth:
 telemetry:
   enabled: true
 
-# Extra environment variables for the backend container (crawler tuning knobs such as
-# SUBPREFIX_SPLIT_MIN_OBJECTS, RECRAWL_INTERVAL, ...), in Kubernetes env syntax.
+# Extra environment variables for the backend container, in Kubernetes env syntax — for variables the
+# chart does not manage (crawler knobs such as SUBPREFIX_SPLIT_MIN_OBJECTS, FULL_CRAWL_INTERVAL,
+# DELTA_MAX_NODES). Chart-managed variables (RECRAWL_INTERVAL → crawler.recrawlInterval, S3_*, AUTH_*, ...)
+# must be set through their values: a duplicate env name is rejected by the API server, and the
+# chart fails at render time with the variable's name if you try.
 extraEnv: []
 
 # Crawler Configuration

--- a/frontend/src/components/CrawlStatus.jsx
+++ b/frontend/src/components/CrawlStatus.jsx
@@ -23,7 +23,9 @@ export default function CrawlStatus({ bucket }) {
 
   const isInterrupted = status.status === "interrupted";
   const isCrawling = status.status === "crawling" || isInterrupted;
-  const isComplete = status.status === "complete";
+  const isDegraded = status.status === "degraded";           // index served, some folders failed to list
+  const isComplete = status.status === "complete" || isDegraded;
+  const isRebuilding = isComplete && status.rebuilding;       // rows in, search index still being rebuilt
   const isError = status.status?.startsWith("error");
 
   const handleRecrawl = async () => {
@@ -55,7 +57,7 @@ export default function CrawlStatus({ bucket }) {
         {isCrawling
           ? `${isInterrupted ? "Resuming index..." : "Indexing..."} ${(status.total_objects || 0).toLocaleString()}`
           : isComplete
-          ? `${(status.total_objects || 0).toLocaleString()} objects`
+          ? `${(status.total_objects || 0).toLocaleString()} objects${isRebuilding ? " · finishing search index" : isDegraded ? " · partial" : ""}`
           : isError ? "Index error" : "Not indexed"}
       </button>
 
@@ -63,8 +65,14 @@ export default function CrawlStatus({ bucket }) {
         <div className="crawl-dropdown">
           <div className="crawl-detail">
             <span className="crawl-label">Status</span>
-            <span>{status.status}</span>
+            <span>{isRebuilding ? `${status.status} (rebuilding search index)` : status.status}</span>
           </div>
+          {status.last_error && (
+            <div className="crawl-detail">
+              <span className="crawl-label">Last error</span>
+              <span>{status.last_error}</span>
+            </div>
+          )}
           <div className="crawl-detail">
             <span className="crawl-label">Objects</span>
             <span>{(status.total_objects || 0).toLocaleString()}</span>

--- a/mcp/requirements.txt
+++ b/mcp/requirements.txt
@@ -1,5 +1,5 @@
 # MCP SDK
-mcp[cli]>=1.9.0
+mcp[cli]>=1.9.0,<2   # 2.x renamed FastMCP; server code targets 1.x
 
 # HTTP client for Sairo API
 httpx>=0.27.0

--- a/mcp/tools/discovery.py
+++ b/mcp/tools/discovery.py
@@ -90,7 +90,7 @@ def register(mcp):
             lines = [f"Found {len(results)} bucket(s):\n"]
             for b in sorted(results, key=lambda x: x["name"]):
                 status = b.get("index_status", "unknown")
-                status_icon = {"complete": "ready", "crawling": "indexing...", "interrupted": "resuming index...", "idle": "ready"}.get(
+                status_icon = {"complete": "ready", "degraded": "partial (some folders failed to list)", "crawling": "indexing...", "interrupted": "resuming index...", "idle": "ready"}.get(
                     status, status
                 )
                 objects = format_number(b.get("objects", 0))

--- a/mcp/tools/operations.py
+++ b/mcp/tools/operations.py
@@ -78,6 +78,7 @@ def register(mcp):
                         "crawling": "Currently indexing...",
                         "interrupted": "Index interrupted by a restart — resuming (serving last valid index)",
                         "complete": "Up to date",
+                        "degraded": "Partial — some folders failed to list; serving what was indexed, retrying next cycle",
                         "idle": "Up to date",
                     }.get(status, status)
 


### PR DESCRIPTION
P0 of the post-merge plan: make every crawl state truthful before optimising further. Central promise: **never claim freshness without evidence.** Small diffs, each with a test.

| Defect | Fix |
|---|---|
| A prefix listing that failed after its retries returned a partial count; the prefix was marked complete and the stale-key prune could delete rows it never saw | The terminal failure raises; the failed-prefix path keeps the index intact and re-lists on resume |
| A full crawl with failed prefixes reported `complete` | Ends as `degraded`: still served, resumable (only unfinished prefixes are re-listed after `RECRAWL_INTERVAL`, no delta-only period), `last_crawl_end` keeps the previous success time |
| A delta crawl that threw, or that had a failed target or a failed discovery, was stamped `complete` with a fresh `last_crawl_end` | Success stamped only for a clean delta over an already-`complete` catalogue; every other outcome records `last_attempt_at` and `last_error` and restores the previous status |
| `complete` reported ~8 min before the search index was rebuilt at 9.9M keys | `fts_ready_gen` persisted (stamped inside the FTS swap transaction, or when a rebuild is skipped); `search_ready` requires it to match `current_crawl_gen` **and** a healthy FTS structure; `rebuilding` derived from it |
| Databases from before the marker would have reported `rebuilding` until the next full reconcile | Startup verifies them with SQLite's external-content integrity check and backfills the marker, or starts an FTS-only repair immediately |
| Startup seeded an errored bucket as fresh | Seeds only from `status == 'complete'` |
| `full_crawl_complete` was true for degraded/errored crawls | `status == 'complete'` |
| `RECRAWL_INTERVAL=120` produced ~240 s cadence | Scheduler ticks at a quarter interval; per-bucket cooldowns unchanged |

Also: `last_attempt_at` / `last_error` / `fts_ready_gen` columns added by migration; MCP and UI labels for `degraded` and "finishing search index"; `mcp` pinned below 2.x.

**Validation:** backend 125 passed (11 new in `TestTruthfulStates`); MCP 103; frontend 55 + 1 pre-existing failure, build ok; helm lint ok; restart harness 4/4 gates; browser e2e 215/230 with the 7 remaining failures identical on `origin/main`; lab layouts, deep-wide, skew and the 9.9M pipeline clean; prod read-only run on each commit.
