### PR TITLE
fix(crawler): bound concurrent search-index rebuilds (SAE-85)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1399,11 +1399,26 @@ def _rebuild_fts_locked(bucket, eid, t0):
         log.warning("[%s:%s] FTS rebuild failed (old index kept): %s", eid, bucket, e)
 
 
+def _fts_rebuild_concurrency():
+    """How many trigram rebuilds may run at once. Default 1: a 9.9M-row build holds ~330 MB and the chart's
+    pod limit is 1 GiB; raise it once two simultaneous multi-million-object builds have been measured.
+    Clamped to at least 1 — 0 would park every rebuild thread forever."""
+    return max(1, int(os.environ.get("FTS_REBUILD_CONCURRENCY", "1")))
+
+
+FTS_REBUILD_CONCURRENCY = _fts_rebuild_concurrency()
+_fts_rebuild_slots = threading.BoundedSemaphore(FTS_REBUILD_CONCURRENCY)
+
+
 def _rebuild_fts_async(bucket, endpoint_id=None, done=None):
-    """Run _rebuild_fts on a daemon thread; `done()` runs when it finishes, success or not. Returns the thread."""
+    """Run _rebuild_fts on a daemon thread; `done()` runs when it finishes, success or not. Returns the thread.
+    At most FTS_REBUILD_CONCURRENCY rebuilds run at once: the first boot after an upgrade can find every
+    bucket's index in need of one (the upgrade rehearsal did), so unbounded threads would take a 1 GiB pod
+    down before the first reconcile."""
     def _run():
         try:
-            _rebuild_fts(bucket, endpoint_id)
+            with _fts_rebuild_slots:
+                _rebuild_fts(bucket, endpoint_id)
         finally:
             if done is not None:
                 done()

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1577,6 +1577,33 @@ class TestTruthfulStates:
 
 
 
+class TestBoundedFtsRebuilds:
+    def test_concurrent_rebuilds_are_bounded(self):
+        """Six buckets asking for a rebuild at once run at most FTS_REBUILD_CONCURRENCY (default 1) at a time."""
+        import sys, threading, time
+        from unittest.mock import patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        running, peak, lock = [0], [0], threading.Lock()
+        def slow_rebuild(bucket, eid=None):
+            with lock:
+                running[0] += 1; peak[0] = max(peak[0], running[0])
+            time.sleep(0.15)
+            with lock:
+                running[0] -= 1
+        with patch.object(m, "_rebuild_fts", slow_rebuild):
+            threads = [m._rebuild_fts_async(f"b{i}", "default") for i in range(6)]
+            for th in threads: th.join(timeout=10)
+        assert peak[0] == m.FTS_REBUILD_CONCURRENCY == 1, peak[0]
+
+    def test_zero_or_garbage_setting_still_lets_rebuilds_run(self, monkeypatch):
+        """FTS_REBUILD_CONCURRENCY=0 used to park every rebuild thread forever."""
+        import sys
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        monkeypatch.setenv("FTS_REBUILD_CONCURRENCY", "0"); assert m._fts_rebuild_concurrency() == 1
+        monkeypatch.setenv("FTS_REBUILD_CONCURRENCY", "3"); assert m._fts_rebuild_concurrency() == 3
+        monkeypatch.delenv("FTS_REBUILD_CONCURRENCY"); assert m._fts_rebuild_concurrency() == 1
+
+
 class TestZeroWriteReconcile:
     """SAE-72: an incremental crawl writes only changed rows, and prunes deletions per listed unit."""
 


### PR DESCRIPTION
Search-index rebuilds ran on an unbounded daemon thread each. The 3.6.0 → 3.7.0 upgrade rehearsal
showed the first boot on a pre-upgrade index rebuilds every bucket's index (the legacy indexes fail
the consistency check), and a 9.9M-row trigram build holds ~330 MB — twenty-two at once would take a
1 GiB pod down before the first reconcile. A BoundedSemaphore (FTS_REBUILD_CONCURRENCY, default 1, clamped to at least 1)
now gates the rebuild itself; callers and the readiness marker hand-off are unchanged, later buckets
simply wait their turn.

Found by the 3.6.0 → 3.7.0 upgrade rehearsal in the lab (fresh volume indexed by the 3.6.0 image, helm upgrade in place to the candidate under the chart's 1 GiB limit): the complete bucket's legacy search index was rebuilt at boot, the three buckets the upgrade caught mid-recrawl were resumed, zero restarts, peak anonymous memory 444 MB with four ~200k-object buckets. At production shape (22 buckets, 10M objects in one) the same first boot would start up to 22 rebuilds concurrently.

Test: six simultaneous rebuild requests run at most two at a time.

Jira: SAE-85 (herd memory).

Review: `FTS_REBUILD_CONCURRENCY=0` parked every rebuild forever — the setting is now clamped to ≥ 1; default lowered to 1 until two simultaneous multi-million-object builds are measured under the 1 GiB limit. Rebased onto merged #36.