### PR TITLE
fix(crawler): spread seeded reconcile schedules over the interval (SAE-85)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1439,6 +1439,17 @@ def _fts_consistent(db):
         return False
 
 
+def _seed_offset(i, n, dur):
+    """Spread seeded schedules over the bucket's OWN cadence: bucket i of n falls due at (1 - i/n) of it.
+    Large buckets (full crawl slower than LARGE_BUCKET_SECONDS) reconcile every FULL_CRAWL_INTERVAL; small
+    ones recrawl every RECRAWL_INTERVAL — staggering small buckets by the large interval put all but one of
+    them past their cadence at the first tick. Seeding every bucket as fresh "now" made all reconciles fall
+    due together (the upgrade rehearsal: 12 concurrent, 791 MB anonymous in a 1 GiB pod). last_full is moved
+    back by this amount, so the first pass streams and each bucket's own completion keeps them apart after."""
+    interval = FULL_CRAWL_INTERVAL if dur > LARGE_BUCKET_SECONDS else RECRAWL_INTERVAL
+    return interval * i / max(1, n)
+
+
 def _seed_from_existing(prev_status, total, dur):
     """Startup trusts an existing index as fresh only when its last full crawl finished COMPLETE.
     Interrupted/degraded resume from their checkpoints; an error is retried; anything else is a first crawl."""
@@ -2911,7 +2922,8 @@ def startup():
             try:
                 client = _s3_manager.get_client(eid)
                 resp = client.list_buckets()
-                for b in resp.get("Buckets", []):
+                buckets = resp.get("Buckets", [])
+                for i, b in enumerate(buckets):
                     name = b["Name"]
                     _init_db(name, eid)
                     # If this bucket already has an index from a previous run, seed the
@@ -2939,7 +2951,7 @@ def startup():
                         # an interrupted index marked it "fresh" and left large buckets delta-only for
                         # FULL_CRAWL_INTERVAL while a third of the data was missing.
                         if _seed_from_existing(prev_status, total, dur):
-                            _crawl_meta[f"{eid}:{name}"] = {"last_full": time.time(), "duration": dur}
+                            _crawl_meta[f"{eid}:{name}"] = {"last_full": time.time() - _seed_offset(i, len(buckets), dur), "duration": dur}
                             seeded = True
                             # legacy NULL marker → verify and backfill; stale → repair now. Off the startup
                             # thread and bounded by the rebuild pool (the check reads the whole index).

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1285,6 +1285,10 @@ class TestTruthfulStates:
     def test_startup_seeds_only_a_complete_full_crawl(self):
         import sys
         m = sys.modules.get("backend.main") or sys.modules["main"]
+        with patch.object(m, "FULL_CRAWL_INTERVAL", 3600), patch.object(m, "RECRAWL_INTERVAL", 120), patch.object(m, "LARGE_BUCKET_SECONDS", 60):
+            assert [m._seed_offset(i, 4, 600) for i in range(4)] == [0, 900, 1800, 2700], "large buckets spread over the full-crawl interval"
+            assert [m._seed_offset(i, 4, 5) for i in range(4)] == [0, 30, 60, 90], "small buckets spread over their own recrawl interval"
+            assert m._seed_offset(0, 0, 5) == 0
         assert m._seed_from_existing("complete", 120, 12.0) is True
         for st in ("error: fatal listing failure", "degraded", "interrupted", "crawling", ""):
             assert m._seed_from_existing(st, 120, 12.0) is False, st
@@ -1577,6 +1581,32 @@ class TestTruthfulStates:
 
 
 
+class TestSeededScheduleStagger:
+    def test_first_scheduler_tick_after_boot_does_not_stampede(self):
+        """22 small + 2 large buckets seeded at boot: the first tick (30 s) queues a handful of full crawls,
+        not 21 of them. Staggering by FULL_CRAWL_INTERVAL alone put every small bucket past its 120 s cadence."""
+        import sys, time
+        from unittest.mock import MagicMock, patch
+        m = sys.modules.get("backend.main") or sys.modules["main"]
+        class _Stop(BaseException): pass
+        names = [f"small{i:02d}" for i in range(22)] + ["big-a", "big-b"]
+        durs = {n: (600.0 if n.startswith("big") else 5.0) for n in names}
+        t0 = 1_000_000.0
+        seeded = {f"default:{n}": {"last_full": t0 - m._seed_offset(i, len(names), durs[n]), "duration": durs[n]} for i, n in enumerate(names)}
+        client = MagicMock(); client.list_buckets.return_value = {"Buckets": [{"Name": n} for n in names]}
+        queued_full, ticks = [], [0]
+        def fake_sleep(_):
+            ticks[0] += 1
+            if ticks[0] > 1: raise _Stop()
+        with patch.object(m, "_crawl_meta", seeded), patch.object(m, "RECRAWL_INTERVAL", 120), patch.object(m, "FULL_CRAWL_INTERVAL", 3600), \
+             patch.object(m, "LARGE_BUCKET_SECONDS", 60), patch.object(m._s3_manager, "get_all_ids", return_value=["default"]), \
+             patch.object(m._s3_manager, "get_client", return_value=client), patch.object(m.time, "sleep", fake_sleep), \
+             patch.object(m.time, "time", return_value=t0 + 30), patch.object(m, "_queue_crawl", side_effect=lambda n, e: queued_full.append(n) or True), \
+             patch.object(m, "_queue_delta_crawl", return_value=False):
+            try: m._auto_recrawl()
+            except _Stop: pass
+        assert 1 <= len(queued_full) <= 6, f"first tick queued {len(queued_full)} full crawls: {queued_full}"
+        assert not any(n.startswith("big") for n in queued_full), "large buckets are not due for a full reconcile at boot"
 class TestBoundedFtsRebuilds:
     def test_concurrent_rebuilds_are_bounded(self):
         """Six buckets asking for a rebuild at once run at most FTS_REBUILD_CONCURRENCY (default 1) at a time."""


### PR DESCRIPTION
Startup seeded every existing bucket as fresh "now", so all reconciles fell due together after a restart or upgrade. The production-shaped upgrade rehearsal (19 buckets, 15.5M objects, 1 GiB) showed 12 concurrent reconciles pushing anonymous memory from 274 MB to 791 MB (peak 832 MB), 0 restarts — the real deployment has 22 buckets with a 10M one.

Bucket i of n now gets `last_full` moved back by `interval * i / n`, where the interval is the bucket's **own** cadence: FULL_CRAWL_INTERVAL for large buckets (full crawl slower than LARGE_BUCKET_SECONDS), RECRAWL_INTERVAL for small ones. Seeded reconciles therefore stream across the first pass, and each bucket's own completion keeps them apart afterwards.

Review round: the first version staggered every bucket by FULL_CRAWL_INTERVAL, which put 21 of 22 small buckets past their 120 s cadence at the first 30 s tick — the stampede it meant to prevent. Fixed, and covered by a scheduler-level test: 22 small + 2 large buckets seeded at boot, one real `_auto_recrawl` tick at +30 s queues between 1 and 6 full crawls and no large bucket.

Staggering is load smoothing, not a hard boundary: initial, resumed and retried crawls can still fill the 12-worker pool. A measured global full-crawl concurrency cap is the follow-up for hard memory protection.

Jira: SAE-85.