### PR TITLE
fix(security): let previews load presigned URLs — S3 endpoint origins in img-src, media-src, frame-src (#27)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -98,17 +98,25 @@ async def security_headers_middleware(request: Request, call_next):
     response = await call_next(request)
     if request.url.path.startswith("/assets/") and response.status_code == 200:   # content-hashed bundles: cache for a year;
         response.headers["Cache-Control"] = "public, max-age=31536000, immutable"  # a 404 mid-rollout must not be cached that long
-    connect_src = ("connect-src 'self' " + _csp_connect_origins()).rstrip()
+    s3 = _csp_connect_origins()   # every configured S3 endpoint origin (and its subdomains)
+    connect_src = f"connect-src 'self' {s3}".rstrip()
     logo = urlparse(os.environ.get("APP_LOGO", ""))   # a documented external logo URL must be allowed by img-src
-    img_src = "img-src 'self' blob: data:" + (f" {logo.scheme}://{logo.netloc}" if logo.scheme in ("http", "https") and logo.netloc else "")
+    logo_origin = f" {logo.scheme}://{logo.netloc}" if logo.scheme in ("http", "https") and logo.netloc else ""
+    # Previews load presigned URLs straight from the bucket — <img> for images, <iframe> for PDFs and
+    # text, <video>/<audio> for media — so those directives need the S3 origins too, or every preview
+    # fails with "Failed to load image" (issue #27).
+    img_src = f"img-src 'self' blob: data:{logo_origin} {s3}".rstrip()
+    media_src = f"media-src 'self' blob: {s3}".rstrip()
+    frame_src = f"frame-src 'self' blob: {s3}".rstrip()
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
         "script-src 'self'; "
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
         "font-src 'self' https://fonts.gstatic.com; "
         f"{img_src}; "
+        f"{media_src}; "
         f"{connect_src}; "
-        "frame-src blob:;"
+        f"{frame_src};"
     )
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -728,10 +728,20 @@ class TestBrandingInjection:
 
     def test_csp_allows_the_configured_external_logo(self, client, monkeypatch):
         csp = client.get("/healthz").headers["content-security-policy"]
-        assert "img-src 'self' blob: data:;" in csp
+        assert "img-src 'self' blob: data: http://" in csp and "cdn.example.com" not in csp
         monkeypatch.setenv("APP_LOGO", "https://cdn.example.com/brand/logo.svg")
         csp = client.get("/healthz").headers["content-security-policy"]
-        assert "img-src 'self' blob: data: https://cdn.example.com;" in csp
+        assert "img-src 'self' blob: data: https://cdn.example.com http://" in csp
+
+    def test_csp_allows_presigned_previews_from_the_s3_endpoint(self, client):
+        """Issue #27: previews load presigned bucket URLs into <img>/<iframe>/<video>; the CSP must name the
+        configured S3 endpoint origin in img-src, media-src and frame-src, not only connect-src."""
+        import re
+        csp = client.get("/healthz").headers["content-security-policy"]
+        origins = _main_module()._csp_connect_origins(); assert origins, "test app has a configured S3 endpoint"
+        for directive in ("img-src", "media-src", "frame-src", "connect-src"):
+            value = re.search(directive + r" ([^;]*)", csp).group(1)
+            assert all(o in value for o in origins.split()), f"{directive}: {value}"
 
     def test_manifest_branded(self):
         m = _main_module()

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -18,6 +18,13 @@ export default defineConfig({
 
   use: {
     baseURL: process.env.SAIRO_URL || 'http://localhost:8888',
+    // The stack signs presigned URLs for the compose-internal host "minio:9000",
+    // which the host browser cannot resolve. Map it to the published port so
+    // previews really load, as they do in production where S3 is reachable.
+    // The Host header stays "minio:9000", so the SigV4 signature still matches.
+    launchOptions: {
+      args: [`--host-resolver-rules=MAP minio:9000 127.0.0.1:${process.env.MINIO_PORT || 9100}`],
+    },
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'on',

--- a/e2e/tests/04-file-operations.spec.ts
+++ b/e2e/tests/04-file-operations.spec.ts
@@ -100,17 +100,21 @@ test.describe('File Operations', () => {
   });
 
   test('4.4 previews image file', async ({ page }) => {
+    // #40: the preview loads a presigned URL straight from the S3 origin, so this
+    // fails if CSP img-src omits that origin. A broken image is still "visible",
+    // so assert the browser actually decoded pixels rather than accepting a
+    // placeholder or the error fallback.
     const pngRow = page.locator(`${SEL.tableRow}:has-text("sample.png")`).first();
-    if (await pngRow.isVisible().catch(() => false)) {
-      await pngRow.locator(`${SEL.colActions} button`).first().click();
-      await expect(page.locator(SEL.modal)).toBeVisible();
-      // Image preview: img may fail to load if presigned URL uses Docker-internal hostname
-      // Accept either a visible img or the error fallback
-      const img = page.locator(`${SEL.modal} img`);
-      const errorFallback = page.locator(`${SEL.modal} :has-text("Failed to load")`);
-      await expect(img.or(errorFallback).first()).toBeVisible({ timeout: 10_000 });
-      await page.locator(SEL.modalDismissButton).click();
-    }
+    await expect(pngRow).toBeVisible({ timeout: 15_000 });
+    await pngRow.locator(`${SEL.colActions} button`).first().click();
+    await expect(page.locator(SEL.modal)).toBeVisible();
+    const img = page.locator(`${SEL.modal} img`).first();
+    await expect(img).toBeVisible({ timeout: 10_000 });
+    await expect.poll(
+      () => img.evaluate((el: HTMLImageElement) => (el.complete ? el.naturalWidth : 0)),
+      { timeout: 15_000, message: 'presigned image preview never decoded' },
+    ).toBeGreaterThan(0);
+    await page.locator(SEL.modalDismissButton).click();
   });
 
   test('4.5 opens ObjectInfo modal on info button click', async ({ page }) => {

--- a/e2e/tests/26-security-hardening.spec.ts
+++ b/e2e/tests/26-security-hardening.spec.ts
@@ -15,7 +15,7 @@ test.describe('Security Hardening', () => {
       expect(csp).toBeDefined();
       expect(csp).toContain("default-src 'self'");
       expect(csp).toContain("script-src 'self'");
-      expect(csp).toContain("frame-src blob:");
+      expect(csp).toMatch(/frame-src [^;]*blob:/);   // may also name the S3 endpoint origins (previews, #27)
     });
 
     test('26.2 responses include X-Content-Type-Options header', async ({ page }) => {


### PR DESCRIPTION
Image, PDF/text and media previews load a presigned URL straight from the bucket, which is a different
origin from Sairo. The CSP named the configured S3 endpoints only in connect-src (for direct uploads),
so every preview failed with "Failed to load image" (issue #27, reported on 3.6.0 with Cloudflare R2).
The same endpoint-origin list now also feeds img-src, media-src and frame-src; nothing else widens.

Closes #27.

Test: every configured endpoint origin appears in img-src, media-src, frame-src and connect-src; the external-logo case still adds only the logo's origin.