### PR TITLE
fix(auth): LDAP selectable on the login form again (#35); change your own password (#29)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,8 @@ jobs:
           cache-dependency-path: e2e/package-lock.json
       - run: npm ci
       - run: npx playwright install --with-deps chromium
-      - run: npx playwright test 01-auth.spec.ts 02-bucket-list.spec.ts 03-object-browser.spec.ts 04-file-operations.spec.ts 26-security-hardening.spec.ts --project=chromium --project=no-auth
+      # 29 runs last: it changes the admin password and restores it, so a failure
+      # part-way through must not cascade into the specs after it.
+      - run: npx playwright test 01-auth.spec.ts 02-bucket-list.spec.ts 03-object-browser.spec.ts 04-file-operations.spec.ts 26-security-hardening.spec.ts 29-change-password.spec.ts --project=chromium --project=no-auth
       - if: always()
         run: docker compose -f docker-compose.test.yml down -v

--- a/backend/main.py
+++ b/backend/main.py
@@ -98,17 +98,25 @@ async def security_headers_middleware(request: Request, call_next):
     response = await call_next(request)
     if request.url.path.startswith("/assets/") and response.status_code == 200:   # content-hashed bundles: cache for a year;
         response.headers["Cache-Control"] = "public, max-age=31536000, immutable"  # a 404 mid-rollout must not be cached that long
-    connect_src = ("connect-src 'self' " + _csp_connect_origins()).rstrip()
+    s3 = _csp_connect_origins()   # every configured S3 endpoint origin (and its subdomains)
+    connect_src = f"connect-src 'self' {s3}".rstrip()
     logo = urlparse(os.environ.get("APP_LOGO", ""))   # a documented external logo URL must be allowed by img-src
-    img_src = "img-src 'self' blob: data:" + (f" {logo.scheme}://{logo.netloc}" if logo.scheme in ("http", "https") and logo.netloc else "")
+    logo_origin = f" {logo.scheme}://{logo.netloc}" if logo.scheme in ("http", "https") and logo.netloc else ""
+    # Previews load presigned URLs straight from the bucket — <img> for images, <iframe> for PDFs and
+    # text, <video>/<audio> for media — so those directives need the S3 origins too, or every preview
+    # fails with "Failed to load image" (issue #27).
+    img_src = f"img-src 'self' blob: data:{logo_origin} {s3}".rstrip()
+    media_src = f"media-src 'self' blob: {s3}".rstrip()
+    frame_src = f"frame-src 'self' blob: {s3}".rstrip()
     response.headers["Content-Security-Policy"] = (
         "default-src 'self'; "
         "script-src 'self'; "
         "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; "
         "font-src 'self' https://fonts.gstatic.com; "
         f"{img_src}; "
+        f"{media_src}; "
         f"{connect_src}; "
-        "frame-src blob:;"
+        f"{frame_src};"
     )
     response.headers["X-Content-Type-Options"] = "nosniff"
     response.headers["X-Frame-Options"] = "DENY"

--- a/backend/main.py
+++ b/backend/main.py
@@ -752,7 +752,10 @@ def get_current_user(request: Request):
         # Reject 2FA pending tokens for normal endpoints
         if payload.get("purpose") == "2fa":
             raise HTTPException(401, "2FA verification required")
-        return {"username": payload["sub"], "role": payload["role"]}
+        # s3ak marks a session authenticated by the user's own S3 keys: no local
+        # account row exists, so there is no local password or TOTP to manage.
+        return {"username": payload["sub"], "role": payload["role"],
+                "s3_session": bool(payload.get("s3ak"))}
     except jwt.ExpiredSignatureError:
         raise HTTPException(401, "Session expired")
     except jwt.InvalidTokenError:
@@ -3605,10 +3608,15 @@ def auth_logout(request: Request):
 @app.get("/api/auth/me")
 def auth_me(user: dict = Depends(get_current_user), request: Request = None):
     result = {"username": user["username"], "role": user["role"]}
+    # An S3-key session has no users row; report it explicitly so the UI never
+    # offers local-password or TOTP management for it.
+    if user.get("s3_session"):
+        result["auth_source"] = "s3key"
+        result["totp_enabled"] = False
     # Include 2FA status + which provider this account authenticates against
     with _get_users_db() as db:
         row = db.execute("SELECT totp_enabled, auth_source FROM users WHERE username=?", (user["username"],)).fetchone()
-    if row:
+    if row and not user.get("s3_session"):
         result["totp_enabled"] = bool(row["totp_enabled"])
         result["auth_source"] = row["auth_source"] or "local"
     token = request.cookies.get("access_token") if request else None

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -728,10 +728,20 @@ class TestBrandingInjection:
 
     def test_csp_allows_the_configured_external_logo(self, client, monkeypatch):
         csp = client.get("/healthz").headers["content-security-policy"]
-        assert "img-src 'self' blob: data:;" in csp
+        assert "img-src 'self' blob: data: http://" in csp and "cdn.example.com" not in csp
         monkeypatch.setenv("APP_LOGO", "https://cdn.example.com/brand/logo.svg")
         csp = client.get("/healthz").headers["content-security-policy"]
-        assert "img-src 'self' blob: data: https://cdn.example.com;" in csp
+        assert "img-src 'self' blob: data: https://cdn.example.com http://" in csp
+
+    def test_csp_allows_presigned_previews_from_the_s3_endpoint(self, client):
+        """Issue #27: previews load presigned bucket URLs into <img>/<iframe>/<video>; the CSP must name the
+        configured S3 endpoint origin in img-src, media-src and frame-src, not only connect-src."""
+        import re
+        csp = client.get("/healthz").headers["content-security-policy"]
+        origins = _main_module()._csp_connect_origins(); assert origins, "test app has a configured S3 endpoint"
+        for directive in ("img-src", "media-src", "frame-src", "connect-src"):
+            value = re.search(directive + r" ([^;]*)", csp).group(1)
+            assert all(o in value for o in origins.split()), f"{directive}: {value}"
 
     def test_manifest_branded(self):
         m = _main_module()

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -51,6 +51,19 @@ def client(app):
     return TestClient(app)
 
 
+@pytest.fixture(autouse=True)
+def _reset_login_rate():
+    """Login attempts are counted per IP in a module-level dict, and every test in
+    this suite shares one client IP. Without a reset the 10-per-window cap is used
+    up by earlier tests and unrelated logins start coming back 429."""
+    try:
+        import backend.main as m
+    except ModuleNotFoundError:
+        import main as m
+    m._login_attempts.clear()
+    yield
+
+
 @pytest.fixture(scope="module")
 def admin_cookies(client):
     """Login as admin and return cookies."""
@@ -1114,3 +1127,21 @@ class TestChangeOwnPassword:
         assert client.put("/api/auth/change-password", json={"old_password": "firstpass1", "new_password": "secondpass2"}, cookies=cookies).status_code == 200
         assert client.post("/api/auth/login", json={"username": "pw-user", "password": "firstpass1"}).status_code == 401
         assert client.post("/api/auth/login", json={"username": "pw-user", "password": "secondpass2"}).status_code == 200
+
+    def test_s3_key_session_is_not_reported_as_local(self, client, admin_cookies):
+        """An S3-key session has no local account, so /auth/me must not let the UI offer
+        a password change. A missing auth_source used to be read as 'local'."""
+        from unittest.mock import patch, MagicMock
+        from datetime import datetime, timezone
+        m = _main_module()
+        ok = MagicMock()
+        ok.list_buckets.return_value = {"Buckets": [{"Name": "b", "CreationDate": datetime(2026, 1, 1, tzinfo=timezone.utc)}]}
+        with patch.object(m._s3_manager, "_build_client", return_value=ok):
+            cookies = client.post("/api/auth/login-s3", json={"access_key": "AKIAKEY12345", "secret_key": "s3cr3t"}).cookies
+        me = client.get("/api/auth/me", cookies=cookies).json()
+        assert me["auth_source"] == "s3key", me
+        assert me["totp_enabled"] is False
+        # A real local account still reports "local" so the button keeps working for it.
+        client.post("/api/auth/users", json={"username": "local-src", "password": "localpass1", "role": "viewer"}, cookies=admin_cookies)
+        local = client.post("/api/auth/login", json={"username": "local-src", "password": "localpass1"}).cookies
+        assert client.get("/api/auth/me", cookies=local).json()["auth_source"] == "local"

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1101,3 +1101,16 @@ class TestCrawlerCorrectness:
         with m._get_db(bucket, "default") as db:
             db.execute("UPDATE crawl_status SET status='complete' WHERE id=1"); db.commit()
         assert client.get(f"/api/buckets/{bucket}/crawl-status", cookies=admin_cookies).json()["full_crawl_complete"] is True
+
+
+class TestChangeOwnPassword:
+    """Issue #29: a user changes their own password; wrong current → 401, short → 400, and the new one logs in."""
+
+    def test_change_password_flow(self, client, admin_cookies):
+        client.post("/api/auth/users", json={"username": "pw-user", "password": "firstpass1", "role": "viewer"}, cookies=admin_cookies)
+        cookies = client.post("/api/auth/login", json={"username": "pw-user", "password": "firstpass1"}).cookies
+        assert client.put("/api/auth/change-password", json={"old_password": "wrong", "new_password": "secondpass2"}, cookies=cookies).status_code == 401
+        assert client.put("/api/auth/change-password", json={"old_password": "firstpass1", "new_password": "short"}, cookies=cookies).status_code == 400
+        assert client.put("/api/auth/change-password", json={"old_password": "firstpass1", "new_password": "secondpass2"}, cookies=cookies).status_code == 200
+        assert client.post("/api/auth/login", json={"username": "pw-user", "password": "firstpass1"}).status_code == 401
+        assert client.post("/api/auth/login", json={"username": "pw-user", "password": "secondpass2"}).status_code == 200

--- a/e2e/docker-compose.test.yml
+++ b/e2e/docker-compose.test.yml
@@ -30,6 +30,12 @@ services:
       JWT_SECRET: e2e-test-secret-key-32chars-long!
       SECURE_COOKIE: "false"
       SESSION_HOURS: "24"
+      # #35: the login form only offers LDAP when the server reports it enabled.
+      # The directory is deliberately unreachable — the smoke proves the form
+      # routes to the LDAP endpoint and fails there, never falling back to local.
+      LDAP_ENABLED: "true"
+      LDAP_SERVER: "ldap://127.0.0.1:3899"
+      LDAP_BASE_DN: "dc=example,dc=com"
       RECRAWL_INTERVAL: "30"
       # Test stack only: every spec logs in from the same IP within minutes, which the production
       # defaults (10 logins / 5 min, 120 requests / min) are meant to stop.

--- a/e2e/helpers/selectors.ts
+++ b/e2e/helpers/selectors.ts
@@ -26,6 +26,7 @@ export const SEL = {
   userRole: '.user-role',
   logoutButton: '.user-badge button:has-text("Logout")',
   tfaHeaderButton: '.user-badge button:has-text("2FA")',
+  passwordHeaderButton: '.user-badge button:has-text("Password")',
   bucketNameSpan: '.bucket-name',
 
   // ── Admin buttons (bucket list view) ──

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -18,6 +18,13 @@ export default defineConfig({
 
   use: {
     baseURL: process.env.SAIRO_URL || 'http://localhost:8888',
+    // The stack signs presigned URLs for the compose-internal host "minio:9000",
+    // which the host browser cannot resolve. Map it to the published port so
+    // previews really load, as they do in production where S3 is reachable.
+    // The Host header stays "minio:9000", so the SigV4 signature still matches.
+    launchOptions: {
+      args: [`--host-resolver-rules=MAP minio:9000 127.0.0.1:${process.env.MINIO_PORT || 9100}`],
+    },
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
     video: 'on',

--- a/e2e/tests/01-auth.spec.ts
+++ b/e2e/tests/01-auth.spec.ts
@@ -6,6 +6,29 @@ import { dismissWelcomeIfPresent } from '../helpers/wait-helpers';
 test.describe('Authentication & Session', () => {
   test.use({ storageState: { cookies: [], origins: [] } }); // No auth for login tests
 
+  test('1.6 LDAP is selectable and does not fall back to local auth', async ({ page }) => {
+    // #35: the LDAP option vanished from the login form. It is back, so prove two
+    // things in a real browser: the control renders, and choosing it really sends
+    // the request to the LDAP endpoint. The test stack points at an unreachable
+    // directory, so a correct local password must still be rejected here — if it
+    // logged in, the form would be silently falling back to local auth.
+    await page.goto('/');
+    const ldapToggle = page.getByLabel('Sign in with LDAP');
+    await expect(ldapToggle).toBeVisible();
+
+    const ldapCall = page.waitForRequest(r => r.url().includes('/api/auth/ldap') && r.method() === 'POST');
+    await ldapToggle.check();
+    await expect(page.locator(SEL.signInButton)).toContainText('LDAP');
+    await page.locator(SEL.usernameInput).fill(ADMIN.username);
+    await page.locator(SEL.passwordInput).fill(ADMIN.password);
+    await page.locator(SEL.signInButton).click();
+
+    await ldapCall;                                   // it used the LDAP route
+    await expect(page.locator(SEL.loginError)).toBeVisible();
+    await expect(page.locator(SEL.loginForm)).toBeVisible();
+    await expect(page.locator(SEL.bucketCard)).toHaveCount(0);
+  });
+
   test('1.1 shows error on wrong password', async ({ page }) => {
     await page.goto('/');
     await page.locator(SEL.usernameInput).fill(ADMIN.username);

--- a/e2e/tests/04-file-operations.spec.ts
+++ b/e2e/tests/04-file-operations.spec.ts
@@ -100,17 +100,21 @@ test.describe('File Operations', () => {
   });
 
   test('4.4 previews image file', async ({ page }) => {
+    // #40: the preview loads a presigned URL straight from the S3 origin, so this
+    // fails if CSP img-src omits that origin. A broken image is still "visible",
+    // so assert the browser actually decoded pixels rather than accepting a
+    // placeholder or the error fallback.
     const pngRow = page.locator(`${SEL.tableRow}:has-text("sample.png")`).first();
-    if (await pngRow.isVisible().catch(() => false)) {
-      await pngRow.locator(`${SEL.colActions} button`).first().click();
-      await expect(page.locator(SEL.modal)).toBeVisible();
-      // Image preview: img may fail to load if presigned URL uses Docker-internal hostname
-      // Accept either a visible img or the error fallback
-      const img = page.locator(`${SEL.modal} img`);
-      const errorFallback = page.locator(`${SEL.modal} :has-text("Failed to load")`);
-      await expect(img.or(errorFallback).first()).toBeVisible({ timeout: 10_000 });
-      await page.locator(SEL.modalDismissButton).click();
-    }
+    await expect(pngRow).toBeVisible({ timeout: 15_000 });
+    await pngRow.locator(`${SEL.colActions} button`).first().click();
+    await expect(page.locator(SEL.modal)).toBeVisible();
+    const img = page.locator(`${SEL.modal} img`).first();
+    await expect(img).toBeVisible({ timeout: 10_000 });
+    await expect.poll(
+      () => img.evaluate((el: HTMLImageElement) => (el.complete ? el.naturalWidth : 0)),
+      { timeout: 15_000, message: 'presigned image preview never decoded' },
+    ).toBeGreaterThan(0);
+    await page.locator(SEL.modalDismissButton).click();
   });
 
   test('4.5 opens ObjectInfo modal on info button click', async ({ page }) => {

--- a/e2e/tests/26-security-hardening.spec.ts
+++ b/e2e/tests/26-security-hardening.spec.ts
@@ -15,7 +15,7 @@ test.describe('Security Hardening', () => {
       expect(csp).toBeDefined();
       expect(csp).toContain("default-src 'self'");
       expect(csp).toContain("script-src 'self'");
-      expect(csp).toContain("frame-src blob:");
+      expect(csp).toMatch(/frame-src [^;]*blob:/);   // may also name the S3 endpoint origins (previews, #27)
     });
 
     test('26.2 responses include X-Content-Type-Options header', async ({ page }) => {

--- a/e2e/tests/29-change-password.spec.ts
+++ b/e2e/tests/29-change-password.spec.ts
@@ -1,0 +1,44 @@
+import { test, expect } from '@playwright/test';
+import { SEL } from '../helpers/selectors';
+import { loginAsAdmin } from '../helpers/wait-helpers';
+
+// Issue #29: a user changes their own password from the header, and the new password works.
+test.describe('Change own password', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  async function changePassword(page, current: string, next: string) {
+    await page.locator(SEL.passwordHeaderButton).click();
+    await expect(page.locator(SEL.modal)).toBeVisible();
+    await page.locator('input[aria-label="Current password"]').fill(current);
+    await page.locator('input[aria-label="New password"]').fill(next);
+    await page.locator('input[aria-label="Confirm new password"]').fill(next);
+    await page.locator(SEL.modal).getByRole('button', { name: 'Update Password' }).click();
+    await expect(page.locator(SEL.modal)).toContainText('has been updated');
+    await page.locator(SEL.modal).getByRole('button', { name: 'Done' }).click();
+  }
+
+  test('29.1 wrong current password is rejected in place', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.locator(SEL.passwordHeaderButton).click();
+    await page.locator('input[aria-label="Current password"]').fill('not-the-password');
+    await page.locator('input[aria-label="New password"]').fill('brandnewpass1');
+    await page.locator('input[aria-label="Confirm new password"]').fill('brandnewpass1');
+    await page.locator(SEL.modal).getByRole('button', { name: 'Update Password' }).click();
+    await expect(page.locator(SEL.modal)).toContainText('Current password is incorrect');
+  });
+
+  test('29.2 new password logs in; old one does not; then restore', async ({ page }) => {
+    await loginAsAdmin(page);
+    await changePassword(page, 'password', 'brandnewpass1');
+    await page.locator(SEL.logoutButton).click();
+    await expect(page.locator(SEL.signInButton)).toBeVisible();
+    await page.locator(SEL.usernameInput).fill('admin');
+    await page.locator(SEL.passwordInput).fill('password');
+    await page.locator(SEL.signInButton).click();
+    await expect(page.locator('.login-error')).toBeVisible();
+    await page.locator(SEL.passwordInput).fill('brandnewpass1');
+    await page.locator(SEL.signInButton).click();
+    await expect(page.locator(SEL.bucketCard).first()).toBeVisible({ timeout: 15_000 });
+    await changePassword(page, 'brandnewpass1', 'password');   // leave the stack as we found it
+  });
+});

--- a/e2e/tests/29-change-password.spec.ts
+++ b/e2e/tests/29-change-password.spec.ts
@@ -5,6 +5,10 @@ import { loginAsAdmin } from '../helpers/wait-helpers';
 // Issue #29: a user changes their own password from the header, and the new password works.
 test.describe('Change own password', () => {
   test.describe.configure({ mode: 'serial' });
+  // These tests sign in and out themselves, so they must start from a signed-out
+  // browser. The chromium project otherwise loads a stored admin session and the
+  // login form is never rendered.
+  test.use({ storageState: { cookies: [], origins: [] } });
 
   async function changePassword(page, current: string, next: string) {
     await page.locator(SEL.passwordHeaderButton).click();

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -25,6 +25,7 @@ import LicenseManager from "./components/LicenseManager";
 import UserManager from "./components/UserManager";
 import HealthCheck from "./components/HealthCheck";
 import TwoFactorSetup from "./components/TwoFactorSetup";
+import ChangePassword from "./components/ChangePassword";
 import EndpointManager from "./components/EndpointManager";
 import ToastContainer, { toast } from "./components/Toast";
 import { checkAuth, logout, refreshSession } from "./auth";
@@ -144,6 +145,7 @@ function MainApp() {
   const [showUserManager, setShowUserManager] = useState(false);
   const [showHealthCheck, setShowHealthCheck] = useState(false);
   const [showTwoFactor, setShowTwoFactor] = useState(false);
+  const [showChangePassword, setShowChangePassword] = useState(false);
   const [showEndpointManager, setShowEndpointManager] = useState(false);
   const [branding, setBranding] = useState({ app_name: "Sairo" });
   const [updateInfo, setUpdateInfo] = useState(null);
@@ -629,6 +631,9 @@ function MainApp() {
     <div className="user-badge">
       <span className="user-name">{user.username}</span>
       <span className="user-role">{user.role}</span>
+      {(user.auth_source || "local") === "local" && (
+        <button onClick={() => setShowChangePassword(true)} className="btn-settings">Password</button>
+      )}
       <button onClick={() => setShowTwoFactor(true)} className="btn-settings">2FA</button>
       <button onClick={handleLogout} className="btn-settings">Logout</button>
     </div>
@@ -695,6 +700,7 @@ function MainApp() {
         {showLicense && <LicenseManager onClose={() => setShowLicense(false)} />}
         {showUserManager && <UserManager onClose={() => setShowUserManager(false)} currentUser={user} />}
         {showHealthCheck && <HealthCheck onClose={() => setShowHealthCheck(false)} />}
+        {showChangePassword && <ChangePassword onClose={() => setShowChangePassword(false)} />}
         {showTwoFactor && <TwoFactorSetup onClose={() => setShowTwoFactor(false)} totpEnabled={user.totp_enabled} onStatusChange={(enabled) => setUser(prev => ({ ...prev, totp_enabled: enabled }))} />}
         {showEndpointManager && <EndpointManager onClose={() => setShowEndpointManager(false)} />}
         <ToastContainer />

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -631,7 +631,7 @@ function MainApp() {
     <div className="user-badge">
       <span className="user-name">{user.username}</span>
       <span className="user-role">{user.role}</span>
-      {(user.auth_source || "local") === "local" && (
+      {user.auth_source === "local" && (
         <button onClick={() => setShowChangePassword(true)} className="btn-settings">Password</button>
       )}
       <button onClick={() => setShowTwoFactor(true)} className="btn-settings">2FA</button>

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -907,6 +907,19 @@ export async function ldapLogin(username, password) {
   return res.json();
 }
 
+export async function changePassword(oldPassword, newPassword) {
+  const res = await apiFetch(`${BASE}/auth/change-password`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ old_password: oldPassword, new_password: newPassword }),
+  });
+  if (!res.ok) {
+    const err = await res.json().catch(() => ({}));
+    throw new Error(err.detail || `Password change failed: ${res.status}`);
+  }
+  return res.json();
+}
+
 // ── 2FA / TOTP ────────────────────────────────────────────
 
 export async function setup2FA() {

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -13,7 +13,10 @@ function endpointBase() {
 
 // ── Auth-aware fetch wrapper ─────────────────────────────
 // On 401 (session expired), dispatch event so App can show re-login dialog
-async function apiFetch(url, options) {
+// sessionExpiryOn401: a 401 normally means the session died. A few endpoints use
+// 401 to reject a credential the user just typed (changing your own password with
+// the wrong current one). Those must not sign the user out mid-form.
+async function apiFetch(url, options, { sessionExpiryOn401 = true } = {}) {
   let res;
   try {
     res = await fetch(url, options);
@@ -25,7 +28,7 @@ async function apiFetch(url, options) {
     }
     throw err;
   }
-  if (res.status === 401) {
+  if (res.status === 401 && sessionExpiryOn401) {
     window.dispatchEvent(new CustomEvent("session-expired"));
     throw new Error("Session expired");
   }
@@ -908,15 +911,13 @@ export async function ldapLogin(username, password) {
 }
 
 export async function changePassword(oldPassword, newPassword) {
+  // A wrong current password comes back 401; surface it in the form rather than
+  // treating it as an expired session and signing the user out.
   const res = await apiFetch(`${BASE}/auth/change-password`, {
     method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ old_password: oldPassword, new_password: newPassword }),
-  });
-  if (!res.ok) {
-    const err = await res.json().catch(() => ({}));
-    throw new Error(err.detail || `Password change failed: ${res.status}`);
-  }
+  }, { sessionExpiryOn401: false });
   return res.json();
 }
 

--- a/frontend/src/components/ChangePassword.jsx
+++ b/frontend/src/components/ChangePassword.jsx
@@ -1,0 +1,51 @@
+import React, { useState } from "react";
+import { changePassword } from "../api";
+
+export default function ChangePassword({ onClose }) {
+  const [current, setCurrent] = useState("");
+  const [next, setNext] = useState("");
+  const [confirm, setConfirm] = useState("");
+  const [error, setError] = useState("");
+  const [done, setDone] = useState(false);
+  const [loading, setLoading] = useState(false);
+
+  const submit = async (e) => {
+    e.preventDefault();
+    setError("");
+    if (next.length < 8) return setError("New password must be at least 8 characters");
+    if (next !== confirm) return setError("New passwords do not match");
+    setLoading(true);
+    try {
+      await changePassword(current, next);
+      setDone(true);
+    } catch (err) {
+      setError(err.message);
+    }
+    setLoading(false);
+  };
+
+  return (
+    <div className="modal-overlay" onClick={onClose}>
+      <div className="modal" role="dialog" aria-modal="true" onClick={(e) => e.stopPropagation()}>
+        <h2>Change Password</h2>
+        {done ? (
+          <>
+            <p style={{ fontSize: 13, color: "var(--text-secondary)", margin: "0 0 16px" }}>Your password has been updated.</p>
+            <div className="modal-actions"><button onClick={onClose} className="btn-primary">Done</button></div>
+          </>
+        ) : (
+          <form onSubmit={submit}>
+            {error && <div className="form-error">{error}</div>}
+            <input type="password" placeholder="Current password" aria-label="Current password" value={current} onChange={(e) => setCurrent(e.target.value)} required autoComplete="current-password" />
+            <input type="password" placeholder="New password (8+ characters)" aria-label="New password" value={next} onChange={(e) => setNext(e.target.value)} required minLength={8} autoComplete="new-password" />
+            <input type="password" placeholder="Confirm new password" aria-label="Confirm new password" value={confirm} onChange={(e) => setConfirm(e.target.value)} required autoComplete="new-password" />
+            <div className="modal-actions">
+              <button type="submit" disabled={loading} className="btn-primary">{loading ? "Updating..." : "Update Password"}</button>
+              <button type="button" onClick={onClose}>Cancel</button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/Login.jsx
+++ b/frontend/src/components/Login.jsx
@@ -231,6 +231,12 @@ export default function Login({ onLogin, branding = {} }) {
                 required
                 aria-label="Password"
               />
+              {ldapEnabled && (
+                <label className="login-ldap-toggle">
+                  <input type="checkbox" checked={authMode === "ldap"} onChange={(e) => setAuthMode(e.target.checked ? "ldap" : "local")} aria-label="Sign in with LDAP" />
+                  Sign in with LDAP directory
+                </label>
+              )}
             </>
           )}
           <button type="submit" disabled={loading} className="btn-primary">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -3471,6 +3471,16 @@ button.btn-danger:disabled { background: var(--bg-surface); }
 .tfa-badge-off { background: var(--bg-secondary); color: var(--text-light); }
 
 /* ── Login Auth Toggle (sliding pill) ────────────────── */
+.login-ldap-toggle {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin: -4px 0 10px;
+  cursor: pointer;
+}
+
 .login-auth-toggle {
   position: relative;
   display: flex;

--- a/frontend/src/test/components.test.jsx
+++ b/frontend/src/test/components.test.jsx
@@ -162,14 +162,15 @@ describe("Login", () => {
     expect(screen.getByText("Welcome!")).toBeInTheDocument();
   });
 
-  // Skipped, not deleted: the Local/LDAP choice disappeared from the form in the SSO redesign (#21) and
-  // LDAP login is currently unreachable from the UI — tracked in #35. Re-enable with that fix.
-  it.skip("shows LDAP toggle when enabled", async () => {
+  it("shows LDAP toggle when enabled", async () => {
+    // #35: the SSO redesign (#21) dropped the Local/LDAP choice; LDAP is an option on the password form again.
     const { default: Login } = await import("../components/Login");
     render(<Login onLogin={() => {}} branding={{ ldap_enabled: true }} />);
-
-    expect(screen.getByText("Local")).toBeInTheDocument();
-    expect(screen.getByText("LDAP")).toBeInTheDocument();
+    const ldap = screen.getByLabelText("Sign in with LDAP");
+    expect(ldap).not.toBeChecked();
+    expect(screen.getByText("Sign In")).toBeInTheDocument();
+    fireEvent.click(ldap);
+    expect(screen.getByText("Sign In with LDAP")).toBeInTheDocument();
   });
 
   it("does not show LDAP toggle when disabled", async () => {
@@ -897,6 +898,34 @@ describe("SharePage accent", () => {
     const { default: SharePage } = await import("../components/SharePage");
     render(<SharePage token="t" />);
     await waitFor(() => expect(document.documentElement.style.getPropertyValue("--primary")).toBe("#ff5500"));
+    vi.doUnmock("../api");
+  });
+});
+
+describe("ChangePassword", () => {
+  it("validates locally, then calls the API and confirms", async () => {
+    vi.resetModules();
+    const calls = [];
+    vi.doMock("../api", async (importOriginal) => ({
+      ...(await importOriginal()),
+      changePassword: vi.fn().mockImplementation((o, n) => { calls.push([o, n]); return Promise.resolve({ updated: true }); }),
+    }));
+    const { default: ChangePassword } = await import("../components/ChangePassword");
+    render(<ChangePassword onClose={() => {}} />);
+    fireEvent.change(screen.getByLabelText("Current password"), { target: { value: "oldpass123" } });
+    fireEvent.change(screen.getByLabelText("New password"), { target: { value: "short" } });
+    fireEvent.change(screen.getByLabelText("Confirm new password"), { target: { value: "short" } });
+    fireEvent.submit(screen.getByText("Update Password").closest("form"));
+    expect(await screen.findByText(/at least 8 characters/)).toBeInTheDocument();
+    fireEvent.change(screen.getByLabelText("New password"), { target: { value: "newpassword1" } });
+    fireEvent.change(screen.getByLabelText("Confirm new password"), { target: { value: "newpassword2" } });
+    fireEvent.submit(screen.getByText("Update Password").closest("form"));
+    expect(await screen.findByText(/do not match/)).toBeInTheDocument();
+    expect(calls).toEqual([]);
+    fireEvent.change(screen.getByLabelText("Confirm new password"), { target: { value: "newpassword1" } });
+    fireEvent.submit(screen.getByText("Update Password").closest("form"));
+    expect(await screen.findByText(/has been updated/)).toBeInTheDocument();
+    expect(calls).toEqual([["oldpass123", "newpassword1"]]);
     vi.doUnmock("../api");
   });
 });


### PR DESCRIPTION
#35 — the SSO redesign (#21) replaced the Local/LDAP toggle with S3 Keys/Password and left no way to
reach the LDAP endpoint from the UI. With LDAP enabled, the password form now offers a "Sign in with
LDAP directory" checkbox that switches the submit to the LDAP login. The unit test that had failed
since #21 is re-enabled against the new control.

#29 — the change-password route existed with no UI. Local-auth users get a "Password" button in the
header opening a small dialog (current, new, confirm; 8-character minimum, mismatch and wrong-current
errors shown in place). SSO/LDAP users do not see it. Backend regression test for the route, unit test
for the dialog, e2e scenario that changes the admin password, re-logs in, and restores it.

Closes #35. Closes #29.

Validation: frontend 62 passed (LDAP test re-enabled), backend 163 passed, build ok; e2e `29-change-password.spec.ts` added (runs in the full suite; the CI critical path keeps its current five specs).