### PR TITLE
feat: per-bucket public URL base — ready-to-copy public links for CDN-fronted buckets (#28)

### DIFF
--- a/e2e/tests/28-public-url.spec.ts
+++ b/e2e/tests/28-public-url.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { SEL } from '../helpers/selectors';
+import { BUCKETS } from '../helpers/test-data';
+import { navigateToBucket, clickTab, openFileInfo } from '../helpers/wait-helpers';
+
+// Issue #28: a per-bucket public base URL (CDN) gives every object a ready-to-copy public link.
+test.describe('Public URL per bucket', () => {
+  test.describe.configure({ mode: 'serial' });
+  const BASE = 'https://cdn.example.com/files';
+
+  async function setPublicBase(page, value: string) {
+    await navigateToBucket(page, BUCKETS.MAIN);
+    await page.locator(SEL.settingsButton).click();
+    await expect(page.locator(SEL.modal)).toBeVisible();
+    await clickTab(page, 'Tags');
+    await page.locator('input[aria-label="Public URL base"]').fill(value);
+    await page.locator(`${SEL.modal} button:has-text("Save")`).first().click();
+    await expect(page.locator(`${SEL.modal} :text("Saved")`)).toBeVisible();
+    await page.locator('.modal-overlay').click({ position: { x: 5, y: 5 } });   // overlay click closes the dialog
+    await expect(page.locator(SEL.modal)).toBeHidden();
+  }
+
+  test('28.1 setting the base shows a public link in the object dialog', async ({ page }) => {
+    await setPublicBase(page, BASE);
+    await openFileInfo(page, BUCKETS.MAIN, 'sample.txt');
+    await clickTab(page, 'Share');
+    const link = page.locator('input[aria-label="Public link"]');
+    await expect(link).toBeVisible();
+    const value = await link.inputValue();
+    expect(value.startsWith(BASE + '/')).toBeTruthy();
+    expect(value.length).toBeGreaterThan(BASE.length + 1);
+  });
+
+  test('28.2 clearing the base removes the public link', async ({ page }) => {
+    await setPublicBase(page, '');
+    await openFileInfo(page, BUCKETS.MAIN, 'sample.txt');
+    await clickTab(page, 'Share');
+    await expect(page.locator('input[aria-label="Public link"]')).toHaveCount(0);
+  });
+});

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -921,6 +921,16 @@ export async function changePassword(oldPassword, newPassword) {
   return res.json();
 }
 
+// ── Public URL per bucket (#28) ─────────────────────────────
+// Stored as a bucket tag so it needs no schema and travels with the bucket.
+export const PUBLIC_URL_TAG = "sairo:public-url";
+
+export function publicObjectUrl(base, key) {
+  if (!base || !key) return null;
+  const path = key.split("/").map(encodeURIComponent).join("/");
+  return `${base.replace(/\/+$/, "")}/${path}`;
+}
+
 // ── 2FA / TOTP ────────────────────────────────────────────
 
 export async function setup2FA() {

--- a/frontend/src/components/BucketSettings.jsx
+++ b/frontend/src/components/BucketSettings.jsx
@@ -5,7 +5,7 @@ import {
   getLifecycle, putLifecycle, deleteLifecycle,
   getCors, putCors, deleteCors,
   getBucketPolicy, putBucketPolicy, deleteBucketPolicy,
-  getBucketAcl, putBucketAcl, getBucketTagging, putBucketTagging,
+  getBucketAcl, putBucketAcl, getBucketTagging, putBucketTagging, PUBLIC_URL_TAG,
   getMultipartUploads, abortMultipart, abortAllMultipart, getObjectLock,
 } from "../api";
 
@@ -17,6 +17,8 @@ export default function BucketSettings({ bucket, onClose, role }) {
   const [policy, setPolicy] = useState(null);
   const [acl, setAcl] = useState(null);
   const [tags, setTags] = useState(null);
+  const [publicBase, setPublicBase] = useState(null);   // null = not edited yet: show the saved tag
+  const [publicSaved, setPublicSaved] = useState(false);
   const [multipart, setMultipart] = useState(null);
   const [objectLock, setObjectLock] = useState(null);
   const [crawl, setCrawl] = useState(null);
@@ -476,6 +478,21 @@ export default function BucketSettings({ bucket, onClose, role }) {
 
             {activeTab === "tags" && tags && (
               <div>
+                <h3>Public URL base</h3>
+                <p className="muted" style={{ fontSize: 12, margin: "4px 0 10px" }}>
+                  If this bucket is served publicly (a CDN or public hostname), set its base URL here; object dialogs then offer a ready-to-copy public link. Stored as the bucket tag <span className="mono">{PUBLIC_URL_TAG}</span>.
+                </p>
+                <div style={{ display: "flex", gap: 6, marginBottom: 16, alignItems: "center" }}>
+                  <input type="url" placeholder="https://cdn.example.com/files" aria-label="Public URL base" value={publicBase ?? (tags.tags[PUBLIC_URL_TAG] || "")}
+                         onChange={(e) => { setPublicBase(e.target.value); setPublicSaved(false); }} className="filter-input" style={{ flex: 1 }} disabled={!isAdmin} />
+                  {isAdmin && <button className="btn-primary btn-xs" onClick={async () => {
+                    const updated = { ...tags.tags }; const v = (publicBase ?? tags.tags[PUBLIC_URL_TAG] ?? "").trim();
+                    if (v) updated[PUBLIC_URL_TAG] = v; else delete updated[PUBLIC_URL_TAG];
+                    try { await putBucketTagging(bucket, updated); setTags({ tags: updated }); setPublicBase(null); setPublicSaved(true); }
+                    catch (e) { setAlertMessage("Failed to save public URL: " + (e.message || "Unknown error")); }
+                  }}>Save</button>}
+                  {publicSaved && <span className="muted" style={{ fontSize: 12 }} aria-live="polite">Saved</span>}
+                </div>
                 <h3>Bucket Tags</h3>
                 {Object.keys(tags.tags).length === 0 ? (
                   <p className="muted">No tags</p>

--- a/frontend/src/components/ObjectInfo.jsx
+++ b/frontend/src/components/ObjectInfo.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import ConfirmDialog from "./ConfirmDialog";
-import { formatSize, formatDate, getObjectInfo, getObjectVersions, getPresignedUrl, getObjectTagging, putObjectTagging, getObjectAcl, putObjectAcl, versionRestore, versionDelete, getVersionPresignedUrl, createShareLink } from "../api";
+import { getBucketTagging, publicObjectUrl, PUBLIC_URL_TAG, formatSize, formatDate, getObjectInfo, getObjectVersions, getPresignedUrl, getObjectTagging, putObjectTagging, getObjectAcl, putObjectAcl, versionRestore, versionDelete, getVersionPresignedUrl, createShareLink } from "../api";
 
 export default function ObjectInfo({ bucket, fileKey, onClose, role }) {
   const isAdmin = role === "admin";
@@ -9,6 +9,8 @@ export default function ObjectInfo({ bucket, fileKey, onClose, role }) {
   const [tags, setTags] = useState(null);
   const [acl, setAcl] = useState(null);
   const [presignedUrl, setPresignedUrl] = useState(null);
+  const [publicBase, setPublicBase] = useState("");   // bucket tag sairo:public-url (a CDN or public host in front of the bucket)
+  const [publicCopied, setPublicCopied] = useState(false);
   const [loading, setLoading] = useState(true);
   const [copySuccess, setCopySuccess] = useState(false);
   const [activeTab, setActiveTab] = useState("details");
@@ -32,7 +34,9 @@ export default function ObjectInfo({ bucket, fileKey, onClose, role }) {
       getObjectVersions(bucket, fileKey),
       getObjectTagging(bucket, fileKey).catch(() => ({ tags: {} })),
       getObjectAcl(bucket, fileKey).catch(() => ({ owner: {}, grants: [] })),
-    ]).then(([infoData, versionData, tagData, aclData]) => {
+      getBucketTagging(bucket).catch(() => ({ tags: {} })),
+    ]).then(([infoData, versionData, tagData, aclData, bucketTags]) => {
+      setPublicBase((bucketTags.tags || {})[PUBLIC_URL_TAG] || "");
       setInfo(infoData);
       setVersions(versionData);
       setTags(tagData);
@@ -306,6 +310,19 @@ export default function ObjectInfo({ bucket, fileKey, onClose, role }) {
 
             {activeTab === "share" && (
               <div>
+                {publicBase && (
+                  <>
+                    <h3>Public link</h3>
+                    <p className="muted" style={{ fontSize: 12, margin: "4px 0 10px" }}>This bucket is served publicly from a configured base URL (Bucket Settings → Tags).</p>
+                    <div className="presigned-url">
+                      <input type="text" value={publicObjectUrl(publicBase, fileKey)} readOnly className="url-input" aria-label="Public link" />
+                      <button onClick={() => { navigator.clipboard.writeText(publicObjectUrl(publicBase, fileKey)); setPublicCopied(true); setTimeout(() => setPublicCopied(false), 2000); }} className="btn-primary">
+                        {publicCopied ? "Copied!" : "Copy"}
+                      </button>
+                    </div>
+                    <hr style={{ border: "none", borderTop: "1px solid var(--border-light)", margin: "16px 0" }} />
+                  </>
+                )}
                 <h3>Presigned URL</h3>
                 <div className="presigned-actions">
                   <button onClick={() => generatePresignedUrl(1)}>1 hour</button>

--- a/frontend/src/test/api.test.js
+++ b/frontend/src/test/api.test.js
@@ -2,7 +2,7 @@
  * Tests for api.js utility functions.
  */
 import { describe, it, expect } from "vitest";
-import { formatSize, formatDate } from "../api";
+import { formatSize, formatDate, publicObjectUrl } from "../api";
 
 describe("formatSize", () => {
   it("formats 0 bytes", () => {
@@ -48,5 +48,15 @@ describe("formatDate", () => {
     const result = formatDate("2024-01-15T10:30:00Z");
     expect(result).toBeTruthy();
     expect(result).not.toBe("—");
+  });
+});
+
+describe("publicObjectUrl (#28)", () => {
+  it("joins the base and the key, encoding path segments", () => {
+    expect(publicObjectUrl("https://cdn.example.com/files/", "a b/ü/x.png")).toBe("https://cdn.example.com/files/a%20b/%C3%BC/x.png");
+  });
+  it("is null without a base or key", () => {
+    expect(publicObjectUrl("", "k")).toBeNull();
+    expect(publicObjectUrl("https://cdn.example.com", "")).toBeNull();
   });
 });


### PR DESCRIPTION
Buckets served publicly (a CDN or public hostname) get a base URL, stored as the bucket tag
sairo:public-url so it needs no schema and travels with the bucket. Bucket Settings → Tags gains the
field; the object dialog's Share tab then shows the object's public link with a Copy button, built by
one helper that URL-encodes each path segment. Presigned URLs and share links are unchanged.

Previews keep loading through presigned URLs (allowed by the CSP since #40); serving previews from the
CDN would need its origin in the CSP per bucket and is left out until someone needs it.

Closes #28.

Validation: frontend 62 passed (helper unit tests), build ok; e2e `28-public-url.spec.ts` sets the base in bucket settings, checks the object dialog shows the link, clears it and checks it disappears.