### PR TITLE
fix(r2): bucket discovery needs an Admin-tier R2 token (#44)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5005,6 +5005,23 @@ def list_endpoints(user: dict = Depends(require_admin)):
         eps.append(d)
     return {"endpoints": eps}
 
+def _bucket_discovery_error(e: Exception) -> str:
+    """Explain a failed ListBuckets instead of passing the raw provider error through.
+
+    Sairo discovers buckets with ListBuckets. Object-scoped credentials can read and
+    list objects inside named buckets but cannot enumerate buckets, so the provider
+    answers AccessDenied and the user is left guessing (#44). Cloudflare R2 is the
+    common case: its "Object Read & Write" token cannot list buckets, only the
+    Admin tiers can.
+    """
+    msg = str(e)[:200]
+    if "AccessDenied" in msg or "not authorized" in msg.lower():
+        return (f"{msg} — these credentials cannot list buckets, which Sairo needs to "
+                "discover them. On Cloudflare R2 that means an Object token: use "
+                "Admin Read & Write, or Admin Read only for read-only browsing.")
+    return msg
+
+
 @app.post("/api/endpoints")
 def create_endpoint(req: EndpointCreateRequest, user: dict = Depends(require_admin)):
     """Add a new S3 endpoint. Tests connectivity before saving."""
@@ -5021,7 +5038,7 @@ def create_endpoint(req: EndpointCreateRequest, user: dict = Depends(require_adm
         )
         test_client.list_buckets()
     except Exception as e:
-        raise HTTPException(400, f"Connection test failed: {str(e)[:200]}")
+        raise HTTPException(400, f"Connection test failed: {_bucket_discovery_error(e)}")
     with _get_users_db() as db:
         existing = db.execute("SELECT id FROM s3_endpoints WHERE id=?", (req.id,)).fetchone()
         if existing:
@@ -5151,19 +5168,25 @@ _BUCKET_LIST_TTL = 30  # seconds
 def list_buckets(user: dict = Depends(get_current_user)):
     now = time.time()
     s3_creds = _user_creds_ctx.get(None)
-    if s3_creds and s3_creds.get("ak"):
-        # AUTH_MODE=s3: list with the USER's keys so the provider IAM scopes the result.
-        # Never use the shared cache here — it's keyed by nothing and would leak one
-        # user's bucket list to another.
-        resp = s3.list_buckets()
-    else:
-        with _bucket_list_cache_lock:
-            if _bucket_list_cache["data"] and now - _bucket_list_cache["ts"] < _BUCKET_LIST_TTL:
-                resp = _bucket_list_cache["data"]
-            else:
-                resp = s3.list_buckets()
-                _bucket_list_cache["data"] = resp
-                _bucket_list_cache["ts"] = now
+    try:
+        if s3_creds and s3_creds.get("ak"):
+            # AUTH_MODE=s3: list with the USER's keys so the provider IAM scopes the result.
+            # Never use the shared cache here — it's keyed by nothing and would leak one
+            # user's bucket list to another.
+            resp = s3.list_buckets()
+        else:
+            with _bucket_list_cache_lock:
+                if _bucket_list_cache["data"] and now - _bucket_list_cache["ts"] < _BUCKET_LIST_TTL:
+                    resp = _bucket_list_cache["data"]
+                else:
+                    resp = s3.list_buckets()
+                    _bucket_list_cache["data"] = resp
+                    _bucket_list_cache["ts"] = now
+    except Exception as e:
+        # A raw AccessDenied here reads as "Sairo is broken". Say what is actually
+        # wrong: the credentials cannot enumerate buckets (#44).
+        log.warning("Bucket listing failed: %s", e)
+        raise HTTPException(502, _bucket_discovery_error(e))
     # Non-admin: only show buckets with explicit permissions. S3-key users are already
     # scoped by their keys above, so no extra filter (their role is admin).
     allowed = None

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1189,3 +1189,31 @@ class TestS3KeyAuth:
         finally:
             with m._s3_manager._lock:
                 m._s3_manager._endpoints.pop("ep-b", None)
+
+
+class TestBucketDiscoveryErrors:
+    """#44: an object-scoped token (Cloudflare R2's 'Object Read & Write') can list
+    objects but not buckets. The raw AccessDenied told users nothing, so both the
+    add-endpoint path and the bucket list now explain what to change."""
+
+    def test_hint_names_the_r2_token_tier(self):
+        m = _main_module()
+        hint = m._bucket_discovery_error(Exception("An error occurred (AccessDenied) when calling ListBuckets"))
+        assert "cannot list buckets" in hint
+        assert "Admin Read" in hint
+        # An unrelated failure is passed through untouched, not mislabelled.
+        assert "Admin Read" not in m._bucket_discovery_error(Exception("Connect timeout on endpoint URL"))
+
+    def test_bucket_listing_explains_denied_discovery(self, client, admin_cookies):
+        from unittest.mock import patch
+        m = _main_module()
+        with m._bucket_list_cache_lock:
+            m._bucket_list_cache["data"] = None
+            m._bucket_list_cache["ts"] = 0
+        with patch.object(m.s3, "list_buckets", side_effect=Exception("An error occurred (AccessDenied) when calling ListBuckets")):
+            r = client.get("/api/buckets", cookies=admin_cookies)
+        assert r.status_code == 502, r.text
+        assert "Admin Read" in r.json()["detail"]
+        with m._bucket_list_cache_lock:
+            m._bucket_list_cache["data"] = None
+            m._bucket_list_cache["ts"] = 0

--- a/website/src/content/docs/guides/cloudflare-r2.mdx
+++ b/website/src/content/docs/guides/cloudflare-r2.mdx
@@ -40,12 +40,23 @@ It is also shown on the R2 overview page under **Account ID**.
 2. Navigate to **R2 > Overview**
 3. Click **Manage R2 API Tokens** in the right sidebar
 4. Click **Create API token**
-5. Set permissions to **Object Read & Write**
-6. Optionally restrict to specific buckets
-7. Click **Create API Token**
-8. Copy the **Access Key ID** and **Secret Access Key**
+5. Set permissions to **Admin Read & Write**, or **Admin Read only** if you want
+   browsing without any writes
+6. Click **Create API Token**
+7. Copy the **Access Key ID** and **Secret Access Key**
 
 Use the Access Key ID as `S3_ACCESS_KEY` and the Secret Access Key as `S3_SECRET_KEY`.
+
+:::caution[Object tokens will not work]
+Sairo discovers your buckets by calling `ListBuckets`. On R2 only the **Admin**
+permission tiers can list buckets. The **Object Read & Write** and **Object Read
+only** tiers can read and list objects inside buckets you name up front, but they
+cannot enumerate buckets, so R2 answers `AccessDenied` and no buckets appear.
+
+If you need to restrict Sairo to specific buckets, do it with Sairo's own
+[per-bucket access management](/security/user-management/) rather than by scoping
+the R2 token, since the token still needs to list buckets.
+:::
 
 ## Docker Compose Example
 


### PR DESCRIPTION
Closes #44.

## What was wrong

Sairo discovers buckets by calling `ListBuckets`. Our R2 guide told users to create an **Object Read & Write** token. On R2 only the **Admin** tiers can list buckets; the Object tiers read and list objects inside buckets named up front but cannot enumerate buckets. Following our own guide therefore produced a bare `AccessDenied` and an empty bucket list, with nothing to indicate the token tier was the cause.

Verified against Cloudflare's published permission table:

| Tier | Can list buckets |
|---|---|
| Admin Read & Write | yes |
| Admin Read only | yes |
| Object Read & Write | no |
| Object Read only | no |

## Changes

- The R2 guide now specifies Admin Read & Write, or Admin Read only for browsing, and explains why Object tokens cannot work.
- A denied `ListBuckets` is turned into that explanation on both the add-endpoint path and the bucket list, instead of surfacing the provider's raw error. The bucket list previously let the exception escape as a 500.
- Unrelated failures (timeouts, bad keys) pass through unchanged rather than being mislabelled as a permissions problem.

## Not in scope

Supporting object-scoped credentials properly means letting an endpoint carry an explicit bucket list instead of discovering one. That is a feature, not a fix, and belongs after this release.

## Validation

Backend suite 169 passed, including two new tests: the hint names the right tier for a denied ListBuckets and passes other errors through, and the bucket list returns 502 with the guidance rather than a 500.

No live R2 check was performed. That would require creating an R2 API token, which I have not done.