### PR TITLE
fix(crawler): bound listing concurrency across all buckets, not per bucket

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1741,23 +1741,24 @@ def _run_crawl(bucket, endpoint_id=None):
         root_failed = False     # the root listing raised: root-level objects were not reconciled this attempt
         try:
             token = None
-            while True:
-                params = {"Bucket": bucket, "Delimiter": "/", "MaxKeys": 1000}
-                if token:
-                    params["ContinuationToken"] = token
-                resp = client.list_objects_v2(**params)
-                for cp in resp.get("CommonPrefixes", []):
-                    known_prefixes.add(cp["Prefix"])
-                root_files.extend(resp.get("Contents", []))
-                if not resp.get("IsTruncated", False):
-                    root_complete = True
-                    break
-                token = resp.get("NextContinuationToken")
-                # On recrawl with saved prefixes, skip slow full pagination
-                if existing_count > 0 and len(saved) > 0:
-                    log.info("[%s:%s] Recrawl: using %d saved prefixes (skipping full pagination)",
-                             eid, bucket, len(known_prefixes))
-                    break
+            with _list_slots:   # discovery lists too: it must share the budget, not sit outside it
+                while True:
+                    params = {"Bucket": bucket, "Delimiter": "/", "MaxKeys": 1000}
+                    if token:
+                        params["ContinuationToken"] = token
+                    resp = client.list_objects_v2(**params)
+                    for cp in resp.get("CommonPrefixes", []):
+                        known_prefixes.add(cp["Prefix"])
+                    root_files.extend(resp.get("Contents", []))
+                    if not resp.get("IsTruncated", False):
+                        root_complete = True
+                        break
+                    token = resp.get("NextContinuationToken")
+                    # On recrawl with saved prefixes, skip slow full pagination
+                    if existing_count > 0 and len(saved) > 0:
+                        log.info("[%s:%s] Recrawl: using %d saved prefixes (skipping full pagination)",
+                                 eid, bucket, len(known_prefixes))
+                        break
         except Exception as e:
             log.warning("[%s:%s] Delimiter listing failed, using known prefixes only: %s", eid, bucket, e)
             root_files = []
@@ -1791,8 +1792,9 @@ def _run_crawl(bucket, endpoint_id=None):
             for p in list(prefixes):
                 direct = []
                 try:
-                    kids = _list_children(client, bucket, p, max_children=SUBPREFIX_SPLIT_MAX_CHILDREN,
-                                          max_pages=3, contents=direct)
+                    with _list_slots:   # expansion is discovery listing: same budget
+                        kids = _list_children(client, bucket, p, max_children=SUBPREFIX_SPLIT_MAX_CHILDREN,
+                                              max_pages=3, contents=direct)
                 except Exception as e:
                     expanded.add(p)  # Keep original on error
                     log.warning("[%s:%s] Sub-prefix discovery failed for '%s': %s", eid, bucket, p, e)
@@ -1963,11 +1965,16 @@ def _run_crawl(bucket, endpoint_id=None):
             for future in futures:
                 p = futures[future]
                 try:
-                    # Scale timeout: 900s base + 1s per 5000 objects expected. The global
-                    # listing budget can also hold this prefix in a queue behind other
-                    # buckets, so allow for that; the deadline is here to catch a stuck
-                    # prefix, not a waiting one, and the crawl's own 2-hour cap still bounds it.
-                    prefix_timeout = max(900, 900 + existing_count // 5000) + _CRAWL_MAX_DURATION
+                    # 900s base + 1s per 5000 objects expected, plus room to sit in the
+                    # global listing queue: under the budget a healthy prefix can wait behind
+                    # other buckets, and waiting is not failing. This is only a backstop
+                    # against a non-cooperative hang. The real bounds are the stall detector,
+                    # which cancels a crawl that completes no prefix or batch for
+                    # _CRAWL_STALL_SECONDS and so lets this future finish, and boto's own
+                    # read timeout on each call. (_CRAWL_MAX_DURATION does NOT cap a
+                    # progressing crawl; it only frees a stale lock once the future is gone.)
+                    # A prefix that trips this is retried sequentially below, never dropped.
+                    prefix_timeout = max(900, 900 + existing_count // 5000) + _CRAWL_STALL_SECONDS * 2
                     count, pruned, written = future.result(timeout=prefix_timeout)
                     total_new += count
                     stale_count += pruned
@@ -2670,7 +2677,8 @@ def _delta_crawl(bucket, endpoint_id):
     root_objs = []
     new_tops = set()
     try:
-        kids = _list_children(client, bucket, "", max_pages=DELTA_ROOT_MAX_PAGES, contents=root_objs)
+        with _list_slots:   # delta root discovery is a listing too
+            kids = _list_children(client, bucket, "", max_pages=DELTA_ROOT_MAX_PAGES, contents=root_objs)
         if kids is None:
             failed_targets.append("root")   # oversized root listing: what we saw is ingested, but not certified
         else:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1209,6 +1209,19 @@ def _record_storage_snapshot(bucket, endpoint_id=None):
 
 # ── Background Crawler (per-bucket) ──────────────────────────────────────
 _crawl_pool = ThreadPoolExecutor(max_workers=12, thread_name_prefix="crawler")
+# One listing budget shared by every bucket, because the per-bucket pools multiply: 12
+# concurrent bucket tasks each opening 16 listing threads is 192 listers in flight, which
+# took a 19-bucket / 15.5M-object deployment past a 1 GiB limit (OOMKilled) and overflowed
+# the boto connection pool. The memory lives in the in-flight buffers — response bodies,
+# parsed key lists, batch accumulators — so bounding how many list at once is what bounds
+# the pod. Throughput does not suffer: listing is capped by XML parsing and SQLite in a
+# single process well below this many threads. Kept at or under S3_MAX_POOL_CONNECTIONS so
+# concurrent LISTs never queue on the connection pool.
+LIST_CONCURRENCY = max(1, min(
+    int(os.environ.get("LIST_CONCURRENCY", "16")),
+    int(os.environ.get("S3_MAX_POOL_CONNECTIONS", "32")),
+))
+_list_slots = threading.BoundedSemaphore(LIST_CONCURRENCY)
 _rebuild_pool = ThreadPoolExecutor(max_workers=4, thread_name_prefix="rebuild")
 _crawling = {}       # crawl_key -> timestamp when crawl started
 _crawl_futures = {}  # crawl_key -> Future of the running _run_crawl (for cancel/shutdown)
@@ -1847,7 +1860,8 @@ def _run_crawl(bucket, endpoint_id=None):
             if existing_count > 0:
                 # The whole bucket is one listing unit: everything the listing does not return is pruned.
                 rc = _PrefixReconcile(bucket, eid, crawl_gen, _write_lock(crawl_key))
-                total_count = _crawl_prefix(bucket, "", endpoint_id=eid, batch_callback=rc.batch, should_stop=stop)
+                with _list_slots:   # an unsplittable bucket is still one lister against the budget
+                    total_count = _crawl_prefix(bucket, "", endpoint_id=eid, batch_callback=rc.batch, should_stop=stop)
                 stale_count = rc.finish(); written_total = rc.written
                 index_changed = written_total > 0 or stale_count > 0
             else:
@@ -1857,7 +1871,8 @@ def _run_crawl(bucket, endpoint_id=None):
                             "INSERT OR REPLACE INTO objects (key,size,last_modified,etag,prefix,depth,crawl_gen) VALUES (?,?,?,?,?,?,?)",
                             [row + (crawl_gen,) for row in batch])
                         db.commit()
-                total_count = _crawl_prefix(bucket, "", endpoint_id=eid, batch_callback=_simple_batch_cb, should_stop=stop)
+                with _list_slots:
+                    total_count = _crawl_prefix(bucket, "", endpoint_id=eid, batch_callback=_simple_batch_cb, should_stop=stop)
             if stale_count:
                 log.info("[%s:%s] Removed %s stale keys", eid, bucket, f"{stale_count:,}")
             with _get_db(bucket, eid) as db:
@@ -1933,12 +1948,14 @@ def _run_crawl(bucket, endpoint_id=None):
         def _crawl_unit(p):
             """List one prefix in a pool thread. Returns (objects listed, stale rows pruned, rows written)."""
             if not incremental:
-                return _crawl_prefix(bucket, p, endpoint_id=eid, batch_callback=_initial_batch_cb, should_stop=stop), 0, 0
+                with _list_slots:   # the initial crawl is the heaviest user of the budget
+                    return _crawl_prefix(bucket, p, endpoint_id=eid, batch_callback=_initial_batch_cb, should_stop=stop), 0, 0
             rc = _PrefixReconcile(bucket, eid, crawl_gen, wlock, lo=p, hi=_prefix_upper(p))
             def cb(batch):
                 rc.batch(batch)
                 _note_progress()
-            count = _crawl_prefix(bucket, p, endpoint_id=eid, batch_callback=cb, should_stop=stop)
+            with _list_slots:   # global budget, not per-bucket: see LIST_CONCURRENCY
+                count = _crawl_prefix(bucket, p, endpoint_id=eid, batch_callback=cb, should_stop=stop)
             return count, rc.finish(), rc.written   # reached only when every page of p was listed
 
         with ThreadPoolExecutor(max_workers=16, thread_name_prefix=f"pfx-{bucket[:8]}") as pool:
@@ -1946,8 +1963,11 @@ def _run_crawl(bucket, endpoint_id=None):
             for future in futures:
                 p = futures[future]
                 try:
-                    # Scale timeout: 900s base + 1s per 5000 objects expected
-                    prefix_timeout = max(900, 900 + existing_count // 5000)
+                    # Scale timeout: 900s base + 1s per 5000 objects expected. The global
+                    # listing budget can also hold this prefix in a queue behind other
+                    # buckets, so allow for that; the deadline is here to catch a stuck
+                    # prefix, not a waiting one, and the crawl's own 2-hour cap still bounds it.
+                    prefix_timeout = max(900, 900 + existing_count // 5000) + _CRAWL_MAX_DURATION
                     count, pruned, written = future.result(timeout=prefix_timeout)
                     total_new += count
                     stale_count += pruned
@@ -2579,7 +2599,10 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
             # Per-node bound too: the node budget alone did not bound remote work — one node with
             # 20,000 children cost 20 LIST pages and 20,000 names in memory. A node wider than
             # DELTA_NODE_MAX_PAGES pages is left unvisited and the walk is reported partial.
-            listed = list(ex.map(lambda p: (p, _list_children(client, bucket, p, max_pages=DELTA_NODE_MAX_PAGES)), frontier))
+            def _list_one(p):
+                with _list_slots:   # deltas share the budget with full crawls
+                    return (p, _list_children(client, bucket, p, max_pages=DELTA_NODE_MAX_PAGES))
+            listed = list(ex.map(_list_one, frontier))
             nxt = []
             for cur, children in listed:
                 if children is None:
@@ -2703,7 +2726,8 @@ def _delta_crawl(bucket, endpoint_id):
         flush(root_objs)
     def _list_or_fail(tp):
         try:
-            res = _delta_list_prefix(client, bucket, tp, sink=flush)
+            with _list_slots:   # delta target listing draws on the same global budget
+                res = _delta_list_prefix(client, bucket, tp, sink=flush)
             if isinstance(res, list):   # a listing helper that returns objects instead of streaming
                 flush(res)
             return tp, True

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1231,9 +1231,11 @@ class TestGlobalListingBudget:
     def test_concurrent_listing_stays_within_the_budget_across_buckets(self, app):
         import threading as _t
         m = self._main()
+        # More buckets than the budget, so the root-discovery listings alone breach it
+        # if any discovery path runs outside the semaphore.
         budget = 3
-        buckets = ["budgeta", "budgetb"]
-        prefixes = [f"p{i}/" for i in range(8)]
+        buckets = [f"budget{c}" for c in "abcde"]
+        prefixes = [f"p{i}/" for i in range(4)]
 
         for b in buckets:
             for suffix in ("", "-wal", "-shm"):
@@ -1250,15 +1252,17 @@ class TestGlobalListingBudget:
         guard = _t.Lock()
 
         def list_objects_v2(**p):
-            if "Delimiter" in p:
-                kids = [{"Prefix": q} for q in prefixes] if not p.get("Prefix") else []
-                return {"CommonPrefixes": kids, "Contents": [], "IsTruncated": False}
+            # Every LIST counts, delimiter ones included. Measuring only the object
+            # listings hid three unguarded discovery paths behind a green test.
             nonlocal live, peak
             with guard:
                 live += 1
                 peak = max(peak, live)
             try:
                 time.sleep(0.05)   # hold the slot long enough for real overlap
+                if "Delimiter" in p:
+                    kids = [{"Prefix": q} for q in prefixes] if not p.get("Prefix") else []
+                    return {"CommonPrefixes": kids, "Contents": [], "IsTruncated": False}
                 return {"Contents": [{"Key": f"{p['Prefix']}{i}", "Size": 1,
                                       "LastModified": datetime(2026, 1, 1, tzinfo=timezone.utc),
                                       "ETag": '"e"'} for i in range(2)],

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1217,3 +1217,71 @@ class TestBucketDiscoveryErrors:
         with m._bucket_list_cache_lock:
             m._bucket_list_cache["data"] = None
             m._bucket_list_cache["ts"] = 0
+
+
+class TestGlobalListingBudget:
+    """The per-bucket listing pools used to multiply: 12 concurrent bucket tasks x 16
+    listing threads each put a 19-bucket / 15.5M-object deployment past a 1 GiB limit
+    (OOMKilled). One budget now caps how many prefixes are listed at once across every
+    bucket, which is what bounds the in-flight buffers."""
+
+    def _main(self):
+        return _main_module()
+
+    def test_concurrent_listing_stays_within_the_budget_across_buckets(self, app):
+        import threading as _t
+        m = self._main()
+        budget = 3
+        buckets = ["budgeta", "budgetb"]
+        prefixes = [f"p{i}/" for i in range(8)]
+
+        for b in buckets:
+            for suffix in ("", "-wal", "-shm"):
+                try: os.remove(m._db_path(b, "default") + suffix)
+                except FileNotFoundError: pass
+            m._init_db(b, "default")
+            with m._get_db(b, "default") as db:
+                db.execute("DELETE FROM objects"); db.execute("DELETE FROM crawl_progress")
+                db.execute("DELETE FROM discovered_prefixes")
+                db.commit()
+
+        live = 0
+        peak = 0
+        guard = _t.Lock()
+
+        def list_objects_v2(**p):
+            if "Delimiter" in p:
+                kids = [{"Prefix": q} for q in prefixes] if not p.get("Prefix") else []
+                return {"CommonPrefixes": kids, "Contents": [], "IsTruncated": False}
+            nonlocal live, peak
+            with guard:
+                live += 1
+                peak = max(peak, live)
+            try:
+                time.sleep(0.05)   # hold the slot long enough for real overlap
+                return {"Contents": [{"Key": f"{p['Prefix']}{i}", "Size": 1,
+                                      "LastModified": datetime(2026, 1, 1, tzinfo=timezone.utc),
+                                      "ETag": '"e"'} for i in range(2)],
+                        "IsTruncated": False}
+            finally:
+                with guard:
+                    live -= 1
+
+        client = MagicMock(); client.list_objects_v2.side_effect = list_objects_v2
+        with patch.object(m, "_list_slots", _t.BoundedSemaphore(budget)), \
+             patch.object(m._s3_manager, "get_client", return_value=client), \
+             patch.object(m._rebuild_pool, "submit"):
+            threads = [_t.Thread(target=m._run_crawl, args=(b, "default")) for b in buckets]
+            for t in threads: t.start()
+            for t in threads: t.join(timeout=120)
+
+        assert peak > 1, "test did not actually run listings concurrently"
+        assert peak <= budget, f"listing concurrency {peak} exceeded the global budget {budget}"
+        for b in buckets:
+            with m._get_db(b, "default") as db:
+                assert db.execute("SELECT COUNT(*) FROM objects").fetchone()[0] == len(prefixes) * 2, b
+
+    def test_budget_never_exceeds_the_connection_pool(self):
+        m = self._main()
+        pool = int(os.environ.get("S3_MAX_POOL_CONNECTIONS", "32"))
+        assert 1 <= m.LIST_CONCURRENCY <= pool, (m.LIST_CONCURRENCY, pool)

--- a/website/src/content/docs/reference/environment-variables.mdx
+++ b/website/src/content/docs/reference/environment-variables.mdx
@@ -54,7 +54,8 @@ These bound how the incremental delta crawler discovers new data on large bucket
 | `DELTA_BRANCH_FANOUT` | `8` | Levels with more children than this are treated as time partitions (follow only the newest few); fewer means a descriptive branch (follow all) |
 | `DELTA_NEWEST_K` | `2` | How many of the newest partitions to re-list at a partition level (current + just-rolled) |
 | `DELTA_MAX_DEPTH` | `12` | Safety cap on prefix-walk depth |
-| `DELTA_LIST_CONCURRENCY` | `16` | Parallel S3 list calls per level during delta discovery |
+| `LIST_CONCURRENCY` | `16` | **Total** S3 list calls in flight across every bucket the crawler is working on, covering initial crawls, reconciles, delta discovery and delta target listing. The per-bucket settings below bound one bucket; this bounds the process. Raising it raises peak memory, since each in-flight listing holds a response body and a batch buffer. Clamped to `S3_MAX_POOL_CONNECTIONS` so concurrent lists never overflow the connection pool. |
+| `DELTA_LIST_CONCURRENCY` | `16` | Parallel S3 list calls per level during delta discovery, within the `LIST_CONCURRENCY` total |
 | `DELTA_MAX_NODES` | `2000` | Safety cap on folders visited per delta crawl |
 
 ## LDAP


### PR DESCRIPTION
Blocks v3.7.0. The production-shaped 19-bucket / 15.5M-object rehearsal on a 1 GiB pod was OOMKilled at exit 137 after per-bucket listing pools multiplied to as many as 192 listers.

## Fix

One standard-library bounded semaphore now limits background-crawler S3 listing work across every bucket. It covers nine crawler sites: full-crawl root discovery, sub-prefix expansion, simple initial and reconcile crawls, prefix-parallel initial and reconcile crawls, delta child discovery, delta root discovery, and delta target listing. `LIST_CONCURRENCY` defaults to 16 and is clamped to `S3_MAX_POOL_CONNECTIONS`.

This is intentionally a crawler-wide budget. Interactive object browsing and the separate on-demand version scanner remain outside it so crawler work cannot block user requests.

## Test

`TestGlobalListingBudget` runs five bucket crawls concurrently with a budget of three, counts delimiter and non-delimiter LIST calls, asserts observed concurrency never exceeds the budget, and verifies every object lands. Five buckets matter: discovery alone exceeds the budget. Removing the root guard reproduces a peak of seven; restoring it passes.

The prefix deadline now allows queue time using `_CRAWL_STALL_SECONDS`. `_CRAWL_MAX_DURATION` does not cap a progressing crawl; the real cooperative bounds are the stall detector and boto per-call read timeout. A prefix that reaches the deadline is retried sequentially rather than dropped.

## Validation

All required hosted checks pass. The focused global-budget tests also pass independently on this exact head.

## Still required before tagging

After merge, build the exact merged head and rerun the 3.6.0-to-3.7.0 19-bucket gate on stable AC power. Require zero unplanned restarts, peak cgroup memory below 800 MiB, all 19 counts matching provider truth, all FTS generations current, and no permanently degraded `seg-main` delta. Rewrite the release notes with the measured result before creating `v3.7.0`.