### PR TITLE
fix(crawler): let delta discovery page past 2,000 children (#seg-main never certified)

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -2537,7 +2537,12 @@ DELTA_NEWEST_K = int(os.environ.get("DELTA_NEWEST_K", "2"))             # partit
 DELTA_MAX_DEPTH = int(os.environ.get("DELTA_MAX_DEPTH", "12"))          # safety cap on walk depth
 DELTA_LIST_CONCURRENCY = int(os.environ.get("DELTA_LIST_CONCURRENCY", "16"))  # parallel S3 list calls per level
 DELTA_MAX_NODES = int(os.environ.get("DELTA_MAX_NODES", "2000"))        # safety cap on folders visited per delta
-DELTA_NODE_MAX_PAGES = int(os.environ.get("DELTA_NODE_MAX_PAGES", "2"))   # delimiter pages per discovery node before the node is left unvisited (partial)
+# Delimiter pages per discovery node before the node is left unvisited (and the walk
+# reported partial). Two pages caps a node at 2,000 children, which silently truncated
+# every delta on a bucket whose datasources hold 2,500 interval prefixes: the walk could
+# never certify a complete refresh. Three pages covers 2,500 while still bounding a
+# genuinely oversized node.
+DELTA_NODE_MAX_PAGES = int(os.environ.get("DELTA_NODE_MAX_PAGES", "3"))
 DELTA_ROOT_MAX_PAGES = int(os.environ.get("DELTA_ROOT_MAX_PAGES", "200"))  # root listing pages per delta before the delta is degraded (200k entries; production has 62k-prefix roots)
 
 

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1289,3 +1289,51 @@ class TestGlobalListingBudget:
         m = self._main()
         pool = int(os.environ.get("S3_MAX_POOL_CONNECTIONS", "32"))
         assert 1 <= m.LIST_CONCURRENCY <= pool, (m.LIST_CONCURRENCY, pool)
+
+
+class TestDeltaDiscoveryPaging:
+    """seg-main holds 2,500 interval prefixes per datasource and S3 pages at 1,000, so a
+    two-page cap abandoned every datasource at 2,000 and no delta could ever certify a
+    complete refresh — the bucket reported discovery:truncated forever. Three pages
+    covers 2,500; a genuinely oversized node must still degrade rather than walk it all."""
+
+    def _client(self, n_children):
+        """A delimiter listing of n_children prefixes, paged at 1,000 like S3."""
+        pages = [[f"ds/i{i:05d}/" for i in range(s, min(s + 1000, n_children))]
+                 for s in range(0, n_children, 1000)]
+        calls = {"n": 0}
+        def list_objects_v2(**p):
+            i = calls["n"]; calls["n"] += 1
+            return {"CommonPrefixes": [{"Prefix": q} for q in pages[i]], "Contents": [],
+                    "IsTruncated": i + 1 < len(pages),
+                    "NextContinuationToken": f"t{i}" if i + 1 < len(pages) else None}
+        c = MagicMock(); c.list_objects_v2.side_effect = list_objects_v2
+        return c, calls
+
+    def test_2500_children_complete_within_the_default_page_budget(self):
+        m = _main_module()
+        assert m.DELTA_NODE_MAX_PAGES >= 3, "2,500 children need three 1,000-key pages"
+        c, calls = self._client(2500)
+        kids = m._list_children(c, "seg-main", "ds/", max_pages=m.DELTA_NODE_MAX_PAGES)
+        assert kids is not None, "a 2,500-child node must not be abandoned as oversized"
+        assert len(kids) == 2500 and calls["n"] == 3
+
+    def test_two_pages_would_have_truncated_it(self):
+        """Pins the regression: the old default could not see past 2,000."""
+        m = _main_module()
+        c, _ = self._client(2500)
+        assert m._list_children(c, "seg-main", "ds/", max_pages=2) is None
+
+    def test_genuinely_oversized_node_still_degrades(self):
+        m = _main_module()
+        c, calls = self._client(4000)
+        assert m._list_children(c, "seg-main", "ds/", max_pages=m.DELTA_NODE_MAX_PAGES) is None
+        assert calls["n"] == m.DELTA_NODE_MAX_PAGES, "must stop at the budget, not read on"
+
+    def test_newest_branches_are_chosen_from_a_full_2500_listing(self):
+        """Seeing all 2,500 is only useful if the newest partitions are the ones followed."""
+        m = _main_module()
+        c, _ = self._client(2500)
+        kids = m._list_children(c, "seg-main", "ds/", max_pages=m.DELTA_NODE_MAX_PAGES)
+        chosen = sorted(kids, key=m._natural_key)[-m.DELTA_NEWEST_K:]
+        assert chosen == ["ds/i02498/", "ds/i02499/"], chosen

--- a/website/src/content/docs/reference/environment-variables.mdx
+++ b/website/src/content/docs/reference/environment-variables.mdx
@@ -57,6 +57,7 @@ These bound how the incremental delta crawler discovers new data on large bucket
 | `LIST_CONCURRENCY` | `16` | **Total** S3 list calls in flight across every bucket the crawler is working on, covering initial crawls, reconciles, delta discovery and delta target listing. The per-bucket settings below bound one bucket; this bounds the process. Raising it raises peak memory, since each in-flight listing holds a response body and a batch buffer. Clamped to `S3_MAX_POOL_CONNECTIONS` so concurrent lists never overflow the connection pool. |
 | `DELTA_LIST_CONCURRENCY` | `16` | Parallel S3 list calls per level during delta discovery, within the `LIST_CONCURRENCY` total |
 | `DELTA_MAX_NODES` | `2000` | Safety cap on folders visited per delta crawl |
+| `DELTA_NODE_MAX_PAGES` | `3` | Delimiter pages read per folder during delta discovery, at 1,000 entries each. A folder wider than this is left unvisited and the delta is reported partial rather than certified. Raise it if a single folder legitimately holds more than 3,000 children. |
 
 ## LDAP
 


### PR DESCRIPTION
Last 3.7.0 blocker. The production-shaped gate passed every criterion except delta certification on the largest bucket, which failed **deterministically**.

## Cause

Arithmetic, not a race:

| | |
|---|---|
| Interval prefixes per datasource | 2,500 |
| S3 delimiter page size | 1,000 |
| `DELTA_NODE_MAX_PAGES` | 2 |

Two pages see 2,000 of 2,500 with `IsTruncated` still set, so `_list_children` returns `None` and the node is abandoned as oversized. Every delta, every time. `seg-main` therefore reported `discovery:truncated` permanently and its freshness timestamp never advanced past its last full crawl.

## Fix

Default raised to 3 pages, which covers 2,500 exactly. A genuinely oversized folder still degrades safely rather than being walked in full.

## Tests

- 2,500 children complete within the budget, in exactly 3 pages
- the newest partitions are the ones selected from the full listing
- 2 pages still truncate — pins the regression
- 4,000 children still abandoned, and it stops **at** the budget rather than reading on

## Gate correction

The gate scored this bucket PASS because it only tested `status != degraded`, and the status read `complete`. It now requires `last_error` clear **and** `last_crawl_end >= last_attempt_at`, across all buckets rather than just `seg-main`. Replayed against the recorded data from the failed run, the old check passes and the corrected one fails — so it would have caught this.

## What is already proven and not re-litigated here

The 75-minute run validated the concurrency fix: 15,500,000 / 15,500,000 across all 19 buckets, zero restarts, zero OOM kills, anonymous memory down from 888 MiB to 605 MiB and falling in the final quarter, and no lock, stall, crawl or connection-pool errors. This change touches only the delta discovery page budget, so the follow-up run targets that path rather than repeating the full upgrade.