### PR TITLE
docs: refresh the stale chart version on the Helm page

### DIFF
--- a/website/src/content/docs/installation/helm.mdx
+++ b/website/src/content/docs/installation/helm.mdx
@@ -13,7 +13,7 @@ Sairo provides an official Helm chart for Kubernetes deployments. The chart bund
 | ----------- | ------------------------ |
 | Registry      | `oci://registry-1.docker.io/stephenjr002/sairo-helm` |
 
-The chart version (`1.0.0`) is independent of the app version. Each chart release bundles the matching Docker image tag via `appVersion`. When you install without `--version`, you get the latest published chart.
+The chart version (currently `1.5.0`) is independent of the app version (currently `3.7.0`). Each chart release bundles the matching Docker image tag via `appVersion`. When you install without `--version`, you get the latest published chart.
 
 ## Install
 


### PR DESCRIPTION
The Helm page quoted chart version `1.0.0`, five chart releases behind. It now names the current chart (`1.5.0`) and app (`3.7.0`) versions, and still explains that the two move independently.

Swept the rest of the docs and site for stale version claims while checking. Nothing else needed changing:

- `Since v3.4.0, uploads go directly…` in upload-download and benchmarks are historical statements about when a feature landed, and are correct as written.
- No image tag pins, version badges, or "latest version is…" claims anywhere, so the install docs don't churn per release.
- Changelogs already carry the 3.7.0 entry from #39.