### PR TITLE
[DO NOT MERGE] full e2e suite against v3.7.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,6 @@ jobs:
       - run: npx playwright install --with-deps chromium
       # 29 runs last: it changes the admin password and restores it, so a failure
       # part-way through must not cascade into the specs after it.
-      - run: npx playwright test 01-auth.spec.ts 02-bucket-list.spec.ts 03-object-browser.spec.ts 04-file-operations.spec.ts 26-security-hardening.spec.ts 29-change-password.spec.ts --project=chromium --project=no-auth
+      - run: npx playwright test --project=chromium --project=no-auth
       - if: always()
         run: docker compose -f docker-compose.test.yml down -v


### PR DESCRIPTION
Throwaway branch, opened only to trigger CI. **Do not merge.**

The release shipped with the 6-spec critical path green, but the other 25 e2e specs were never run against the final code. The local Playwright install on my host cannot extract its browsers (download completes, extraction stalls), so this runs all 31 specs on the Linux runners instead.

The only change is widening the critical-path step to the full suite. I'll delete the branch once the results are in.