### PR TITLE
fix(crawler): stop the search-index rebuild racing a delta on the same bucket

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1384,6 +1384,21 @@ def _rebuild_fts(bucket, endpoint_id=None):
         _rebuild_fts_locked(bucket, eid, t0)
 
 
+def _fts_swap(db, start_max):
+    """Catch up rows written during the build, then swap the shadow table in. One transaction, and
+    the caller holds the bucket's write lock so a concurrent delta waits instead of erroring."""
+    db.execute("BEGIN IMMEDIATE")
+    db.execute("INSERT INTO objects_fts_new(rowid, key) SELECT rowid, key FROM objects WHERE rowid > ?", (start_max,))
+    for trg in ("objects_fts_ai", "objects_fts_ad", "objects_fts_au"):
+        db.execute(f"DROP TRIGGER IF EXISTS {trg}")
+    db.execute("DROP TABLE IF EXISTS objects_fts")
+    db.execute("ALTER TABLE objects_fts_new RENAME TO objects_fts")
+    _create_fts_triggers(db)
+    # Persisted readiness: the search index now covers this generation (survives restarts).
+    db.execute("UPDATE crawl_status SET fts_ready_gen = current_crawl_gen WHERE id=1")
+    db.commit()
+
+
 def _rebuild_fts_locked(bucket, eid, t0):
     try:
         with _get_db(bucket, eid) as db:
@@ -1408,16 +1423,13 @@ def _rebuild_fts_locked(bucket, eid, t0):
                 last = hi
             # One transaction: catch up rows added during the build, swap the tables, recreate the sync
             # triggers (they name objects_fts, so the table cannot be dropped underneath them).
-            db.execute("BEGIN IMMEDIATE")
-            db.execute("INSERT INTO objects_fts_new(rowid, key) SELECT rowid, key FROM objects WHERE rowid > ?", (start_max,))
-            for trg in ("objects_fts_ai", "objects_fts_ad", "objects_fts_au"):
-                db.execute(f"DROP TRIGGER IF EXISTS {trg}")
-            db.execute("DROP TABLE IF EXISTS objects_fts")
-            db.execute("ALTER TABLE objects_fts_new RENAME TO objects_fts")
-            _create_fts_triggers(db)
-            # Persisted readiness: the search index now covers this generation (survives restarts).
-            db.execute("UPDATE crawl_status SET fts_ready_gen = current_crawl_gen WHERE id=1")
-            db.commit()
+            #
+            # Hold the bucket's write lock across it. BEGIN IMMEDIATE takes SQLite's write lock and
+            # keeps it through a DROP of a multi-million-row FTS table, which on a 10M-object bucket
+            # outlasts busy_timeout. Without this lock a concurrent delta write does not queue behind
+            # the swap in-process, it races it in SQLite and fails with "database is locked".
+            with _write_lock(f"{eid}:{bucket}"):
+                _fts_swap(db, start_max)
         log.info("[%s:%s] FTS index rebuilt in %.1fs (shadow table, %d-row chunks)", eid, bucket, time.monotonic() - t0, FTS_REBUILD_CHUNK)
     except Exception as e:
         log.warning("[%s:%s] FTS rebuild failed (old index kept): %s", eid, bucket, e)
@@ -1490,29 +1502,36 @@ def _ensure_fts_ready(bucket, endpoint_id=None):
     full reconcile. Returns the rebuild thread when one was started, else None."""
     eid = endpoint_id or "default"
     crawl_key = f"{eid}:{bucket}"
-    try:
-        with _get_db(bucket, eid) as db:
-            row = db.execute("SELECT status, fts_ready_gen, current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
-            if not row or row["status"] not in ("complete", "degraded"):
-                return None
-            ready, gen = row["fts_ready_gen"], (row["current_crawl_gen"] or 0)
-            healthy = _fts_healthy(db)
-            if ready == gen and healthy:
-                return None
-            if ready is None and healthy and _fts_consistent(db):
-                db.execute("UPDATE crawl_status SET fts_ready_gen=? WHERE id=1", (gen,))
-                db.commit()
-                log.info("[%s:%s] Search index verified against the catalogue; readiness marker backfilled for generation %d", eid, bucket, gen)
-                return None
-    except Exception as e:
-        log.warning("[%s:%s] Could not check search readiness: %s", eid, bucket, e)
-        return None
-    log.info("[%s:%s] Search index generation %s behind catalogue generation %d (or unhealthy) — repairing now", eid, bucket, ready, gen)
+    # Reserve the bucket BEFORE the integrity check, not after it. The check reads the whole
+    # catalogue, and _queue_delta_crawl only declines while the key sits in _rebuilding, so
+    # reserving afterwards left a window: a delta started during the check, the rebuild then took
+    # the write lock for its swap, and the delta died with "database is locked" (seen in production
+    # on the first boot after 3.7.0, when every bucket is verified at once).
     with _crawl_lock:
+        if crawl_key in _rebuilding:
+            return None
         _rebuilding.add(crawl_key)
     def _release():
         with _crawl_lock:
             _rebuilding.discard(crawl_key)
+    try:
+        with _get_db(bucket, eid) as db:
+            row = db.execute("SELECT status, fts_ready_gen, current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
+            if not row or row["status"] not in ("complete", "degraded"):
+                _release(); return None
+            ready, gen = row["fts_ready_gen"], (row["current_crawl_gen"] or 0)
+            healthy = _fts_healthy(db)
+            if ready == gen and healthy:
+                _release(); return None
+            if ready is None and healthy and _fts_consistent(db):
+                db.execute("UPDATE crawl_status SET fts_ready_gen=? WHERE id=1", (gen,))
+                db.commit()
+                log.info("[%s:%s] Search index verified against the catalogue; readiness marker backfilled for generation %d", eid, bucket, gen)
+                _release(); return None
+    except Exception as e:
+        log.warning("[%s:%s] Could not check search readiness: %s", eid, bucket, e)
+        _release(); return None
+    log.info("[%s:%s] Search index generation %s behind catalogue generation %d (or unhealthy) — repairing now", eid, bucket, ready, gen)
     return _rebuild_fts_async(bucket, eid, done=_release)
 
 
@@ -2615,6 +2634,15 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
                 with _list_slots:   # deltas share the budget with full crawls
                     return (p, _list_children(client, bucket, p, max_pages=DELTA_NODE_MAX_PAGES))
             listed = list(ex.map(_list_one, frontier))
+            # Name the folder that tripped the bound. Without this, "discovery:truncated" says the
+            # walk was partial but not which prefix or what to raise, so sizing DELTA_NODE_MAX_PAGES
+            # for a real bucket is guesswork.
+            for _cur, _kids in listed:
+                if _kids is None:
+                    log.warning("[%s:%s] Delta discovery bound hit at '%s': more than %d pages "
+                                "(%d children); raise DELTA_NODE_MAX_PAGES to cover it",
+                                endpoint_id or "default", bucket, _cur[:80], DELTA_NODE_MAX_PAGES,
+                                DELTA_NODE_MAX_PAGES * 1000)
             nxt = []
             for cur, children in listed:
                 if children is None:

--- a/backend/main.py
+++ b/backend/main.py
@@ -1492,7 +1492,17 @@ def _seed_from_existing(prev_status, total, dur):
     return total > 0 and dur > 0 and prev_status == "complete"
 
 
-def _ensure_fts_ready(bucket, endpoint_id=None):
+def _reserve_rebuild(crawl_key):
+    """Claim a bucket for a search-index rebuild. False when a crawl, a delta or another rebuild
+    already owns it. Callers that get True must release it."""
+    with _crawl_lock:
+        if crawl_key in _rebuilding or crawl_key in _crawling:
+            return False
+        _rebuilding.add(crawl_key)
+        return True
+
+
+def _ensure_fts_ready(bucket, endpoint_id=None, reserved=False):
     """Startup repair for a served index whose search generation is absent or stale.
 
     Databases from before fts_ready_gen existed have NULL: the marker is backfilled only after SQLite's
@@ -1507,10 +1517,8 @@ def _ensure_fts_ready(bucket, endpoint_id=None):
     # reserving afterwards left a window: a delta started during the check, the rebuild then took
     # the write lock for its swap, and the delta died with "database is locked" (seen in production
     # on the first boot after 3.7.0, when every bucket is verified at once).
-    with _crawl_lock:
-        if crawl_key in _rebuilding:
-            return None
-        _rebuilding.add(crawl_key)
+    if not reserved and not _reserve_rebuild(crawl_key):
+        return None
     def _release():
         with _crawl_lock:
             _rebuilding.discard(crawl_key)
@@ -2639,10 +2647,12 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
             # for a real bucket is guesswork.
             for _cur, _kids in listed:
                 if _kids is None:
-                    log.warning("[%s:%s] Delta discovery bound hit at '%s': more than %d pages "
-                                "(%d children); raise DELTA_NODE_MAX_PAGES to cover it",
-                                endpoint_id or "default", bucket, _cur[:80], DELTA_NODE_MAX_PAGES,
-                                DELTA_NODE_MAX_PAGES * 1000)
+                    # MaxKeys counts returned entries, objects and rolled-up prefixes together,
+                    # so the page budget does not translate to a child count. All this proves is
+                    # that results remained after the budget ran out.
+                    log.warning("[%s:%s] Delta discovery bound hit at '%s': still more results after "
+                                "%d pages of %d entries; raise DELTA_NODE_MAX_PAGES to cover it",
+                                endpoint_id or "default", bucket, _cur[:80], DELTA_NODE_MAX_PAGES, 1000)
             nxt = []
             for cur, children in listed:
                 if children is None:
@@ -3031,7 +3041,16 @@ def startup():
                             seeded = True
                             # legacy NULL marker → verify and backfill; stale → repair now. Off the startup
                             # thread and bounded by the rebuild pool (the check reads the whole index).
-                            _rebuild_pool.submit(_ensure_fts_ready, name, eid)
+                            # Reserve before submitting, not when the worker starts: these checks
+                            # share a 4-worker pool, so a queued bucket could begin a delta first
+                            # and then collide when its check finally ran.
+                            if _reserve_rebuild(f"{eid}:{name}"):
+                                try:
+                                    _rebuild_pool.submit(_ensure_fts_ready, name, eid, reserved=True)
+                                except Exception:
+                                    with _crawl_lock:
+                                        _rebuilding.discard(f"{eid}:{name}")
+                                    raise
                             log.info("Seeded schedule for %s:%s from existing index (%s objects); will keep fresh via scheduler",
                                      eid, name, f"{total:,}")
                     except Exception:

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1337,3 +1337,56 @@ class TestDeltaDiscoveryPaging:
         kids = m._list_children(c, "seg-main", "ds/", max_pages=m.DELTA_NODE_MAX_PAGES)
         chosen = sorted(kids, key=m._natural_key)[-m.DELTA_NEWEST_K:]
         assert chosen == ["ds/i02498/", "ds/i02499/"], chosen
+
+
+class TestRebuildDeltaRace:
+    """Production hit `database is locked` on the first boot after 3.7.0: startup verified every
+    bucket's search index while the 120s scheduler fired deltas at the same buckets. The guard that
+    should stop that was reserved only AFTER the integrity check, which reads the whole catalogue,
+    so a delta could start inside that window and then lose the race to the rebuild's swap."""
+
+    def test_verification_reserves_the_bucket_before_checking(self, app):
+        """A delta queued while the check is still running must be declined."""
+        import threading as _t
+        m = _main_module()
+        bucket, key = "racebkt", "default:racebkt"
+        for suffix in ("", "-wal", "-shm"):
+            try: os.remove(m._db_path(bucket, "default") + suffix)
+            except FileNotFoundError: pass
+        m._init_db(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            db.execute("UPDATE crawl_status SET status='complete', fts_ready_gen=1, current_crawl_gen=9")
+            db.commit()
+        m._rebuilding.discard(key)
+
+        during_check = {}
+        real_healthy = m._fts_healthy
+        def slow_healthy(db):
+            # stand-in for the real check reading millions of rows
+            during_check["delta_allowed"] = m._queue_delta_crawl(bucket, "default")
+            return real_healthy(db)
+
+        started = []
+        with patch.object(m, "_fts_healthy", slow_healthy), \
+             patch.object(m, "_rebuild_fts_async", lambda b, e, done=None: started.append(b)):
+            m._ensure_fts_ready(bucket, "default")
+
+        assert during_check.get("delta_allowed") is False, \
+            "a delta was allowed to start while the search index was being verified"
+        m._rebuilding.discard(key)
+
+    def test_every_early_return_releases_the_bucket(self, app):
+        """Reserving early must not strand the key when no rebuild is needed."""
+        m = _main_module()
+        bucket, key = "racebkt2", "default:racebkt2"
+        for suffix in ("", "-wal", "-shm"):
+            try: os.remove(m._db_path(bucket, "default") + suffix)
+            except FileNotFoundError: pass
+        m._init_db(bucket, "default")
+        with m._get_db(bucket, "default") as db:   # already current => early return, no rebuild
+            db.execute("UPDATE crawl_status SET status='complete', fts_ready_gen=3, current_crawl_gen=3")
+            db.commit()
+        m._rebuilding.discard(key)
+        with patch.object(m, "_fts_healthy", lambda db: True):
+            assert m._ensure_fts_ready(bucket, "default") is None
+        assert key not in m._rebuilding, "bucket left reserved after an early return"

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1390,3 +1390,40 @@ class TestRebuildDeltaRace:
         with patch.object(m, "_fts_healthy", lambda db: True):
             assert m._ensure_fts_ready(bucket, "default") is None
         assert key not in m._rebuilding, "bucket left reserved after an early return"
+
+    def test_a_delta_already_running_blocks_the_readiness_check(self, app):
+        """The inverse race: startup queues 22 checks onto a 4-worker pool, so a bucket can start a
+        delta while its own check is still queued. When the worker finally runs it must not rebuild
+        underneath the delta."""
+        m = _main_module()
+        bucket, key = "racebkt3", "default:racebkt3"
+        for suffix in ("", "-wal", "-shm"):
+            try: os.remove(m._db_path(bucket, "default") + suffix)
+            except FileNotFoundError: pass
+        m._init_db(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            db.execute("UPDATE crawl_status SET status='complete', fts_ready_gen=1, current_crawl_gen=9")
+            db.commit()
+        m._rebuilding.discard(key)
+        m._crawling[key] = time.time()          # a delta started while this check sat in the queue
+        started = []
+        try:
+            with patch.object(m, "_rebuild_fts_async", lambda b, e, done=None: started.append(b)):
+                m._ensure_fts_ready(bucket, "default")
+            assert started == [], "rebuilt underneath a running delta"
+            assert key not in m._rebuilding
+        finally:
+            m._crawling.pop(key, None)
+
+    def test_reservation_happens_at_submit_not_at_worker_start(self, app):
+        """Reserving only when the worker starts leaves the queue window open."""
+        m = _main_module()
+        key = "default:racebkt4"
+        m._rebuilding.discard(key); m._crawling.pop(key, None)
+        assert m._reserve_rebuild(key) is True
+        try:
+            # while reserved, neither a delta nor a second rebuild may claim the bucket
+            assert m._queue_delta_crawl("racebkt4", "default") is False
+            assert m._reserve_rebuild(key) is False
+        finally:
+            m._rebuilding.discard(key)

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -456,8 +456,12 @@ class TestAsyncFTSRebuild:
         source = inspect.getsource(_rebuild_fts_async)
         assert "Thread" in source
         assert "daemon=True" in source
-        body = inspect.getsource(sys.modules["main"]._rebuild_fts_locked)
+        m = sys.modules["main"]
+        # The swap lives in its own helper so the bucket write lock wraps exactly the transaction.
+        body = inspect.getsource(m._rebuild_fts_locked) + inspect.getsource(m._fts_swap)
         assert "objects_fts_new" in body and "RENAME TO objects_fts" in body and "FTS_REBUILD_CHUNK" in body   # shadow-table, bounded-memory rebuild
+        assert "_write_lock" in inspect.getsource(m._rebuild_fts_locked), \
+            "the swap must hold the bucket write lock, or a concurrent delta races it in SQLite"
 
     def test_fts_rebuild_runs_in_background(self):
         """Test that _rebuild_fts_async actually rebuilds the FTS index."""


### PR DESCRIPTION
First production findings from 3.7.0. Three deltas failed with `database is locked` during the first boot, when every bucket's search index is verified at once.

## Cause

Two races between the search-index rebuild and a delta on the same bucket. Both are code, neither is environmental — the PVC is not slow, a 525k-object bucket rebuilt in 23.9 s, in line with the lab.

**Delta starting during the check.** `_queue_delta_crawl` declines while a bucket sits in `_rebuilding`, but `_ensure_fts_ready` only added it *after* the integrity check, and that check reads the whole catalogue.

**The check starting during a delta.** Startup submits one readiness check per bucket onto a four-worker pool, so a bucket can begin a delta while its own check is still queued. The check consulted `_rebuilding` but never `_crawling`, so it rebuilt underneath the running delta.

**The swap did not take the bucket write lock.** It runs `BEGIN IMMEDIATE` and holds SQLite's write lock through a catch-up insert, a `DROP TABLE` of a multi-million-row FTS table, a rename and trigger recreation. On a 10M-object bucket that outlasts `busy_timeout` (30 s), so a concurrent delta raced it in SQLite rather than queueing behind it in process.

## Fix

`_reserve_rebuild` claims a bucket only when no crawl, delta or other rebuild owns it. Startup reserves **before submitting**, not when the worker starts, and releases if submit fails. Every path that decides no rebuild is needed releases the reservation. The swap moved into `_fts_swap` so the per-bucket write lock wraps exactly the transaction, and a concurrent delta waits instead of erroring.

## Diagnostics

Truncated discovery now names the folder and the bound:

```
Delta discovery bound hit at 'druid/segments/<ds>/': still more results
after 3 pages of 1000 entries; raise DELTA_NODE_MAX_PAGES to cover it
```

Deliberately phrased as entries, not children: `MaxKeys` counts objects and rolled-up prefixes together, so the page budget does not convert to a child count. All the bound proves is that results remained.

That is the separate open issue: `druid-lw-prod` still truncates because its real fan-out exceeds the 3 pages sized against the lab's 2,500. Raising `DELTA_NODE_MAX_PAGES` is an env change needing no new image; this logging makes the right value measurable rather than guessed.

## Tests

`TestRebuildDeltaRace`, four cases, each verified to fail against the code it fixes:

- a delta queued from inside the integrity check is declined — fails on pre-fix code with *"a delta was allowed to start while the search index was being verified"*
- a check whose bucket already has a delta running does not rebuild — fails on the first revision of this PR with *"rebuilt underneath a running delta"*
- early returns do not strand the reservation
- a reserved bucket rejects both a delta and a second rebuild

The existing rebuild source test now also asserts the swap holds the write lock.

CI: backend **177 passed, 2 skipped** (the two skips need a built frontend, absent in a bare checkout). Browser critical path 60 passed.

## Not included

The delta path still has no sequential retry, unlike the full crawl. With both races closed that should be unnecessary, but it remains the reason one collision discards a whole delta rather than one prefix.