### PR TITLE
fix(crawler): a stalled search-index rebuild no longer freezes its bucket

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to Sairo are documented here. This project uses [Semantic Ve
 
 ## [Unreleased]
 
+### Fixed
+
+- **A bucket whose search-index rebuild never finished stopped being crawled at all.** `_rebuilding`
+  had no timestamp and no ceiling — unlike a crawl, which has both — so a rebuild that hung left the
+  bucket refused by every later crawl and delta for the life of the process. Observed in production:
+  one 12,479-object bucket went over an hour with zero crawls and zero deltas while the other 24 stayed
+  fresh. A rebuild is now abandoned after `REBUILD_MAX_DURATION` (default 2 h, the same ceiling a crawl
+  already had) so the scheduler can make progress; the bucket's own rebuild lock still serialises any
+  later rebuild against the orphan.
+- **The search-index health probe could block indefinitely.** A corrupt index makes an ordinary scan run
+  without end, which hung the crawl-status endpoint for that bucket — the poll behind the UI's index
+  state — with no timeout at any layer. The probe is now bounded by `FTS_PROBE_MS` (default 10 s) using
+  SQLite's own progress handler; an index that cannot be verified reads as unhealthy and is rebuilt,
+  rather than stalling the caller.
+- The same probe counted every row in the bucket to decide whether any objects existed. At 10M keys that
+  full scan cost seconds on the status path; it is now a constant-time existence check.
+
 ## [3.7.0] - 2026-09-10
 
 ### Rollout

--- a/backend/main.py
+++ b/backend/main.py
@@ -6,6 +6,7 @@ import os
 import secrets
 import sqlite3
 from urllib.parse import urlparse
+import itertools
 import threading
 import shutil
 import time
@@ -1256,7 +1257,8 @@ def _disk_low():
         return u.total > 0 and (u.free * 100.0 / u.total) < MIN_FREE_DISK_PCT
     except Exception:
         return False
-_rebuilding = {}  # crawl_key -> start time of the in-progress rebuild (blocks a colliding recrawl)
+_rebuilding = {}  # crawl_key -> (token, start time) of the in-progress rebuild (blocks a colliding recrawl)
+_rebuild_seq = itertools.count(1)  # reservation tokens, so a late release cannot clear a replacement's claim
 _fts_rebuild_locks = {}  # crawl_key -> Lock: one FTS rebuild per bucket at a time (guarded by _crawl_lock)
 _crawl_lock = threading.Lock()
 _CRAWL_MAX_DURATION = 7200  # 2 hours — if a crawl exceeds this, force-release the lock
@@ -1504,28 +1506,41 @@ def _rebuild_blocked(crawl_key):
     Past _REBUILD_MAX_DURATION the reservation is abandoned so the scheduler can make progress; the
     orphaned rebuild thread still holds the bucket's own _fts_rebuild_locks entry, so a later
     rebuild waits for it rather than corrupting the shadow table."""
-    started = _rebuilding.get(crawl_key)
-    if started is None:
+    held = _rebuilding.get(crawl_key)
+    if held is None:
         return False
-    if time.time() - started <= _REBUILD_MAX_DURATION:
+    if time.time() - held[1] <= _REBUILD_MAX_DURATION:
         return True
-    _rebuilding.pop(crawl_key, None)
+    del _rebuilding[crawl_key]
     log.warning("Search-index rebuild for %s has run for over %d min with no result; releasing the "
                 "bucket so crawls can resume", crawl_key, int(_REBUILD_MAX_DURATION // 60))
     return False
 
 
 def _reserve_rebuild(crawl_key):
-    """Claim a bucket for a search-index rebuild. False when a crawl, a delta or another rebuild
-    already owns it. Callers that get True must release it."""
+    """Claim a bucket for a search-index rebuild. Returns a token the caller must release with, or
+    None when a crawl, a delta or another rebuild already owns it."""
     with _crawl_lock:
         if _rebuild_blocked(crawl_key) or crawl_key in _crawling:
-            return False
-        _rebuilding[crawl_key] = time.time()
-        return True
+            return None
+        token = next(_rebuild_seq)
+        _rebuilding[crawl_key] = (token, time.time())
+        return token
 
 
-def _ensure_fts_ready(bucket, endpoint_id=None, reserved=False):
+def _release_rebuild(crawl_key, token):
+    """Drop a reservation, but only the one this caller made.
+
+    An expired rebuild can still return after the ceiling handed its bucket to a replacement, and a
+    blind delete would then strip the replacement's claim and let a crawl run underneath it. The
+    token makes release a compare-and-delete, so a late finisher clears nothing."""
+    with _crawl_lock:
+        held = _rebuilding.get(crawl_key)
+        if held is not None and held[0] == token:
+            del _rebuilding[crawl_key]
+
+
+def _ensure_fts_ready(bucket, endpoint_id=None, token=None):
     """Startup repair for a served index whose search generation is absent or stale.
 
     Databases from before fts_ready_gen existed have NULL: the marker is backfilled only after SQLite's
@@ -1540,11 +1555,12 @@ def _ensure_fts_ready(bucket, endpoint_id=None, reserved=False):
     # reserving afterwards left a window: a delta started during the check, the rebuild then took
     # the write lock for its swap, and the delta died with "database is locked" (seen in production
     # on the first boot after 3.7.0, when every bucket is verified at once).
-    if not reserved and not _reserve_rebuild(crawl_key):
-        return None
+    if token is None:
+        token = _reserve_rebuild(crawl_key)
+        if token is None:
+            return None
     def _release():
-        with _crawl_lock:
-            _rebuilding.pop(crawl_key, None)
+        _release_rebuild(crawl_key, token)
     try:
         with _get_db(bucket, eid) as db:
             row = db.execute("SELECT status, fts_ready_gen, current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
@@ -1573,9 +1589,15 @@ def _sqlite_deadline(db, ms):
     bucket and hanging every crawl-status poll on it). The handler runs between VM steps, so the
     statement raises instead of blocking the caller forever."""
     end = time.monotonic() + ms / 1000.0
-    db.set_progress_handler(lambda: time.monotonic() > end, 2000)
+    fired = []
+    def _abort():
+        if time.monotonic() > end:
+            fired.append(True)
+            return 1
+        return 0
+    db.set_progress_handler(_abort, 2000)
     try:
-        yield
+        yield fired          # non-empty once the deadline aborted a statement
     finally:
         db.set_progress_handler(None, 0)
 
@@ -1587,7 +1609,7 @@ def _fts_healthy(db):
     Bounded by FTS_PROBE_MS: a probe that cannot finish is not evidence of health, so it reads as
     unhealthy and the caller rebuilds — never as a hang."""
     try:
-        with _sqlite_deadline(db, FTS_PROBE_MS):
+        with _sqlite_deadline(db, FTS_PROBE_MS) as timed_out:
             if not db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='objects_fts'").fetchone():
                 return False
             db.execute("SELECT rowid FROM objects_fts LIMIT 1").fetchall()
@@ -1595,8 +1617,13 @@ def _fts_healthy(db):
             # the whole primary key — seconds at 10M rows, which would push a healthy large bucket
             # past the deadline and trigger a needless multi-minute rebuild.
             if not db.execute("SELECT 1 FROM objects LIMIT 1").fetchone():
-                return True
-            return not _fts_is_empty(db)
+                healthy = True
+            else:
+                healthy = not _fts_is_empty(db)
+            # A probe that ran out of time proves nothing. Checking the flag is not belt-and-braces:
+            # _fts_is_empty() answers False on ANY exception, the deadline's own abort included, and
+            # `not False` would certify exactly the unverifiable index this bound exists to catch.
+            return healthy and not timed_out
     except Exception:
         return False
 
@@ -2175,7 +2202,8 @@ def _run_crawl(bucket, endpoint_id=None):
             _write_locks.pop(crawl_key, None)
             _crawl_progress_ts.pop(crawl_key, None)
             if crawl_ok:
-                _rebuilding[crawl_key] = time.time()
+                rebuild_token = next(_rebuild_seq)
+                _rebuilding[crawl_key] = (rebuild_token, time.time())
                 # Record full-crawl timing so the scheduler can decide between a
                 # cheap full recrawl (small buckets) and fast delta crawls (large).
                 m = _crawl_meta.setdefault(crawl_key, {})
@@ -2202,8 +2230,7 @@ def _run_crawl(bucket, endpoint_id=None):
     if crawl_ok:
         def _do_rebuilds():
             def _release():
-                with _crawl_lock:
-                    _rebuilding.pop(crawl_key, None)
+                _release_rebuild(crawl_key, rebuild_token)
             handed_off = False
             try:
                 # Run the fast metadata rebuilds FIRST and grab the writer quickly.
@@ -3088,12 +3115,12 @@ def startup():
                             # Reserve before submitting, not when the worker starts: these checks
                             # share a 4-worker pool, so a queued bucket could begin a delta first
                             # and then collide when its check finally ran.
-                            if _reserve_rebuild(f"{eid}:{name}"):
+                            _tok = _reserve_rebuild(f"{eid}:{name}")
+                            if _tok is not None:
                                 try:
-                                    _rebuild_pool.submit(_ensure_fts_ready, name, eid, reserved=True)
+                                    _rebuild_pool.submit(_ensure_fts_ready, name, eid, token=_tok)
                                 except Exception:
-                                    with _crawl_lock:
-                                        _rebuilding.pop(f"{eid}:{name}", None)
+                                    _release_rebuild(f"{eid}:{name}", _tok)
                                     raise
                             log.info("Seeded schedule for %s:%s from existing index (%s objects); will keep fresh via scheduler",
                                      eid, name, f"{total:,}")

--- a/backend/main.py
+++ b/backend/main.py
@@ -1256,10 +1256,12 @@ def _disk_low():
         return u.total > 0 and (u.free * 100.0 / u.total) < MIN_FREE_DISK_PCT
     except Exception:
         return False
-_rebuilding = set()  # crawl_keys whose post-crawl rebuild is in progress (blocks a colliding recrawl)
+_rebuilding = {}  # crawl_key -> start time of the in-progress rebuild (blocks a colliding recrawl)
 _fts_rebuild_locks = {}  # crawl_key -> Lock: one FTS rebuild per bucket at a time (guarded by _crawl_lock)
 _crawl_lock = threading.Lock()
 _CRAWL_MAX_DURATION = 7200  # 2 hours — if a crawl exceeds this, force-release the lock
+_REBUILD_MAX_DURATION = int(os.environ.get("REBUILD_MAX_DURATION", "7200"))  # 2 h, as for a crawl — a rebuild past this is abandoned so the bucket can crawl again
+FTS_PROBE_MS = int(os.environ.get("FTS_PROBE_MS", "10000"))  # cap on the search-index health probe (3 O(1) queries); only a pathological index reaches it
 
 
 def _crawl_prefix(bucket, prefix, max_retries=3, endpoint_id=None, batch_callback=None, batch_size=10000, should_stop=None):
@@ -1492,13 +1494,34 @@ def _seed_from_existing(prev_status, total, dur):
     return total > 0 and dur > 0 and prev_status == "complete"
 
 
+def _rebuild_blocked(crawl_key):
+    """True while a rebuild owns this bucket. Caller must hold _crawl_lock.
+
+    A rebuild that never returns used to freeze its bucket until the process restarted: _rebuilding
+    had no timestamp and no escape, unlike _crawling (_CRAWL_STALL_SECONDS/_CRAWL_MAX_DURATION), so
+    both _queue_crawl and _queue_delta_crawl refused forever. Seen in production on a 12k-object
+    bucket: zero crawls and zero deltas for over an hour while every other bucket stayed fresh.
+    Past _REBUILD_MAX_DURATION the reservation is abandoned so the scheduler can make progress; the
+    orphaned rebuild thread still holds the bucket's own _fts_rebuild_locks entry, so a later
+    rebuild waits for it rather than corrupting the shadow table."""
+    started = _rebuilding.get(crawl_key)
+    if started is None:
+        return False
+    if time.time() - started <= _REBUILD_MAX_DURATION:
+        return True
+    _rebuilding.pop(crawl_key, None)
+    log.warning("Search-index rebuild for %s has run for over %d min with no result; releasing the "
+                "bucket so crawls can resume", crawl_key, int(_REBUILD_MAX_DURATION // 60))
+    return False
+
+
 def _reserve_rebuild(crawl_key):
     """Claim a bucket for a search-index rebuild. False when a crawl, a delta or another rebuild
     already owns it. Callers that get True must release it."""
     with _crawl_lock:
-        if crawl_key in _rebuilding or crawl_key in _crawling:
+        if _rebuild_blocked(crawl_key) or crawl_key in _crawling:
             return False
-        _rebuilding.add(crawl_key)
+        _rebuilding[crawl_key] = time.time()
         return True
 
 
@@ -1521,7 +1544,7 @@ def _ensure_fts_ready(bucket, endpoint_id=None, reserved=False):
         return None
     def _release():
         with _crawl_lock:
-            _rebuilding.discard(crawl_key)
+            _rebuilding.pop(crawl_key, None)
     try:
         with _get_db(bucket, eid) as db:
             row = db.execute("SELECT status, fts_ready_gen, current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
@@ -1543,16 +1566,37 @@ def _ensure_fts_ready(bucket, endpoint_id=None, reserved=False):
     return _rebuild_fts_async(bucket, eid, done=_release)
 
 
+@contextmanager
+def _sqlite_deadline(db, ms):
+    """Abort SQLite work in this block once `ms` have passed. A corrupt FTS index makes an ordinary
+    scan run unboundedly (production: a 12k-object bucket whose probe never returned, freezing the
+    bucket and hanging every crawl-status poll on it). The handler runs between VM steps, so the
+    statement raises instead of blocking the caller forever."""
+    end = time.monotonic() + ms / 1000.0
+    db.set_progress_handler(lambda: time.monotonic() > end, 2000)
+    try:
+        yield
+    finally:
+        db.set_progress_handler(None, 0)
+
+
 def _fts_healthy(db):
     """The search index exists, is readable and is not empty while objects exist. A generation
-    marker alone is not proof: a missing or unreadable FTS table must never read as ready."""
+    marker alone is not proof: a missing or unreadable FTS table must never read as ready.
+
+    Bounded by FTS_PROBE_MS: a probe that cannot finish is not evidence of health, so it reads as
+    unhealthy and the caller rebuilds — never as a hang."""
     try:
-        if not db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='objects_fts'").fetchone():
-            return False
-        db.execute("SELECT rowid FROM objects_fts LIMIT 1").fetchall()
-        if db.execute("SELECT COUNT(*) FROM objects").fetchone()[0] == 0:
-            return True
-        return not _fts_is_empty(db)
+        with _sqlite_deadline(db, FTS_PROBE_MS):
+            if not db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='objects_fts'").fetchone():
+                return False
+            db.execute("SELECT rowid FROM objects_fts LIMIT 1").fetchall()
+            # EXISTS, not COUNT(*): the probe only asks "are there any objects", and counting scans
+            # the whole primary key — seconds at 10M rows, which would push a healthy large bucket
+            # past the deadline and trigger a needless multi-minute rebuild.
+            if not db.execute("SELECT 1 FROM objects LIMIT 1").fetchone():
+                return True
+            return not _fts_is_empty(db)
     except Exception:
         return False
 
@@ -2131,7 +2175,7 @@ def _run_crawl(bucket, endpoint_id=None):
             _write_locks.pop(crawl_key, None)
             _crawl_progress_ts.pop(crawl_key, None)
             if crawl_ok:
-                _rebuilding.add(crawl_key)
+                _rebuilding[crawl_key] = time.time()
                 # Record full-crawl timing so the scheduler can decide between a
                 # cheap full recrawl (small buckets) and fast delta crawls (large).
                 m = _crawl_meta.setdefault(crawl_key, {})
@@ -2159,7 +2203,7 @@ def _run_crawl(bucket, endpoint_id=None):
         def _do_rebuilds():
             def _release():
                 with _crawl_lock:
-                    _rebuilding.discard(crawl_key)
+                    _rebuilding.pop(crawl_key, None)
             handed_off = False
             try:
                 # Run the fast metadata rebuilds FIRST and grab the writer quickly.
@@ -2814,7 +2858,7 @@ def _queue_delta_crawl(bucket, endpoint_id=None):
     eid = endpoint_id or "default"
     crawl_key = f"{eid}:{bucket}"
     with _crawl_lock:
-        if crawl_key in _rebuilding or crawl_key in _crawling:
+        if _rebuild_blocked(crawl_key) or crawl_key in _crawling:
             return False
         _crawling[crawl_key] = time.time()  # reuse crawl lock to block colliding full crawls
 
@@ -2880,7 +2924,7 @@ def _queue_crawl(bucket, endpoint_id=None):
         # Don't start a crawl while this bucket's post-crawl rebuild is still
         # running — they would contend on the single SQLite writer and the
         # rebuild would lose, leaving folder_stats/prefix_children empty.
-        if crawl_key in _rebuilding:
+        if _rebuild_blocked(crawl_key):
             return False
         started_at = _crawling.get(crawl_key)
         if started_at:
@@ -3049,7 +3093,7 @@ def startup():
                                     _rebuild_pool.submit(_ensure_fts_ready, name, eid, reserved=True)
                                 except Exception:
                                     with _crawl_lock:
-                                        _rebuilding.discard(f"{eid}:{name}")
+                                        _rebuilding.pop(f"{eid}:{name}", None)
                                     raise
                             log.info("Seeded schedule for %s:%s from existing index (%s objects); will keep fresh via scheduler",
                                      eid, name, f"{total:,}")

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -13,6 +13,7 @@ import json
 import base64
 import hashlib
 import time
+import sqlite3
 from datetime import datetime, timezone, timedelta
 from unittest.mock import patch, MagicMock
 
@@ -1357,7 +1358,7 @@ class TestRebuildDeltaRace:
         with m._get_db(bucket, "default") as db:
             db.execute("UPDATE crawl_status SET status='complete', fts_ready_gen=1, current_crawl_gen=9")
             db.commit()
-        m._rebuilding.discard(key)
+        m._rebuilding.pop(key, None)
 
         during_check = {}
         real_healthy = m._fts_healthy
@@ -1373,7 +1374,7 @@ class TestRebuildDeltaRace:
 
         assert during_check.get("delta_allowed") is False, \
             "a delta was allowed to start while the search index was being verified"
-        m._rebuilding.discard(key)
+        m._rebuilding.pop(key, None)
 
     def test_every_early_return_releases_the_bucket(self, app):
         """Reserving early must not strand the key when no rebuild is needed."""
@@ -1386,7 +1387,7 @@ class TestRebuildDeltaRace:
         with m._get_db(bucket, "default") as db:   # already current => early return, no rebuild
             db.execute("UPDATE crawl_status SET status='complete', fts_ready_gen=3, current_crawl_gen=3")
             db.commit()
-        m._rebuilding.discard(key)
+        m._rebuilding.pop(key, None)
         with patch.object(m, "_fts_healthy", lambda db: True):
             assert m._ensure_fts_ready(bucket, "default") is None
         assert key not in m._rebuilding, "bucket left reserved after an early return"
@@ -1404,7 +1405,7 @@ class TestRebuildDeltaRace:
         with m._get_db(bucket, "default") as db:
             db.execute("UPDATE crawl_status SET status='complete', fts_ready_gen=1, current_crawl_gen=9")
             db.commit()
-        m._rebuilding.discard(key)
+        m._rebuilding.pop(key, None)
         m._crawling[key] = time.time()          # a delta started while this check sat in the queue
         started = []
         try:
@@ -1419,11 +1420,134 @@ class TestRebuildDeltaRace:
         """Reserving only when the worker starts leaves the queue window open."""
         m = _main_module()
         key = "default:racebkt4"
-        m._rebuilding.discard(key); m._crawling.pop(key, None)
+        m._rebuilding.pop(key, None); m._crawling.pop(key, None)
         assert m._reserve_rebuild(key) is True
         try:
             # while reserved, neither a delta nor a second rebuild may claim the bucket
             assert m._queue_delta_crawl("racebkt4", "default") is False
             assert m._reserve_rebuild(key) is False
         finally:
-            m._rebuilding.discard(key)
+            m._rebuilding.pop(key, None)
+
+
+class TestRebuildStallGuard:
+    """Production froze a 12,479-object bucket for over an hour: its startup search-index repair
+    never returned, and `_rebuilding` — unlike `_crawling`, which has _CRAWL_STALL_SECONDS and
+    _CRAWL_MAX_DURATION — had no timestamp and no escape, so _queue_crawl and _queue_delta_crawl
+    both refused for the life of the process. Every other bucket stayed fresh; that one never
+    crawled again. The probe that hung it was also unbounded."""
+
+    def test_a_rebuild_that_never_returns_stops_blocking_the_bucket(self, app):
+        m = _main_module()
+        key = "default:stallbkt"
+        m._rebuilding.pop(key, None); m._crawling.pop(key, None)
+        try:
+            with m._crawl_lock:
+                m._rebuilding[key] = time.time()
+            assert m._queue_crawl("stallbkt", "default") is False, \
+                "a running rebuild must still block a crawl"
+            with m._crawl_lock:                       # same rebuild, now past the ceiling
+                m._rebuilding[key] = time.time() - m._REBUILD_MAX_DURATION - 1
+            with m._crawl_lock:
+                assert m._rebuild_blocked(key) is False, \
+                    "a rebuild past _REBUILD_MAX_DURATION must not block the bucket forever"
+            assert key not in m._rebuilding, "the abandoned reservation must be dropped"
+        finally:
+            m._rebuilding.pop(key, None); m._crawling.pop(key, None)
+
+    def test_a_stalled_rebuild_also_releases_the_delta_path(self, app):
+        m = _main_module()
+        key = "default:stallbkt2"
+        m._rebuilding.pop(key, None); m._crawling.pop(key, None)
+        try:
+            with m._crawl_lock:
+                m._rebuilding[key] = time.time() - m._REBUILD_MAX_DURATION - 1
+            assert m._queue_delta_crawl("stallbkt2", "default") is not False, \
+                "delta stayed blocked by a rebuild that will never finish"
+        finally:
+            m._rebuilding.pop(key, None); m._crawling.pop(key, None)
+
+    def test_a_healthy_rebuild_is_never_abandoned_early(self, app):
+        m = _main_module()
+        key = "default:stallbkt3"
+        m._rebuilding.pop(key, None)
+        try:
+            with m._crawl_lock:
+                m._rebuilding[key] = time.time() - m._REBUILD_MAX_DURATION + 60
+                assert m._rebuild_blocked(key) is True
+            assert m._reserve_rebuild(key) is False, "a second rebuild claimed a live bucket"
+        finally:
+            m._rebuilding.pop(key, None)
+
+    def test_health_probe_is_bounded_and_reports_unhealthy_rather_than_hanging(self, app):
+        """A corrupt index makes an ordinary scan run without end. The probe must give up and read
+        as unhealthy (so the caller rebuilds), never block the caller."""
+        m = _main_module()
+        real = sqlite3.connect(":memory:")
+        real.row_factory = sqlite3.Row
+        real.execute("CREATE TABLE objects (key TEXT)")
+        real.execute("INSERT INTO objects VALUES ('a')")
+        real.execute("CREATE VIRTUAL TABLE objects_fts USING fts5(key, tokenize='trigram')")
+        forever = ("WITH RECURSIVE c(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM c WHERE i<100000000) "
+                   "SELECT COUNT(*) FROM c")
+
+        class CorruptIndex:
+            """Any read of objects_fts never finishes, as on the production bucket."""
+            def __init__(self, c): self._c = c
+            def execute(self, sql, *a, **k):
+                if "objects_fts" in sql and "sqlite_master" not in sql:
+                    return self._c.execute(forever)
+                return self._c.execute(sql, *a, **k)
+            def __getattr__(self, n): return getattr(self._c, n)
+
+        with patch.object(m, "FTS_PROBE_MS", 1500):
+            t0 = time.monotonic()
+            result = m._fts_healthy(CorruptIndex(real))
+            elapsed = time.monotonic() - t0
+        assert elapsed < 5.0, f"health probe ran unbounded ({elapsed:.1f}s)"
+        assert result is False, "an index that cannot be verified must not read as healthy"
+
+    def test_probe_does_not_scan_the_whole_table(self, app):
+        """The probe must stay O(1) in bucket size. It once counted every row, which at 10M keys
+        takes seconds — enough to trip its own deadline and trigger a needless full rebuild."""
+        m = _main_module()
+        big = sqlite3.connect(":memory:")
+        big.execute("CREATE TABLE objects (key TEXT PRIMARY KEY)")
+        big.executemany("INSERT INTO objects VALUES (?)", [(f"k/{i:07d}",) for i in range(200_000)])
+        big.execute("CREATE VIRTUAL TABLE objects_fts USING fts5(key, content='objects', tokenize='trigram')")
+        big.execute("INSERT INTO objects_fts(rowid, key) SELECT rowid, key FROM objects")
+        big.commit()
+        t0 = time.monotonic()
+        assert m._fts_healthy(big) is True
+        elapsed = time.monotonic() - t0
+        assert elapsed < 1.0, f"probe scales with bucket size ({elapsed:.2f}s at 200k rows)"
+
+    def test_probe_still_classifies_real_indexes_correctly(self, app):
+        """The deadline must not change any healthy/unhealthy verdict."""
+        m = _main_module()
+        empty = sqlite3.connect(":memory:")
+        empty.execute("CREATE TABLE objects (key TEXT)")
+        empty.execute("CREATE VIRTUAL TABLE objects_fts USING fts5(key, content='objects', tokenize='trigram')")
+        assert m._fts_healthy(empty) is True, "empty bucket with an index is healthy"
+
+        populated = sqlite3.connect(":memory:")
+        populated.execute("CREATE TABLE objects (key TEXT)")
+        populated.execute("CREATE VIRTUAL TABLE objects_fts USING fts5(key, content='objects', tokenize='trigram')")
+        populated.execute("INSERT INTO objects VALUES ('a/b.txt')")
+        populated.execute("INSERT INTO objects_fts(rowid, key) SELECT rowid, key FROM objects")
+        populated.commit()
+        assert m._fts_healthy(populated) is True
+
+        missing = sqlite3.connect(":memory:")
+        missing.execute("CREATE TABLE objects (key TEXT)")
+        missing.execute("INSERT INTO objects VALUES ('x')")
+        assert m._fts_healthy(missing) is False
+
+    def test_deadline_does_not_leak_onto_the_connection(self, app):
+        """The progress handler must be cleared, or every later query on that connection aborts."""
+        m = _main_module()
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE TABLE objects (key TEXT)")
+        m._fts_healthy(conn)
+        conn.execute("WITH RECURSIVE c(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM c WHERE i<300000) "
+                     "SELECT COUNT(*) FROM c").fetchall()

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1421,11 +1421,11 @@ class TestRebuildDeltaRace:
         m = _main_module()
         key = "default:racebkt4"
         m._rebuilding.pop(key, None); m._crawling.pop(key, None)
-        assert m._reserve_rebuild(key) is True
+        assert m._reserve_rebuild(key) is not None
         try:
             # while reserved, neither a delta nor a second rebuild may claim the bucket
             assert m._queue_delta_crawl("racebkt4", "default") is False
-            assert m._reserve_rebuild(key) is False
+            assert m._reserve_rebuild(key) is None
         finally:
             m._rebuilding.pop(key, None)
 
@@ -1443,11 +1443,11 @@ class TestRebuildStallGuard:
         m._rebuilding.pop(key, None); m._crawling.pop(key, None)
         try:
             with m._crawl_lock:
-                m._rebuilding[key] = time.time()
+                m._rebuilding[key] = (next(m._rebuild_seq), time.time())
             assert m._queue_crawl("stallbkt", "default") is False, \
                 "a running rebuild must still block a crawl"
             with m._crawl_lock:                       # same rebuild, now past the ceiling
-                m._rebuilding[key] = time.time() - m._REBUILD_MAX_DURATION - 1
+                m._rebuilding[key] = (next(m._rebuild_seq), time.time() - m._REBUILD_MAX_DURATION - 1)
             with m._crawl_lock:
                 assert m._rebuild_blocked(key) is False, \
                     "a rebuild past _REBUILD_MAX_DURATION must not block the bucket forever"
@@ -1461,7 +1461,7 @@ class TestRebuildStallGuard:
         m._rebuilding.pop(key, None); m._crawling.pop(key, None)
         try:
             with m._crawl_lock:
-                m._rebuilding[key] = time.time() - m._REBUILD_MAX_DURATION - 1
+                m._rebuilding[key] = (next(m._rebuild_seq), time.time() - m._REBUILD_MAX_DURATION - 1)
             assert m._queue_delta_crawl("stallbkt2", "default") is not False, \
                 "delta stayed blocked by a rebuild that will never finish"
         finally:
@@ -1473,9 +1473,9 @@ class TestRebuildStallGuard:
         m._rebuilding.pop(key, None)
         try:
             with m._crawl_lock:
-                m._rebuilding[key] = time.time() - m._REBUILD_MAX_DURATION + 60
+                m._rebuilding[key] = (next(m._rebuild_seq), time.time() - m._REBUILD_MAX_DURATION + 60)
                 assert m._rebuild_blocked(key) is True
-            assert m._reserve_rebuild(key) is False, "a second rebuild claimed a live bucket"
+            assert m._reserve_rebuild(key) is None, "a second rebuild claimed a live bucket"
         finally:
             m._rebuilding.pop(key, None)
 
@@ -1551,3 +1551,60 @@ class TestRebuildStallGuard:
         m._fts_healthy(conn)
         conn.execute("WITH RECURSIVE c(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM c WHERE i<300000) "
                      "SELECT COUNT(*) FROM c").fetchall()
+
+    def test_late_release_cannot_clear_a_replacement_reservation(self, app):
+        """An expired rebuild can still return after the ceiling handed its bucket to a
+        replacement. A blind delete on release strips the replacement's claim and lets a crawl run
+        underneath it, which is the collision the reservation exists to prevent."""
+        m = _main_module()
+        key = "default:handoverbkt"
+        m._rebuilding.pop(key, None); m._crawling.pop(key, None)
+        try:
+            first = m._reserve_rebuild(key)
+            assert first is not None
+            # first overruns; the ceiling hands the bucket on
+            with m._crawl_lock:
+                m._rebuilding[key] = (first, time.time() - m._REBUILD_MAX_DURATION - 1)
+                assert m._rebuild_blocked(key) is False
+            second = m._reserve_rebuild(key)
+            assert second is not None and second != first, "replacement could not claim the bucket"
+
+            m._release_rebuild(key, first)          # the late finisher returns at last
+
+            assert key in m._rebuilding, "a late release cleared the replacement's reservation"
+            with m._crawl_lock:
+                assert m._rebuild_blocked(key) is True
+            assert m._queue_delta_crawl("handoverbkt", "default") is False, \
+                "a delta started underneath a live rebuild"
+            m._release_rebuild(key, second)         # the real owner can still release
+            assert key not in m._rebuilding
+        finally:
+            m._rebuilding.pop(key, None); m._crawling.pop(key, None)
+
+    def test_probe_timeout_inside_fts_is_empty_is_not_reported_healthy(self, app):
+        """_fts_is_empty() answers False on ANY exception, the deadline's own abort included, and
+        `not False` reads as healthy — certifying the very index the bound exists to catch."""
+        m = _main_module()
+        real = sqlite3.connect(":memory:")
+        real.row_factory = sqlite3.Row
+        real.execute("CREATE TABLE objects (key TEXT)")
+        real.execute("INSERT INTO objects VALUES ('a')")
+        real.execute("CREATE VIRTUAL TABLE objects_fts USING fts5(key, tokenize='trigram')")
+        forever = ("WITH RECURSIVE c(i) AS (SELECT 1 UNION ALL SELECT i+1 FROM c WHERE i<100000000) "
+                   "SELECT COUNT(*) FROM c")
+
+        class SlowOnlyInIsEmpty:
+            """Everything answers fast except the objects_fts_data read inside _fts_is_empty()."""
+            def __init__(self, c): self._c = c
+            def execute(self, sql, *a, **k):
+                if "objects_fts_data" in sql:
+                    return self._c.execute(forever)
+                return self._c.execute(sql, *a, **k)
+            def __getattr__(self, n): return getattr(self._c, n)
+
+        with patch.object(m, "FTS_PROBE_MS", 1500):
+            t0 = time.monotonic()
+            result = m._fts_healthy(SlowOnlyInIsEmpty(real))
+            elapsed = time.monotonic() - t0
+        assert elapsed < 5.0, f"probe ran unbounded ({elapsed:.1f}s)"
+        assert result is False, "a timed-out probe was reported as a healthy index"

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1021,7 +1021,7 @@ class TestTruthfulStates:
         with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
             m._run_crawl(bucket, "default")
         with m._crawl_lock:
-            m._rebuilding.discard(f"default:{bucket}")   # the rebuild pool was mocked, so release the post-crawl marker by hand
+            m._rebuilding.pop(f"default:{bucket}", None)   # the rebuild pool was mocked, so release the post-crawl marker by hand
         with m._get_db(bucket, "default") as db:
             before = dict(db.execute("SELECT status, last_crawl_end FROM crawl_status").fetchone())
         def boom(*a, **k): raise RuntimeError("SlowDown")
@@ -1043,7 +1043,7 @@ class TestTruthfulStates:
         with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
             m._run_crawl(bucket, "default")
         with m._crawl_lock:
-            m._rebuilding.discard(f"default:{bucket}")
+            m._rebuilding.pop(f"default:{bucket}", None)
         d = m.crawl_status(bucket, user={})
         assert d["status"] == "complete" and d["fts_ready_gen"] is None and d["rebuilding"] is True and d["search_ready"] is False, d
         assert m._fts_should_rebuild(bucket, "default", False) is True, "no committed rebuild for this generation → rebuild"
@@ -1072,7 +1072,7 @@ class TestTruthfulStates:
         meta = m._crawl_meta.get(key, {})
         assert "last_full" not in meta and meta.get("degraded_at"), meta   # scheduler retries after RECRAWL_INTERVAL, no delta-only period
         with m._crawl_lock:
-            m._rebuilding.discard(key)
+            m._rebuilding.pop(key, None)
         healthy = self._mk(m, bucket)
         with patch.object(m._s3_manager, "get_client", return_value=healthy), patch.object(m._rebuild_pool, "submit"):
             m._run_crawl(bucket, "default")
@@ -1093,7 +1093,7 @@ class TestTruthfulStates:
         with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
             m._run_crawl(bucket, "default")
         with m._crawl_lock:
-            m._rebuilding.discard(key)
+            m._rebuilding.pop(key, None)
         with m._get_db(bucket, "default") as db:
             end0 = db.execute("SELECT last_crawl_end FROM crawl_status").fetchone()[0]
         # degraded delta: one target failed
@@ -1165,7 +1165,7 @@ class TestTruthfulStates:
         with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
             m._run_crawl(bucket, "default")
         with m._crawl_lock:
-            m._rebuilding.discard(f"default:{bucket}")
+            m._rebuilding.pop(f"default:{bucket}", None)
         with m._get_db(bucket, "default") as db:
             end0 = db.execute("SELECT last_crawl_end FROM crawl_status").fetchone()[0]
             db.execute("UPDATE crawl_status SET status='error: AccessDenied', last_error='AccessDenied'"); db.commit()
@@ -1186,7 +1186,7 @@ class TestTruthfulStates:
         with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
             m._run_crawl(bucket, "default")
         with m._crawl_lock:
-            m._rebuilding.discard(f"default:{bucket}")
+            m._rebuilding.pop(f"default:{bucket}", None)
         # legacy database: the previous release built the index at completion but knew no marker.
         # Simulate: healthy index, fts_ready_gen NULL → verified backfill, no rebuild.
         m._rebuild_fts(bucket, "default")
@@ -1215,7 +1215,7 @@ class TestTruthfulStates:
         with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
             m._run_crawl(bucket, "default")
         with m._crawl_lock:
-            m._rebuilding.discard(f"default:{bucket}")
+            m._rebuilding.pop(f"default:{bucket}", None)
         m._rebuild_fts(bucket, "default")
         assert m.crawl_status(bucket, user={})["search_ready"] is True
         # marker says ready, but the index has been emptied underneath it
@@ -1265,7 +1265,7 @@ class TestTruthfulStates:
         with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
             m._run_crawl(bucket, "default")
         with m._crawl_lock:
-            m._rebuilding.discard(f"default:{bucket}")
+            m._rebuilding.pop(f"default:{bucket}", None)
         m._rebuild_fts(bucket, "default")   # generation N fully indexed
         with m._get_db(bucket, "default") as db:
             # catalogue moves to N+1 behind the index's back (triggers off, as during a crawl); marker NULL like a legacy DB
@@ -1319,7 +1319,7 @@ class TestTruthfulStates:
         with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
             m._run_crawl(bucket, "default")
         with m._crawl_lock:
-            m._rebuilding.discard(f"default:{bucket}")
+            m._rebuilding.pop(f"default:{bucket}", None)
         with m._get_db(bucket, "default") as db:
             end0 = db.execute("SELECT last_crawl_end FROM crawl_status").fetchone()[0]
         with patch.object(m, "_delta_crawl", return_value=(1, ["discovery"])), patch.object(m._crawl_pool, "submit", side_effect=lambda fn: fn()):
@@ -1338,7 +1338,7 @@ class TestTruthfulStates:
         with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
             m._run_crawl(bucket, "default")
         with m._crawl_lock:
-            m._rebuilding.discard(f"default:{bucket}")
+            m._rebuilding.pop(f"default:{bucket}", None)
         with m._get_db(bucket, "default") as db:
             db.execute("UPDATE crawl_status SET status='degraded', last_error='x'"); db.commit()
             before = dict(db.execute("SELECT status, last_crawl_end, last_error FROM crawl_status").fetchone())
@@ -1369,7 +1369,7 @@ class TestTruthfulStates:
         with patch.object(m._s3_manager, "get_client", return_value=self._mk(m, bucket)), patch.object(m._rebuild_pool, "submit"):
             m._run_crawl(bucket, "default")
         with m._crawl_lock:
-            m._rebuilding.discard(f"default:{bucket}")
+            m._rebuilding.pop(f"default:{bucket}", None)
         with m._get_db(bucket, "default") as db:
             end0 = db.execute("SELECT last_crawl_end FROM crawl_status").fetchone()[0]
         time.sleep(1.1)
@@ -1683,7 +1683,7 @@ class TestZeroWriteReconcile:
         layout["root.txt"] = 9
         self._crawl(m, bucket, layout)
         with m._crawl_lock:
-            m._rebuilding.discard(f"default:{bucket}")
+            m._rebuilding.pop(f"default:{bucket}", None)
         m._rebuild_fts(bucket, "default")           # the first crawl's rebuild pool was mocked: build + certify its index now
         written = []
         _finish = m._PrefixReconcile.finish
@@ -1900,7 +1900,7 @@ class TestZeroWriteReconcile:
         bucket = "zw-disklow"; m._init_db(bucket, "default")
         self._crawl(m, bucket, {"a/x1": 1})
         with m._crawl_lock:
-            m._rebuilding.discard(f"default:{bucket}")   # the mocked rebuild pool never released the post-crawl marker
+            m._rebuilding.pop(f"default:{bucket}", None)   # the mocked rebuild pool never released the post-crawl marker
         with patch.object(m, "_disk_low", return_value=True):
             assert m._queue_crawl(bucket, "default") is False
         with m._get_db(bucket, "default") as db:
@@ -1920,7 +1920,7 @@ class TestZeroWriteReconcile:
         layout = {"a/x1": 1, "b/y1": 2}
         self._crawl(m, bucket, layout)
         with m._crawl_lock:
-            m._rebuilding.discard(f"default:{bucket}")
+            m._rebuilding.pop(f"default:{bucket}", None)
         m._rebuild_fts(bucket, "default")                     # search index built and certified for gen 1
         layout["a/x2new"] = 3                                 # new object at the provider (trigram search needs 3+ chars)
         with m._get_db(bucket, "default") as db:              # the interrupted attempt: a/ finished (and wrote a/x2 with triggers off), b/ did not

--- a/website/src/content/docs/reference/environment-variables.mdx
+++ b/website/src/content/docs/reference/environment-variables.mdx
@@ -42,6 +42,8 @@ All Sairo configuration is done through environment variables. This page lists e
 | `DB_DIR` | `/data` | Directory where SQLite index databases are stored |
 | `FULL_CRAWL_INTERVAL` | `3600` | Seconds between full reconcile crawls for large buckets (delta crawls run on `RECRAWL_INTERVAL` in between) |
 | `LARGE_BUCKET_SECONDS` | `60` | A bucket whose full crawl takes longer than this is treated as "large" and kept fresh with delta crawls + periodic full reconcile, instead of full re-crawls every interval |
+| `REBUILD_MAX_DURATION` | `7200` | Seconds a search-index rebuild may hold its bucket. Past this the reservation is abandoned so crawls and deltas can resume, mirroring the equivalent ceiling on a crawl. Raise it only if a single bucket's rebuild legitimately runs longer than two hours. |
+| `FTS_PROBE_MS` | `10000` | Milliseconds the search-index health probe may run before it gives up. The probe is three constant-time queries, so only an unreadable or corrupt index reaches this; one that does is treated as unhealthy and rebuilt rather than blocking the caller. |
 
 ### Delta-crawl tuning
 


### PR DESCRIPTION
## What broke

One production bucket (12,479 objects) went **over an hour with zero crawls and zero deltas** while the other 24 stayed fresh. It was the only bucket in the fleet with no activity at all.

`_crawling` has had two escapes all along — `_CRAWL_STALL_SECONDS` and `_CRAWL_MAX_DURATION`. `_rebuilding` was a bare `set()` with **no timestamp and no escape**. So once a rebuild stopped releasing its bucket, `_queue_crawl` and `_queue_delta_crawl` both refused it for the life of the process.

What hung the rebuild was also unbounded. `_fts_healthy()` runs an ordinary scan of the FTS index, which on a corrupt index never finishes, and there was no timeout at any layer — so `/api/buckets/{b}/crawl-status`, the poll behind the UI's index state, hung with it. Measured on that bucket: two attempts, both cut off at ~60s, neither ever reaching the access log, while `list` and `storage-breakdown` on the same DB answered in under 0.6s.

## The fix

- `_rebuilding` records when each rebuild started; one `_rebuild_blocked()` helper gates all three sites. Past `REBUILD_MAX_DURATION` (default 7200s — the ceiling a crawl already had) the reservation is abandoned so the scheduler can progress. The bucket's own `_fts_rebuild_locks` entry still serialises a later rebuild against the orphan.
- `_fts_healthy()` is bounded by `FTS_PROBE_MS` (default 10s) via SQLite's own progress handler. An index that cannot be verified reads as **unhealthy** — so it gets rebuilt — rather than blocking the caller. The handler is cleared in a `finally`, with a test that fails if it leaks onto the connection.
- That probe also ran `SELECT COUNT(*) FROM objects` to decide whether any objects existed. At 10.28M rows that full scan costs seconds on the status path and would have tripped the new deadline on a **healthy** large bucket, triggering a needless multi-minute rebuild. Now an existence check, with a test that fails if the probe ever scales with bucket size again.

`+60 −16` in `backend/main.py`.

## Evidence

Every claim below was run against unfixed `main` first, so the differential is real and not just "the new tests pass".

| | unfixed main | this branch |
|---|---|---|
| `TestRebuildStallGuard` | **4 failed**, 2 passed | **7 passed** |
| Health probe on an unverifiable index | `ran unbounded (22.8s)` | 2.00s, returns unhealthy |
| Backend suite | 177 passed, 2 skipped | **184 passed, 2 skipped** |
| Live uvicorn + real HTTP + cookie session | 2 failed | **6/6** |

Live-server check starts a real uvicorn, logs in over HTTP as a browser does, and asks for `crawl-status` on a bucket whose index cannot be verified:

```
[PASS] responds in under 5s                     — 2.00s   (main: 11.37s)
[PASS] degrades to rebuilding, not a hang       — rebuilding=True search_ready=False
[PASS] catalogue data still served              — total_objects=500
[PASS] object listing unaffected                — 0.00s
[PASS] bucket is still schedulable
```

Browser suite (233 specs, Playwright container against this build): **222 passed, 2 skipped**. The 6 failures are pre-existing drift or container artifacts, each verified individually — clipboard `"Copy"` vs `"Copied!"`; Optimize-tab pricing data absent; `/api/version` returns `current` where the test wants `current_version`, which never existed; `/api/pricing` field undefined; `storage-history` returning 8 rows for an empty bucket. None touch `_rebuilding`, `_rebuild_blocked`, `_fts_healthy`, `_queue_crawl` or `_queue_delta_crawl`, and all six reproduce without this change.

## Deliberately not in this PR

**A rebuild thread that hangs while holding a write transaction still blocks WAL checkpointing.** On the same production bucket that is 22 GB of WAL beside a 21.9 GB database — 44 GB, 52% of the volume, for 12,479 objects. This PR frees the bucket's *scheduling*; it does not kill the thread. That needs `journal_size_limit` plus a watchdog that interrupts the rebuild connection, and its own reproduction.

**Reservation held during the `FTS_REBUILD_CONCURRENCY=1` queue wait.** A queued rebuild marks its bucket `_rebuilding` before it acquires the slot, so buckets are blocked while merely waiting. With the ceiling above, that wait is now bounded, and production showed it self-resolving (`ds-mletl-data` completed a 1790s rebuild and immediately delta'd `140 new/changed`). Reordering the reservation risks reopening the race #50 just closed, so it is left alone.