### PR TITLE
fix(index): stop the index volume growing without bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,6 @@ All notable changes to Sairo are documented here. This project uses [Semantic Ve
 - **A rebuild killed mid-flight left its whole shadow index on disk.** `objects_fts_new` was dropped
   only when that same bucket next rebuilt, which might be never. It is now dropped as part of the
   post-crawl maintenance.
-
 - **A bucket whose search-index rebuild never finished stopped being crawled at all.** `_rebuilding`
   had no timestamp and no ceiling — unlike a crawl, which has both — so a rebuild that hung left the
   bucket refused by every later crawl and delta for the life of the process. Observed in production:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ All notable changes to Sairo are documented here. This project uses [Semantic Ve
 
 ### Fixed
 
+- **The index volume only ever grew.** Four separate paths had no ceiling, and together they took a
+  98 GB volume to 86% full holding 16 GB of real data. SQLite reuses free pages but never shrinks
+  the file, so a bucket that deletes as fast as it writes ratchets up forever — one 12,479-object
+  backup bucket reached 21.9 GB of which 21.90 GB (99.92%) was free pages. New databases are created
+  with incremental auto-vacuum, and a bucket whose file is mostly free space is compacted after a
+  crawl (`VACUUM_MIN_FREE_RATIO` / `VACUUM_MIN_FREE_BYTES`), which also converts existing ones.
+- **The write-ahead log had no size limit.** Checkpointing returns WAL pages to the database but
+  never shrinks the WAL itself; production carried a 22 GB `-wal` beside a 21.9 GB database. Capped
+  by `WAL_SIZE_LIMIT_BYTES`.
+- **`storage_history` had no retention.** One row per prefix per crawl, so a bucket recrawled every
+  120 s wrote hundreds of identical snapshots a day and production reached 3.1M rows. Completed days
+  are collapsed to one row per prefix — the granularity the chart actually reads — and anything past
+  `STORAGE_HISTORY_DAYS` is dropped.
+- **A rebuild killed mid-flight left its whole shadow index on disk.** `objects_fts_new` was dropped
+  only when that same bucket next rebuilt, which might be never. It is now dropped as part of the
+  post-crawl maintenance.
+
 - **A bucket whose search-index rebuild never finished stopped being crawled at all.** `_rebuilding`
   had no timestamp and no ceiling — unlike a crawl, which has both — so a rebuild that hung left the
   bucket refused by every later crawl and delta for the life of the process. Observed in production:

--- a/backend/main.py
+++ b/backend/main.py
@@ -895,6 +895,12 @@ def _init_db(bucket, endpoint_id=None):
     os.makedirs(DB_DIR, exist_ok=True)
     conn = sqlite3.connect(_db_path(bucket, endpoint_id), timeout=30)
     conn.execute("PRAGMA page_size = 8192")          # larger pages → shallower B-trees (new DBs only)
+    # Freed pages must come back. Without this SQLite only ever grows the file to its high-water
+    # mark: a 12,479-object bucket in production reached 21.9 GB of which 21.90 GB — 99.92% — was
+    # free pages, because a backup bucket deletes as fast as it writes. INCREMENTAL rather than FULL
+    # so reclaim happens in bounded steps we choose, not on every commit. Only takes effect on a
+    # database with no tables yet; existing ones are converted by _reclaim_free_pages().
+    conn.execute("PRAGMA auto_vacuum = INCREMENTAL")
     conn.execute("PRAGMA journal_mode=WAL")
     conn.execute("PRAGMA busy_timeout = 30000")      # wait up to 30s for locks (heavy parallel crawl contends)
     conn.execute("PRAGMA synchronous=NORMAL")
@@ -1049,6 +1055,9 @@ def _get_db(bucket, endpoint_id=None):
     conn.execute("PRAGMA synchronous = NORMAL")      # safe under WAL; fewer fsyncs on the crawl write path
     conn.execute("PRAGMA cache_size = -64000")       # 64MB page cache (default 2MB)
     conn.execute("PRAGMA mmap_size = 268435456")     # 256MB memory-mapped I/O
+    # Checkpointing returns WAL pages to the file but never shrinks the WAL itself: production had a
+    # 22 GB -wal next to a 21.9 GB database. With a limit set, each checkpoint truncates back to it.
+    conn.execute(f"PRAGMA journal_size_limit = {WAL_SIZE_LIMIT}")
     # temp_store stays DEFAULT (file-backed): the post-crawl GROUP BY rebuilds sort the whole objects table
     # in a temp b-tree, which in RAM is a full-table copy (OOM at 9.9M rows under the 1Gi chart limit).
     try:
@@ -1205,7 +1214,60 @@ def _record_storage_snapshot(bucket, endpoint_id=None):
                    (ts, "", (row[0] if row else 0) or 0, (row[1] if row else 0) or 0))
         db.execute("INSERT INTO storage_history (timestamp, prefix, object_count, total_size) "
                    "SELECT ?, prefix, object_count, total_size FROM folder_stats WHERE prefix != ''", (ts,))
+        # This table had no retention and one row per prefix per crawl: a bucket recrawled every
+        # 120 s writes ~700 identical snapshots a day, and production reached 3.1M rows. The chart
+        # groups by day, so anything finer than one row per prefix per day is never read — collapse
+        # completed days to their last sample and drop whatever falls outside the window.
+        cutoff = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - STORAGE_HISTORY_DAYS * 86400))
+        db.execute("DELETE FROM storage_history WHERE timestamp < ?", (cutoff,))
+        today = ts[:10]
+        db.execute("DELETE FROM storage_history WHERE substr(timestamp,1,10) < ? AND id NOT IN "
+                   "(SELECT MAX(id) FROM storage_history WHERE substr(timestamp,1,10) < ? "
+                   " GROUP BY substr(timestamp,1,10), prefix)", (today, today))
         db.commit()
+
+
+def _reclaim_free_pages(bucket, endpoint_id=None):
+    """Give a bucket's dead pages back to the filesystem when the file is mostly free space.
+
+    SQLite reuses free pages but never shrinks the file, so a bucket that deletes as fast as it
+    writes ratchets up forever. Production: a 12,479-object backup bucket at 21.9 GB, of which
+    21.90 GB (99.92%) was free pages, on a volume that was 86% full.
+
+    VACUUM writes a *compacted* copy, so the temporary file is the size of the result rather than
+    the source — on exactly these pathological files it costs megabytes and seconds, not a second
+    copy of the database. Gated on ratio AND absolute win so a healthy large bucket is never
+    rewritten for a few percent. It is also the only way to switch an existing database to
+    incremental auto-vacuum, so from here on it reclaims without a full rewrite.
+
+    Runs as a post-crawl step, where the bucket is already reserved, so nothing else is writing.
+    """
+    path = _db_path(bucket, endpoint_id)
+    if not os.path.exists(path):
+        return
+    eid = endpoint_id or "default"
+    try:
+        with _get_db(bucket, endpoint_id) as db:
+            # A rebuild killed mid-flight leaves its whole shadow index behind; it is only dropped
+            # when that same bucket next rebuilds, which may be never.
+            if db.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name='objects_fts_new'").fetchone():
+                db.execute("DROP TABLE objects_fts_new")
+                db.commit()
+                log.info("[%s:%s] Dropped an orphaned search-index shadow table left by an interrupted rebuild", eid, bucket)
+            page = db.execute("PRAGMA page_size").fetchone()[0]
+            total = page * db.execute("PRAGMA page_count").fetchone()[0]
+            free = page * db.execute("PRAGMA freelist_count").fetchone()[0]
+            if total <= 0 or free < VACUUM_MIN_FREE_BYTES or free / total < VACUUM_MIN_FREE_RATIO:
+                return
+            t0 = time.monotonic()
+            db.execute("PRAGMA auto_vacuum = INCREMENTAL")
+            db.execute("VACUUM")
+            db.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+        after = os.path.getsize(path)
+        log.info("[%s:%s] Compacted index: %.2f GB → %.2f GB (%.0f%% was free pages) in %.1fs",
+                 eid, bucket, total / 1e9, after / 1e9, free * 100.0 / total, time.monotonic() - t0)
+    except Exception as e:
+        log.warning("[%s:%s] Could not compact index (kept as-is): %s", eid, bucket, e)
 
 
 # ── Background Crawler (per-bucket) ──────────────────────────────────────
@@ -1234,6 +1296,10 @@ _CRAWL_STALL_SECONDS = int(os.environ.get("CRAWL_STALL_SECONDS", "1800"))  # no 
 _crawl_cancel = {}   # crawl_key -> threading.Event requesting a cooperative stop
 _shutting_down = threading.Event()
 MIN_FREE_DISK_PCT = int(os.environ.get("MIN_FREE_DISK_PCT", "10"))
+WAL_SIZE_LIMIT = int(os.environ.get("WAL_SIZE_LIMIT_BYTES", str(256 * 1024 * 1024)))   # truncate the -wal back to this at each checkpoint
+VACUUM_MIN_FREE_RATIO = float(os.environ.get("VACUUM_MIN_FREE_RATIO", "0.5"))          # compact a bucket once this much of its file is free pages
+VACUUM_MIN_FREE_BYTES = int(os.environ.get("VACUUM_MIN_FREE_BYTES", str(512 * 1024 * 1024)))  # ...and there is at least this much to win
+STORAGE_HISTORY_DAYS = int(os.environ.get("STORAGE_HISTORY_DAYS", "365"))              # storage_history retention
 
 
 class CrawlInterrupted(Exception):
@@ -2244,7 +2310,7 @@ def _run_crawl(bucket, endpoint_id=None):
                 steps = [_rebuild_folder_stats, _rebuild_prefix_children] if index_changed else []
                 if not index_changed:
                     log.info("[%s:%s] Folder aggregates unchanged — rebuild skipped", eid, bucket)
-                for step in steps + [_record_storage_snapshot]:
+                for step in steps + [_record_storage_snapshot, _reclaim_free_pages]:
                     try:
                         step(bucket, eid)
                     except Exception as step_e:

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1608,3 +1608,119 @@ class TestRebuildStallGuard:
             elapsed = time.monotonic() - t0
         assert elapsed < 5.0, f"probe ran unbounded ({elapsed:.1f}s)"
         assert result is False, "a timed-out probe was reported as a healthy index"
+
+
+class TestIndexDiskReclaim:
+    """The index volume only ever grew. SQLite reuses free pages but never shrinks the file, the
+    WAL had no size limit, storage_history had no retention, and a rebuild killed mid-flight left
+    its whole shadow index behind. Production reached 86% of a 98 GB volume, with one 12,479-object
+    backup bucket holding 21.9 GB of which 99.92% was free pages, beside a 22 GB WAL."""
+
+    def _churned(self, m, bucket, live=2_000, grown=60_000):
+        """A backup-style bucket: grow the file, then expire almost everything."""
+        for suffix in ("", "-wal", "-shm"):
+            try: os.remove(m._db_path(bucket, "default") + suffix)
+            except FileNotFoundError: pass
+        m._init_db(bucket, "default")
+        with m._get_db(bucket, "default") as db:
+            db.executemany("INSERT INTO objects (key,size,last_modified,etag,prefix,depth) VALUES (?,?,?,?,?,?)",
+                           [(f"backupstore/volumes/{i%256:02x}/pvc-{i//256:05d}/blocks/{i:012x}.blk",
+                             4096, "2026-09-10T00:00:00Z", "e", f"backupstore/volumes/{i%256:02x}/", 3)
+                            for i in range(grown)])
+            db.execute("CREATE VIRTUAL TABLE IF NOT EXISTS objects_fts USING fts5"
+                       "(key, content='objects', content_rowid='rowid', tokenize='trigram')")
+            db.execute("INSERT INTO objects_fts(rowid,key) SELECT rowid,key FROM objects")
+            db.commit()
+            db.execute("DELETE FROM objects WHERE rowid > ?", (live,))
+            db.execute("UPDATE crawl_status SET status='complete' WHERE id=1")
+            db.commit()
+
+    def test_a_mostly_free_index_is_compacted_and_keeps_every_row(self, app):
+        m = _main_module()
+        b = "reclaimbkt"
+        self._churned(m, b)
+        path = m._db_path(b, "default")
+        before = os.path.getsize(path)
+        with m._get_db(b, "default") as db:
+            n = db.execute("SELECT COUNT(*) FROM objects").fetchone()[0]
+            ps = db.execute("PRAGMA page_size").fetchone()[0]
+            free = ps * db.execute("PRAGMA freelist_count").fetchone()[0]
+        assert free / before > 0.4, f"fixture did not bloat ({free/before:.0%} free)"
+        with patch.object(m, "VACUUM_MIN_FREE_BYTES", 1024):
+            m._reclaim_free_pages(b, "default")
+        after = os.path.getsize(path)
+        assert after < before * 0.6, f"index was not compacted ({before} -> {after})"
+        with m._get_db(b, "default") as db:
+            assert db.execute("SELECT COUNT(*) FROM objects").fetchone()[0] == n, "compaction lost rows"
+            assert db.execute("PRAGMA auto_vacuum").fetchone()[0] == 2, "not converted to incremental"
+
+    def test_a_healthy_index_is_never_rewritten(self, app):
+        """A big bucket with a normal amount of slack must not be rewritten every crawl."""
+        m = _main_module()
+        b = "healthyidx"
+        for suffix in ("", "-wal", "-shm"):
+            try: os.remove(m._db_path(b, "default") + suffix)
+            except FileNotFoundError: pass
+        m._init_db(b, "default")
+        with m._get_db(b, "default") as db:
+            db.executemany("INSERT INTO objects (key,size,last_modified,etag,prefix,depth) VALUES (?,?,?,?,?,?)",
+                           [(f"data/p{i:07d}.parquet", 1024, "t", "e", "data/", 1) for i in range(20_000)])
+            db.execute("UPDATE crawl_status SET status='complete' WHERE id=1"); db.commit()
+        path = m._db_path(b, "default"); before = os.path.getsize(path)
+        m._reclaim_free_pages(b, "default")
+        assert os.path.getsize(path) == before, "a healthy index was rewritten for nothing"
+
+    def test_orphaned_shadow_index_is_dropped(self, app):
+        """A rebuild killed mid-flight leaves objects_fts_new behind — a full duplicate index that
+        is otherwise only dropped when that same bucket next rebuilds, which may be never."""
+        m = _main_module()
+        b = "orphanbkt"
+        for suffix in ("", "-wal", "-shm"):
+            try: os.remove(m._db_path(b, "default") + suffix)
+            except FileNotFoundError: pass
+        m._init_db(b, "default")
+        with m._get_db(b, "default") as db:
+            db.execute("INSERT INTO objects (key,size,last_modified,etag,prefix,depth) VALUES ('a',1,'t','e','',0)")
+            db.execute("CREATE VIRTUAL TABLE objects_fts_new USING fts5(key, tokenize='trigram')")
+            db.execute("UPDATE crawl_status SET status='complete' WHERE id=1"); db.commit()
+        m._reclaim_free_pages(b, "default")
+        with m._get_db(b, "default") as db:
+            assert not db.execute("SELECT 1 FROM sqlite_master WHERE name='objects_fts_new'").fetchone(), \
+                "orphaned shadow index survived"
+
+    def test_storage_history_is_bounded(self, app):
+        """One row per prefix per crawl, no retention: a bucket recrawled every 120s wrote ~700
+        identical snapshots a day and production reached 3.1M rows. The chart groups by day."""
+        m = _main_module()
+        b = "histbkt"
+        for suffix in ("", "-wal", "-shm"):
+            try: os.remove(m._db_path(b, "default") + suffix)
+            except FileNotFoundError: pass
+        m._init_db(b, "default")
+        with m._get_db(b, "default") as db:
+            for d in range(20):
+                db.executemany("INSERT INTO storage_history (timestamp,prefix,object_count,total_size) VALUES (?,?,?,?)",
+                               [(f"2026-08-{(d%28)+1:02d}T{h:02d}:00:00Z", f"p{i}/", 10, 1000)
+                                for i in range(5) for h in range(12)])
+            db.execute("INSERT INTO storage_history (timestamp,prefix,object_count,total_size) "
+                       "VALUES ('2019-01-01T00:00:00Z','ancient/',1,1)")   # outside any window
+            db.execute("UPDATE crawl_status SET status='complete' WHERE id=1"); db.commit()
+            before = db.execute("SELECT COUNT(*) FROM storage_history").fetchone()[0]
+        m._record_storage_snapshot(b, "default")
+        with m._get_db(b, "default") as db:
+            after = db.execute("SELECT COUNT(*) FROM storage_history").fetchone()[0]
+            dupes = db.execute("SELECT COUNT(*) FROM (SELECT substr(timestamp,1,10) d, prefix "
+                               "FROM storage_history WHERE substr(timestamp,1,10) < ? "
+                               "GROUP BY d, prefix HAVING COUNT(*) > 1)",
+                               (time.strftime('%Y-%m-%d'),)).fetchone()[0]
+            ancient = db.execute("SELECT COUNT(*) FROM storage_history WHERE timestamp < '2020-01-01'").fetchone()[0]
+        assert after < before, f"history not pruned ({before} -> {after})"
+        assert dupes == 0, "completed days still hold more than one sample per prefix"
+        assert ancient == 0, "rows outside the retention window survived"
+
+    def test_wal_is_capped_on_every_connection(self, app):
+        m = _main_module()
+        b = "walbkt"
+        m._init_db(b, "default")
+        with m._get_db(b, "default") as db:
+            assert db.execute("PRAGMA journal_size_limit").fetchone()[0] == m.WAL_SIZE_LIMIT

--- a/website/src/content/docs/reference/environment-variables.mdx
+++ b/website/src/content/docs/reference/environment-variables.mdx
@@ -44,6 +44,10 @@ All Sairo configuration is done through environment variables. This page lists e
 | `LARGE_BUCKET_SECONDS` | `60` | A bucket whose full crawl takes longer than this is treated as "large" and kept fresh with delta crawls + periodic full reconcile, instead of full re-crawls every interval |
 | `REBUILD_MAX_DURATION` | `7200` | Seconds a search-index rebuild may hold its bucket. Past this the reservation is abandoned so crawls and deltas can resume, mirroring the equivalent ceiling on a crawl. Raise it only if a single bucket's rebuild legitimately runs longer than two hours. |
 | `FTS_PROBE_MS` | `10000` | Milliseconds the search-index health probe may run before it gives up. The probe is three constant-time queries, so only an unreadable or corrupt index reaches this; one that does is treated as unhealthy and rebuilt rather than blocking the caller. |
+| `WAL_SIZE_LIMIT_BYTES` | `268435456` | Size the write-ahead log is truncated back to at each checkpoint. Without a limit the WAL only ever grows to its high-water mark and stays there. |
+| `VACUUM_MIN_FREE_RATIO` | `0.5` | Compact a bucket's index once this fraction of its file is free pages. SQLite reuses free pages but never shrinks the file, so a bucket that deletes as fast as it writes grows forever. |
+| `VACUUM_MIN_FREE_BYTES` | `536870912` | ...and only when at least this much space would actually be returned, so a healthy large bucket is never rewritten for a few percent. |
+| `STORAGE_HISTORY_DAYS` | `365` | Retention for `storage_history`. Completed days are also collapsed to one row per prefix, the granularity the chart reads. |
 
 ### Delta-crawl tuning
 


### PR DESCRIPTION
Stacked on #51 (same file, adjacent regions). Retarget to `main` once #51 lands.

## What was wrong

The index volume was at **86% of 98 GB while holding 16.4 GB of real data**. Four paths had no ceiling:

| | measured in production |
|---|---|
| Free pages never returned | `ssp-longhorn-backups-sfo`: **21.91 GB file, 21.90 GB free (99.92%)**, 12,479 live objects |
| WAL never truncated | **22.0 GB** `-wal` beside it; `journal_size_limit = -1` |
| `storage_history` no retention | **3,106,230 rows** |
| Orphaned shadow index | `objects_fts_new` left by a killed rebuild |

`auto_vacuum = 0` on every database. SQLite reuses free pages but never shrinks the file, so a backup bucket that deletes as fast as it writes ratchets up forever. Fleet-wide, **35.1 GB** sits in files that are >50% free — `longhorn-backups-eu` 97.9%, `us-west-1` 97.2%, `cctd` 91.9% — while `druid` (21.5%) and `ds-mletl-data` (3.6%) are healthy and must not be touched.

## The fix

- `PRAGMA auto_vacuum = INCREMENTAL` in `_init_db`, before any table exists — new buckets self-reclaim and never need a migration.
- `PRAGMA journal_size_limit` in `_get_db`, the single connection chokepoint — every checkpoint truncates the WAL back.
- `_reclaim_free_pages()` as a post-crawl step: drops an orphaned `objects_fts_new`, and when the file is mostly free space, converts to incremental auto-vacuum and `VACUUM`s. **VACUUM writes a compacted copy, so the temp file is the size of the result, not the source** — on these files that is megabytes and seconds, not a second copy of the database. It runs where the bucket is already reserved, so nothing else is writing.
- `storage_history` retention plus collapsing completed days to one row per prefix — the granularity `GROUP BY d` in the endpoint actually reads.

Gated on **ratio AND absolute win** (`VACUUM_MIN_FREE_RATIO` 0.5, `VACUUM_MIN_FREE_BYTES` 512 MB) so a healthy large bucket is never rewritten for a few percent.

## Evidence

A fixture reproducing the production state — grow a backup-style bucket with a trigram index over long keys, then expire almost everything:

```
before   file=284.0 MB  free=270.7 MB (95.3%)  objects=12,479  storage_history=18,000  orphan=1
after    file=  7.1 MB  free=  0.0 MB          objects=12,479  storage_history= 5,601  orphan=0

[PASS] file actually shrank on disk           — 284.0 MB -> 7.1 MB (97% back)
[PASS] no object rows lost                    — 12,479 -> 12,479
[PASS] orphaned shadow index dropped
[PASS] storage_history collapsed              — 18,000 -> 5,601
[PASS] converted to incremental auto-vacuum   — auto_vacuum=2
[PASS] WAL is capped                          — journal_size_limit=268435456
[PASS] healthy bucket skipped                 — free=0.5%, 0.00s, size unchanged
```

Against unfixed `main`, same fixture: bloats identically (95.4% free) and has no way to recover it — `journal_size_limit = -1`, `auto_vacuum = 0`, `storage_history` 18,000 → 18,001, no `_reclaim_free_pages`.

**`TestIndexDiskReclaim`: 5 passed here, all 5 fail on `main`.** Full backend suite **191 passed, 2 skipped**.

## Expected effect on the live deployment

~35 GB from compaction, ~22 GB from the WAL cap, ~0.5 GB from history. Reclaim happens per bucket as each next crawl completes, not in one burst.

## Not addressed

The 16.4 GB steady state is real, and ~437 B/object of it is the trigram FTS — about half. That scales with object count, not bytes stored (100M objects ≈ 87 GB). Lowering the floor means a cheaper tokenizer or indexing less of the key, which changes search behaviour and belongs in its own discussion.