### PR TITLE
fix(crawler): a flat folder no longer blocks its bucket from certifying freshness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ All notable changes to Sairo are documented here. This project uses [Semantic Ve
 
 ### Fixed
 
+- **A folder holding only objects could never be covered by delta discovery, so its bucket never
+  certified freshness.** The delimiter walk bounds each folder at `DELTA_NODE_MAX_PAGES` pages and
+  abandoned anything wider, but that bound counts returned entries — objects and rolled-up prefixes
+  together — so a *flat* folder trips it no matter how the knob is set. Production's
+  `druid/indexing-logs/` holds 789,345 objects directly under one prefix: every delta on that 10.3M
+  object bucket reported `discovery:truncated` and degraded, 21 times in a row, and covering it by
+  raising the budget would have taken about 790 pages. A folder that trips the bound on objects
+  rather than sub-folders is now handed to the delta's target phase, which already streams a prefix
+  whole with a bounded sink, and the delta certifies only once that listing succeeds. A folder wide
+  in sub-prefixes still reports the walk partial, because streaming one has no delimiter and would
+  walk its entire subtree.
+
 - **A bucket whose search-index rebuild never finished stopped being crawled at all.** `_rebuilding`
   had no timestamp and no ceiling — unlike a crawl, which has both — so a rebuild that hung left the
   bucket refused by every later crawl and delta for the life of the process. Observed in production:

--- a/backend/main.py
+++ b/backend/main.py
@@ -2739,11 +2739,16 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
             def _list_one(p):
                 direct, kids = [], []   # both halves: a folder can be wide in objects AND sub-prefixes
                 with _list_slots:   # deltas share the budget with full crawls
-                    return (p, _list_children(client, bucket, p, max_pages=DELTA_NODE_MAX_PAGES,
-                                              contents=direct, seen=kids), direct, kids)
+                    children = _list_children(client, bucket, p, max_pages=DELTA_NODE_MAX_PAGES,
+                                              contents=direct, seen=kids)
+                # Return COUNTS, never the payloads. Classifying a folder needs only how many of
+                # each came back, and ex.map materialises every result before the loop runs: at the
+                # configured bounds that is DELTA_MAX_NODES x DELTA_NODE_MAX_PAGES x 1000 object
+                # dictionaries — six million — alive at once. The lists die with this frame.
+                return (p, children, len(direct), len(kids))
             listed = list(ex.map(_list_one, frontier))
             nxt = []
-            for cur, children, direct, kids_seen in listed:
+            for cur, children, n_direct, n_kids in listed:
                 if children is None:
                     # The per-node page bound tripped. MaxKeys counts returned entries — objects and
                     # rolled-up prefixes together — so this only proves results remained, not that the
@@ -2766,14 +2771,14 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
                     # it streams every one of those sub-trees. Objects must DOMINATE what we read,
                     # and the promoted listing carries a ceiling for the case the sample cannot see
                     # (objects sort before sub-prefixes, so a truncated page may show only objects).
-                    entries = len(direct) + len(kids_seen)
-                    dominant = entries > 0 and len(kids_seen) <= entries * (1.0 - _FLAT_PREFIX_MIN_OBJECT_SHARE)
-                    if len(direct) >= DELTA_NODE_MAX_PAGES * _FLAT_PREFIX_MIN_OBJECTS_PER_PAGE and dominant:
+                    entries = n_direct + n_kids
+                    dominant = entries > 0 and n_kids <= entries * (1.0 - _FLAT_PREFIX_MIN_OBJECT_SHARE)
+                    if n_direct >= DELTA_NODE_MAX_PAGES * _FLAT_PREFIX_MIN_OBJECTS_PER_PAGE and dominant:
                         targets.add(cur); promoted.add(cur)
                         log.info("[%s:%s] Delta discovery: '%s' is flat (%d objects directly under it "
                                  "beside %d sub-folders) — listing it whole instead of reporting the "
                                  "walk truncated", endpoint_id or "default", bucket, cur[:80],
-                                 len(direct), len(kids_seen))
+                                 n_direct, n_kids)
                     else:
                         truncated = True
                         log.warning("[%s:%s] Delta discovery bound hit at '%s': still more results after "

--- a/backend/main.py
+++ b/backend/main.py
@@ -2601,12 +2601,20 @@ def _hot_target_prefixes(bucket, endpoint_id, sample=None, max_targets=None):
     return _minimal_prefixes({p for (p,) in rows})[:max_targets]
 
 
-def _delta_list_prefix(client, bucket, prefix, sink=None, batch_size=5000):
+class DeltaListTooLarge(Exception):
+    """A delimiter-less listing ran past its ceiling, so it is a subtree crawl, not a target."""
+
+
+def _delta_list_prefix(client, bucket, prefix, sink=None, batch_size=5000, max_objects=None):
     """Recursively list every object under `prefix` (no delimiter).
 
     Without `sink`, returns the raw S3 objects. With `sink`, hands them over in batches of at most
     `batch_size` as pages arrive and returns the count — a brand-new dataset with millions of objects
-    must not be held in memory (that is the large-bucket OOM path)."""
+    must not be held in memory (that is the large-bucket OOM path).
+
+    `max_objects` stops a listing that has clearly stopped being a target: this has no delimiter, so
+    a prefix promoted here on a wrong guess about its shape would drag the whole subtree in. Raising
+    beats running — the caller records a failed target and the delta degrades honestly."""
     objs = []
     total = 0
     token = None
@@ -2620,6 +2628,8 @@ def _delta_list_prefix(client, bucket, prefix, sink=None, batch_size=5000):
                 objs.append(o)
         if sink is not None and len(objs) >= batch_size:
             total += len(objs); sink(objs); objs = []
+        if max_objects is not None and total + len(objs) > max_objects:
+            raise DeltaListTooLarge(f"{prefix!r} exceeded {max_objects:,} objects without a delimiter")
         if not resp.get("IsTruncated", False):
             break
         token = resp.get("NextContinuationToken")
@@ -2645,6 +2655,13 @@ DELTA_NODE_MAX_PAGES = int(os.environ.get("DELTA_NODE_MAX_PAGES", "3"))
 # sub-folders. Half a 1000-entry page per page read is a clear majority either way, and the decision
 # only picks between streaming the prefix whole and reporting the walk partial.
 _FLAT_PREFIX_MIN_OBJECTS_PER_PAGE = 500
+# ...and those objects must be at least this share of what the listing returned. A folder that is
+# half sub-prefixes is not flat in any sense that makes a delimiter-less listing safe.
+_FLAT_PREFIX_MIN_OBJECT_SHARE = float(os.environ.get("FLAT_PREFIX_MIN_OBJECT_SHARE", "0.9"))
+# A promoted prefix is listed without a delimiter, so a wrong guess descends its whole subtree.
+# Production's worst real case is ~789k objects under one prefix; past this it is not a delta
+# target any more and the delta degrades rather than quietly becoming a full crawl.
+DELTA_FLAT_MAX_OBJECTS = int(os.environ.get("DELTA_FLAT_MAX_OBJECTS", "2000000"))
 DELTA_ROOT_MAX_PAGES = int(os.environ.get("DELTA_ROOT_MAX_PAGES", "200"))  # root listing pages per delta before the delta is degraded (200k entries; production has 62k-prefix roots)
 
 
@@ -2658,12 +2675,14 @@ def _natural_key(prefix):
     return [(0, int(t)) if t.isdigit() else (1, t) for t in re.split(r"(\d+)", s) if t]
 
 
-def _list_children(client, bucket, prefix, max_children=None, max_pages=None, contents=None):
+def _list_children(client, bucket, prefix, max_children=None, max_pages=None, contents=None, seen=None):
     """Immediate child 'folders' of prefix (delimiter list, fully paginated).
 
     Returns None when a bound trips (more than max_children children, or max_pages pages read
     without finishing) so callers keep the prefix as one unit. The listing's direct objects
-    (Contents) are appended to `contents` when given."""
+    (Contents) are appended to `contents` when given, and the child prefixes seen before the bound
+    tripped to `seen` — a caller deciding what KIND of folder this is needs both halves, because
+    `None` alone cannot distinguish a flat folder from one wide in sub-prefixes."""
     out, token, pages = [], None, 0
     while True:
         params = {"Bucket": bucket, "Prefix": prefix, "Delimiter": "/", "MaxKeys": 1000}
@@ -2671,7 +2690,10 @@ def _list_children(client, bucket, prefix, max_children=None, max_pages=None, co
             params["ContinuationToken"] = token
         resp = client.list_objects_v2(**params)
         pages += 1
-        out.extend(cp["Prefix"] for cp in resp.get("CommonPrefixes", []))
+        kids = [cp["Prefix"] for cp in resp.get("CommonPrefixes", [])]
+        out.extend(kids)
+        if seen is not None:
+            seen.extend(kids)
         if contents is not None:
             contents.extend(resp.get("Contents", []))
         if max_children is not None and len(out) > max_children:
@@ -2695,8 +2717,9 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
     brand-new hour folder — even when it sits beyond the first 1000 siblings and in a
     dataset that isn't the globally most-recently-modified one)."""
     if not tops:
-        return set(), False
+        return set(), False, set()
     targets, frontier, visited, truncated = set(), list(tops), 0, False
+    promoted = set()   # listed without a delimiter, so they carry a ceiling
     with _get_db(bucket, endpoint_id) as db, \
          ThreadPoolExecutor(max_workers=DELTA_LIST_CONCURRENCY) as ex:
         depth = 0
@@ -2714,13 +2737,13 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
             # 20,000 children cost 20 LIST pages and 20,000 names in memory. A node wider than
             # DELTA_NODE_MAX_PAGES pages is left unvisited and the walk is reported partial.
             def _list_one(p):
-                direct = []   # the delimiter listing's own objects, to tell a flat prefix from a wide branch
+                direct, kids = [], []   # both halves: a folder can be wide in objects AND sub-prefixes
                 with _list_slots:   # deltas share the budget with full crawls
                     return (p, _list_children(client, bucket, p, max_pages=DELTA_NODE_MAX_PAGES,
-                                              contents=direct), direct)
+                                              contents=direct, seen=kids), direct, kids)
             listed = list(ex.map(_list_one, frontier))
             nxt = []
-            for cur, children, direct in listed:
+            for cur, children, direct, kids_seen in listed:
                 if children is None:
                     # The per-node page bound tripped. MaxKeys counts returned entries — objects and
                     # rolled-up prefixes together — so this only proves results remained, not that the
@@ -2738,11 +2761,19 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
                     # A folder wide in SUB-PREFIXES is a different animal: streaming it has no
                     # delimiter, so it would walk the whole subtree — a full crawl by another name.
                     # Those still report the walk as partial.
-                    if len(direct) >= DELTA_NODE_MAX_PAGES * _FLAT_PREFIX_MIN_OBJECTS_PER_PAGE:
-                        targets.add(cur)
-                        log.info("[%s:%s] Delta discovery: '%s' is flat (%d+ objects directly under it, "
-                                 "no sub-folders to walk) — listing it whole instead of reporting the "
-                                 "walk truncated", endpoint_id or "default", bucket, cur[:80], len(direct))
+                    # Counting objects alone is not enough: a folder can be wide in BOTH. 1,500
+                    # objects beside 1,500 sub-prefixes clears any absolute threshold, and promoting
+                    # it streams every one of those sub-trees. Objects must DOMINATE what we read,
+                    # and the promoted listing carries a ceiling for the case the sample cannot see
+                    # (objects sort before sub-prefixes, so a truncated page may show only objects).
+                    entries = len(direct) + len(kids_seen)
+                    dominant = entries > 0 and len(kids_seen) <= entries * (1.0 - _FLAT_PREFIX_MIN_OBJECT_SHARE)
+                    if len(direct) >= DELTA_NODE_MAX_PAGES * _FLAT_PREFIX_MIN_OBJECTS_PER_PAGE and dominant:
+                        targets.add(cur); promoted.add(cur)
+                        log.info("[%s:%s] Delta discovery: '%s' is flat (%d objects directly under it "
+                                 "beside %d sub-folders) — listing it whole instead of reporting the "
+                                 "walk truncated", endpoint_id or "default", bucket, cur[:80],
+                                 len(direct), len(kids_seen))
                     else:
                         truncated = True
                         log.warning("[%s:%s] Delta discovery bound hit at '%s': still more results after "
@@ -2768,7 +2799,7 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
             frontier = nxt
         if frontier:
             truncated = True   # depth or node budget exhausted with folders still unvisited
-    return targets, truncated
+    return targets, truncated, promoted
 
 
 def _delta_write(db, objs, gen):
@@ -2844,7 +2875,7 @@ def _delta_crawl(bucket, endpoint_id):
         row = db.execute("SELECT current_crawl_gen FROM crawl_status WHERE id=1").fetchone()
         gen = (row[0] if row else 0) or 0
     try:
-        discovered, partial = _discover_delta_targets(client, bucket, eid, tops)  # opens its own per-thread connections
+        discovered, partial, promoted = _discover_delta_targets(client, bucket, eid, tops)  # opens its own per-thread connections
         if partial:
             failed_targets.append("discovery:truncated")   # bounded walk did not cover every folder → not a clean delta
     except Exception as e:
@@ -2852,6 +2883,7 @@ def _delta_crawl(bucket, endpoint_id):
         # freshness: keep the hot-prefix refresh, but report the delta as degraded.
         log.warning("[%s:%s] delta target discovery failed: %s", eid, bucket, e)
         discovered = set()
+        promoted = set()
         failed_targets.append("discovery")
     targets = _minimal_prefixes(set(hot) | discovered | new_tops)   # new top-level prefixes are listed in full
 
@@ -2869,7 +2901,10 @@ def _delta_crawl(bucket, endpoint_id):
     def _list_or_fail(tp):
         try:
             with _list_slots:   # delta target listing draws on the same global budget
-                res = _delta_list_prefix(client, bucket, tp, sink=flush)
+                # Only a promoted prefix carries the ceiling: an ordinary hot target came from the
+                # index and is known-small; a promotion is a guess about folder shape.
+                res = _delta_list_prefix(client, bucket, tp, sink=flush,
+                                         max_objects=DELTA_FLAT_MAX_OBJECTS if tp in promoted else None)
             if isinstance(res, list):   # a listing helper that returns objects instead of streaming
                 flush(res)
             return tp, True

--- a/backend/main.py
+++ b/backend/main.py
@@ -2641,6 +2641,10 @@ DELTA_MAX_NODES = int(os.environ.get("DELTA_MAX_NODES", "2000"))        # safety
 # never certify a complete refresh. Three pages covers 2,500 while still bounding a
 # genuinely oversized node.
 DELTA_NODE_MAX_PAGES = int(os.environ.get("DELTA_NODE_MAX_PAGES", "3"))
+# A folder that trips the page bound is "flat" when most of what came back were objects rather than
+# sub-folders. Half a 1000-entry page per page read is a clear majority either way, and the decision
+# only picks between streaming the prefix whole and reporting the walk partial.
+_FLAT_PREFIX_MIN_OBJECTS_PER_PAGE = 500
 DELTA_ROOT_MAX_PAGES = int(os.environ.get("DELTA_ROOT_MAX_PAGES", "200"))  # root listing pages per delta before the delta is degraded (200k entries; production has 62k-prefix roots)
 
 
@@ -2710,24 +2714,40 @@ def _discover_delta_targets(client, bucket, endpoint_id, tops):
             # 20,000 children cost 20 LIST pages and 20,000 names in memory. A node wider than
             # DELTA_NODE_MAX_PAGES pages is left unvisited and the walk is reported partial.
             def _list_one(p):
+                direct = []   # the delimiter listing's own objects, to tell a flat prefix from a wide branch
                 with _list_slots:   # deltas share the budget with full crawls
-                    return (p, _list_children(client, bucket, p, max_pages=DELTA_NODE_MAX_PAGES))
+                    return (p, _list_children(client, bucket, p, max_pages=DELTA_NODE_MAX_PAGES,
+                                              contents=direct), direct)
             listed = list(ex.map(_list_one, frontier))
-            # Name the folder that tripped the bound. Without this, "discovery:truncated" says the
-            # walk was partial but not which prefix or what to raise, so sizing DELTA_NODE_MAX_PAGES
-            # for a real bucket is guesswork.
-            for _cur, _kids in listed:
-                if _kids is None:
-                    # MaxKeys counts returned entries, objects and rolled-up prefixes together,
-                    # so the page budget does not translate to a child count. All this proves is
-                    # that results remained after the budget ran out.
-                    log.warning("[%s:%s] Delta discovery bound hit at '%s': still more results after "
-                                "%d pages of %d entries; raise DELTA_NODE_MAX_PAGES to cover it",
-                                endpoint_id or "default", bucket, _cur[:80], DELTA_NODE_MAX_PAGES, 1000)
             nxt = []
-            for cur, children in listed:
+            for cur, children, direct in listed:
                 if children is None:
-                    truncated = True
+                    # The per-node page bound tripped. MaxKeys counts returned entries — objects and
+                    # rolled-up prefixes together — so this only proves results remained, not that the
+                    # folder has many CHILDREN.
+                    #
+                    # When what we read back was mostly OBJECTS, the folder is flat and no page budget
+                    # will ever cover it: production's `druid/indexing-logs/` holds 789,345 objects
+                    # directly, so it tripped the bound on every delta, reported discovery:truncated
+                    # and never certified — raising the knob would need ~790 pages. Hand it to the
+                    # target phase instead, which streams a prefix whole with a sink and bounded
+                    # memory. _minimal_prefixes() drops it when it is already a hot target, so this
+                    # usually converts a listing we were going to do anyway from permanently degraded
+                    # into certifiable, rather than adding one.
+                    #
+                    # A folder wide in SUB-PREFIXES is a different animal: streaming it has no
+                    # delimiter, so it would walk the whole subtree — a full crawl by another name.
+                    # Those still report the walk as partial.
+                    if len(direct) >= DELTA_NODE_MAX_PAGES * _FLAT_PREFIX_MIN_OBJECTS_PER_PAGE:
+                        targets.add(cur)
+                        log.info("[%s:%s] Delta discovery: '%s' is flat (%d+ objects directly under it, "
+                                 "no sub-folders to walk) — listing it whole instead of reporting the "
+                                 "walk truncated", endpoint_id or "default", bucket, cur[:80], len(direct))
+                    else:
+                        truncated = True
+                        log.warning("[%s:%s] Delta discovery bound hit at '%s': still more results after "
+                                    "%d pages of %d entries; raise DELTA_NODE_MAX_PAGES to cover it",
+                                    endpoint_id or "default", bucket, cur[:80], DELTA_NODE_MAX_PAGES, 1000)
                     continue
                 if not children:
                     targets.add(cur)  # leaf: objects live directly under cur

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1618,10 +1618,14 @@ class TestFlatPrefixDiscovery:
     on a 10.3M-object bucket. No page budget fixes that: covering it would take ~790 pages. A flat
     prefix must instead be handed to the target phase, which streams a prefix whole with a sink."""
 
-    def _client(self, n_objects=0, n_children=0, per_page=1000):
+    def _client(self, n_objects=0, n_children=0, per_page=1000, interleave=False):
         """A delimiter listing paged at 1,000 like S3, holding objects, sub-folders, or both."""
-        entries = ([("o", f"logs/f{i:07d}.log") for i in range(n_objects)]
-                   + [("p", f"logs/s{i:05d}/") for i in range(n_children)])
+        objs = [("o", f"logs/f{i:07d}.log") for i in range(n_objects)]
+        kids = [("p", f"logs/s{i:05d}/") for i in range(n_children)]
+        if interleave:      # S3 returns keys in sort order; a real mixed folder alternates
+            entries = [x for pair in zip(objs, kids) for x in pair] + objs[len(kids):] + kids[len(objs):]
+        else:
+            entries = objs + kids
         pages = [entries[s:s + per_page] for s in range(0, len(entries), per_page)] or [[]]
         calls = {"n": 0}
         def list_objects_v2(**p):
@@ -1650,24 +1654,52 @@ class TestFlatPrefixDiscovery:
         m = _main_module()
         # far more objects than any page budget can cover, and no sub-folders at all
         c, _ = self._client(n_objects=m.DELTA_NODE_MAX_PAGES * 1000 + 5000)
-        targets, truncated = self._discover(m, c)
+        targets, truncated, _ = self._discover(m, c)
         assert "logs/" in targets, "a flat prefix must become a streaming target"
         assert truncated is False, \
             "a flat prefix reported the whole delta truncated, so the bucket could never certify"
+
+    def test_a_mixed_folder_is_not_mistaken_for_flat(self, app):
+        """A folder can be wide in BOTH at once. Counting only its objects and calling it flat
+        promotes it to a delimiter-less listing that walks every sub-tree — a delta silently
+        becoming a full crawl."""
+        m = _main_module()
+        half = m.DELTA_NODE_MAX_PAGES * 1000
+        c, _ = self._client(n_objects=half, n_children=half, per_page=1000, interleave=True)
+        targets, truncated, promoted = self._discover(m, c, bucket="mixedbkt")
+        assert "logs/" not in promoted, \
+            "a folder with as many sub-prefixes as objects was promoted to a recursive listing"
+        assert truncated is True, "a folder wide in sub-prefixes must report the walk partial"
+
+    def test_a_promoted_listing_is_bounded(self, app):
+        """Objects sort before sub-prefixes, so a truncated sample cannot always see them. The
+        promotion is a guess; without a ceiling a wrong one descends the whole subtree."""
+        m = _main_module()
+        pages = {"n": 0}
+        def list_objects_v2(**p):
+            pages["n"] += 1
+            return {"Contents": [{"Key": f"logs/x{pages['n']:05d}-{i}.log", "Size": 1,
+                                  "LastModified": _dt.datetime(2026, 9, 10), "ETag": "e"}
+                                 for i in range(1000)],
+                    "CommonPrefixes": [], "IsTruncated": True, "NextContinuationToken": f"t{pages['n']}"}
+        cl = MagicMock(); cl.list_objects_v2.side_effect = list_objects_v2
+        with pytest.raises(m.DeltaListTooLarge):
+            m._delta_list_prefix(cl, "b", "logs/", sink=lambda o: None, batch_size=1000, max_objects=5000)
+        assert pages["n"] < 50, "the ceiling did not stop an endless listing"
 
     def test_a_wide_branch_still_degrades_rather_than_walking_the_subtree(self, app):
         """The inverse must not regress: streaming has no delimiter, so promoting a folder that is
         wide in SUB-PREFIXES would walk its entire subtree — a full crawl by another name."""
         m = _main_module()
         c, _ = self._client(n_children=m.DELTA_NODE_MAX_PAGES * 1000 + 5000)
-        targets, truncated = self._discover(m, c, bucket="widebkt")
+        targets, truncated, _ = self._discover(m, c, bucket="widebkt")
         assert truncated is True, "an oversized branch must still report the walk partial"
         assert "logs/" not in targets, "a wide branch must not be streamed whole"
 
     def test_a_prefix_within_the_budget_is_unaffected(self, app):
         m = _main_module()
         c, calls = self._client(n_children=2500)
-        targets, truncated = self._discover(m, c, bucket="normalbkt")
+        targets, truncated, _ = self._discover(m, c, bucket="normalbkt")
         assert truncated is False and calls["n"] >= 3, "a 2,500-child node must still walk normally"
 
     def test_the_streaming_lister_can_actually_take_the_promoted_prefix(self, app):

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -1671,6 +1671,40 @@ class TestFlatPrefixDiscovery:
             "a folder with as many sub-prefixes as objects was promoted to a recursive listing"
         assert truncated is True, "a folder wide in sub-prefixes must report the walk partial"
 
+    def test_discovery_does_not_retain_the_objects_it_counts(self, app):
+        """Classifying a folder needs only how MANY objects came back, never the objects. ex.map
+        materialises every result before the loop runs, so returning the payloads keeps
+        DELTA_MAX_NODES x DELTA_NODE_MAX_PAGES x 1000 object dictionaries alive at once — six
+        million at the configured bounds, on a pod sized for one gigabyte.
+
+        Measured with tracemalloc rather than refcounts: the retained lists die when the walk
+        returns, so anything sampled afterwards looks identical either way."""
+        import tracemalloc
+        m = _main_module()
+        tops = [f"p{i:03d}/" for i in range(40)]          # 40 frontier nodes
+        def list_objects_v2(**p):
+            return {"CommonPrefixes": [],
+                    "Contents": [dict(Key=f"{p.get('Prefix','')}f{i:05d}.log", Size=1,
+                                      LastModified=_dt.datetime(2026, 9, 10), ETag="e" * 32)
+                                 for i in range(1000)],
+                    "IsTruncated": True, "NextContinuationToken": "t"}
+        cl = MagicMock(); cl.list_objects_v2.side_effect = list_objects_v2
+        for suffix in ("", "-wal", "-shm"):
+            try: os.remove(m._db_path("retainbkt", "default") + suffix)
+            except FileNotFoundError: pass
+        m._init_db("retainbkt", "default")
+
+        tracemalloc.start()
+        try:
+            m._discover_delta_targets(cl, "retainbkt", "default", tops)
+            peak = tracemalloc.get_traced_memory()[1]
+        finally:
+            tracemalloc.stop()
+        # 40 nodes x 3 pages x 1000 objects retained is tens of MB; counts are a few hundred bytes.
+        assert peak < 20 * 1024 * 1024, (
+            f"discovery peaked at {peak/1024/1024:.1f} MB — it is retaining object payloads "
+            f"instead of returning counts")
+
     def test_a_promoted_listing_is_bounded(self, app):
         """Objects sort before sub-prefixes, so a truncated sample cannot always see them. The
         promotion is a guess; without a ceiling a wrong one descends the whole subtree."""

--- a/backend/test_main.py
+++ b/backend/test_main.py
@@ -14,6 +14,7 @@ import base64
 import hashlib
 import time
 import sqlite3
+import datetime as _dt
 from datetime import datetime, timezone, timedelta
 from unittest.mock import patch, MagicMock
 
@@ -1608,3 +1609,74 @@ class TestRebuildStallGuard:
             elapsed = time.monotonic() - t0
         assert elapsed < 5.0, f"probe ran unbounded ({elapsed:.1f}s)"
         assert result is False, "a timed-out probe was reported as a healthy index"
+
+
+class TestFlatPrefixDiscovery:
+    """Production's `druid/indexing-logs/` holds 789,345 objects directly under one prefix and no
+    sub-folders. Delimiter discovery tripped its page bound on every single delta, reported
+    discovery:truncated, and the bucket never certified freshness — 21 consecutive degraded deltas
+    on a 10.3M-object bucket. No page budget fixes that: covering it would take ~790 pages. A flat
+    prefix must instead be handed to the target phase, which streams a prefix whole with a sink."""
+
+    def _client(self, n_objects=0, n_children=0, per_page=1000):
+        """A delimiter listing paged at 1,000 like S3, holding objects, sub-folders, or both."""
+        entries = ([("o", f"logs/f{i:07d}.log") for i in range(n_objects)]
+                   + [("p", f"logs/s{i:05d}/") for i in range(n_children)])
+        pages = [entries[s:s + per_page] for s in range(0, len(entries), per_page)] or [[]]
+        calls = {"n": 0}
+        def list_objects_v2(**p):
+            # only the prefix under test has content; anything deeper is an empty leaf, so the
+            # walk terminates instead of recursing on the same canned pages forever
+            if p.get("Prefix") != "logs/":
+                return {"CommonPrefixes": [], "Contents": [], "IsTruncated": False}
+            i = min(calls["n"], len(pages) - 1); calls["n"] += 1
+            pg = pages[i]
+            return {"CommonPrefixes": [{"Prefix": k} for t, k in pg if t == "p"],
+                    "Contents": [{"Key": k, "Size": 1, "LastModified": _dt.datetime(2026, 9, 10),
+                                  "ETag": "e"} for t, k in pg if t == "o"],
+                    "IsTruncated": i + 1 < len(pages),
+                    "NextContinuationToken": f"t{i}" if i + 1 < len(pages) else None}
+        c = MagicMock(); c.list_objects_v2.side_effect = list_objects_v2
+        return c, calls
+
+    def _discover(self, m, client, bucket="flatbkt"):
+        for suffix in ("", "-wal", "-shm"):
+            try: os.remove(m._db_path(bucket, "default") + suffix)
+            except FileNotFoundError: pass
+        m._init_db(bucket, "default")
+        return m._discover_delta_targets(client, bucket, "default", ["logs/"])
+
+    def test_a_flat_prefix_is_listed_whole_instead_of_truncating_the_delta(self, app):
+        m = _main_module()
+        # far more objects than any page budget can cover, and no sub-folders at all
+        c, _ = self._client(n_objects=m.DELTA_NODE_MAX_PAGES * 1000 + 5000)
+        targets, truncated = self._discover(m, c)
+        assert "logs/" in targets, "a flat prefix must become a streaming target"
+        assert truncated is False, \
+            "a flat prefix reported the whole delta truncated, so the bucket could never certify"
+
+    def test_a_wide_branch_still_degrades_rather_than_walking_the_subtree(self, app):
+        """The inverse must not regress: streaming has no delimiter, so promoting a folder that is
+        wide in SUB-PREFIXES would walk its entire subtree — a full crawl by another name."""
+        m = _main_module()
+        c, _ = self._client(n_children=m.DELTA_NODE_MAX_PAGES * 1000 + 5000)
+        targets, truncated = self._discover(m, c, bucket="widebkt")
+        assert truncated is True, "an oversized branch must still report the walk partial"
+        assert "logs/" not in targets, "a wide branch must not be streamed whole"
+
+    def test_a_prefix_within_the_budget_is_unaffected(self, app):
+        m = _main_module()
+        c, calls = self._client(n_children=2500)
+        targets, truncated = self._discover(m, c, bucket="normalbkt")
+        assert truncated is False and calls["n"] >= 3, "a 2,500-child node must still walk normally"
+
+    def test_the_streaming_lister_can_actually_take_the_promoted_prefix(self, app):
+        """The promotion is only worth anything if the target phase streams rather than buffers:
+        789,345 objects held in memory is the large-bucket OOM path."""
+        m = _main_module()
+        c, _ = self._client(n_objects=4500)
+        seen = []
+        total = m._delta_list_prefix(c, "flatbkt", "logs/", sink=lambda objs: seen.append(len(objs)),
+                                     batch_size=1000)
+        assert total == 4500, f"streamed {total} of 4500"
+        assert max(seen) <= 1000, f"sink received a batch of {max(seen)} — not bounded"

--- a/backend/test_scaling.py
+++ b/backend/test_scaling.py
@@ -1123,7 +1123,7 @@ class TestTruthfulStates:
             if tp == "b/":
                 raise ConnectionError("provider went away")
             return [{"Key": f"{tp}new", "Size": 1, "LastModified": lm, "ETag": '"n"'}]
-        with patch.object(m, "_hot_target_prefixes", return_value=["a/", "b/"]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
+        with patch.object(m, "_hot_target_prefixes", return_value=["a/", "b/"]), patch.object(m, "_discover_delta_targets", return_value=(set(), False, set())), \
              patch.object(m, "_list_children", return_value=[]), \
              patch.object(m, "_delta_list_prefix", side_effect=listing), patch.object(m._s3_manager, "get_client", return_value=object()):
             changed, failed = m._delta_crawl(bucket, "default")
@@ -1410,7 +1410,7 @@ class TestTruthfulStates:
         bucket = "truth-delta-root"
         m._init_db(bucket, "default")
         client, calls = self._root_client(m, root_objs=["fresh.bin"], tops=[])
-        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False, set())), \
              patch.object(m._s3_manager, "get_client", return_value=client):
             changed, failed = m._delta_crawl(bucket, "default")
         assert calls and calls[0] == ("", True), "a delta must issue the root LIST even with no hot prefixes"
@@ -1427,7 +1427,7 @@ class TestTruthfulStates:
         with m._get_db(bucket, "default") as db:
             db.execute("INSERT OR IGNORE INTO discovered_prefixes (prefix) VALUES ('old/')"); db.commit()
         client, calls = self._root_client(m, root_objs=[], tops=["old/", "brandnew/"], prefix_objs={"brandnew/": ["brandnew/part-1.zip", "brandnew/part-2.zip"]})
-        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False, set())), \
              patch.object(m._s3_manager, "get_client", return_value=client):
             changed, failed = m._delta_crawl(bucket, "default")
         assert (changed, failed) == (2, []), (changed, failed)
@@ -1444,13 +1444,13 @@ class TestTruthfulStates:
         bucket = "truth-delta-rootfail"
         m._init_db(bucket, "default")
         client, calls = self._root_client(m, root_objs=[], tops=[], fail_root=True, prefix_objs={"hot/": ["hot/x"]})
-        with patch.object(m, "_hot_target_prefixes", return_value=["hot/"]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
+        with patch.object(m, "_hot_target_prefixes", return_value=["hot/"]), patch.object(m, "_discover_delta_targets", return_value=(set(), False, set())), \
              patch.object(m._s3_manager, "get_client", return_value=client):
             changed, failed = m._delta_crawl(bucket, "default")
         assert changed == 1 and failed == ["root"], (changed, failed)   # hot prefix still refreshed, delta not certified
         # oversized root (page bound) is reported the same way
         client2, _ = self._root_client(m, root_objs=[], tops=[])
-        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False, set())), \
              patch.object(m, "_list_children", return_value=None), patch.object(m._s3_manager, "get_client", return_value=client2):
             assert m._delta_crawl(bucket, "default") == (0, ["root"])
 
@@ -1469,7 +1469,7 @@ class TestTruthfulStates:
                 raise ConnectionError("provider went away")
             return orig(**p)
         client.list_objects_v2.side_effect = failing
-        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False, set())), \
              patch.object(m._s3_manager, "get_client", return_value=client):
             changed, failed = m._delta_crawl(bucket, "default")
         assert failed == ["brandnew/"], failed
@@ -1477,7 +1477,7 @@ class TestTruthfulStates:
             assert db.execute("SELECT COUNT(*) FROM discovered_prefixes WHERE prefix='brandnew/'").fetchone()[0] == 0, "must stay unknown until listed"
         # next delta: the prefix is still new, gets listed, and only then recorded
         client2, calls2 = self._root_client(m, root_objs=[], tops=["brandnew/"], prefix_objs={"brandnew/": ["brandnew/a"]})
-        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False, set())), \
              patch.object(m._s3_manager, "get_client", return_value=client2):
             assert m._delta_crawl(bucket, "default") == (1, [])
         assert ("brandnew/", False) in calls2
@@ -1494,14 +1494,14 @@ class TestTruthfulStates:
         calls = []   # list.append is atomic under the GIL; MagicMock.call_count is not (16 listing threads lost increments on CI)
         client = MagicMock(); client.list_objects_v2.side_effect = lambda **p: calls.append(p) or {"CommonPrefixes": [], "Contents": [], "IsTruncated": False}
         with patch.object(m, "DELTA_MAX_NODES", 2000):
-            targets, partial = m._discover_delta_targets(client, bucket, "default", tops)
+            targets, partial, _ = m._discover_delta_targets(client, bucket, "default", tops)
         assert partial is True
         assert len(calls) == 2000, len(calls)
         assert len(targets) == 2000 and "p02036/" in targets and "p00000/" not in targets, "newest names are kept"
         # and the delta reports the partial walk instead of certifying itself
         with patch.object(m, "_hot_target_prefixes", return_value=["hot/"]), patch.object(m, "_list_children", return_value=[]), \
              patch.object(m, "_delta_list_prefix", return_value=[]), \
-             patch.object(m, "_discover_delta_targets", return_value=(set(), True)), patch.object(m._s3_manager, "get_client", return_value=object()):
+             patch.object(m, "_discover_delta_targets", return_value=(set(), True, set())), patch.object(m._s3_manager, "get_client", return_value=object()):
             assert m._delta_crawl(bucket, "default") == (0, ["discovery:truncated"])
 
     def test_delta_streams_a_large_new_prefix_in_bounded_batches(self):
@@ -1524,7 +1524,7 @@ class TestTruthfulStates:
         real = m._delta_write
         def spy(db, objs, gen):
             sizes.append(len(objs)); return real(db, objs, gen)
-        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False)), \
+        with patch.object(m, "_hot_target_prefixes", return_value=[]), patch.object(m, "_discover_delta_targets", return_value=(set(), False, set())), \
              patch.object(m, "_delta_write", side_effect=spy), patch.object(m._s3_manager, "get_client", return_value=client):
             changed, failed = m._delta_crawl(bucket, "default")
         assert (changed, failed) == (7000, []), (changed, failed)
@@ -1546,7 +1546,7 @@ class TestTruthfulStates:
                     "Contents": [], "IsTruncated": tok + 1 < 20, "NextContinuationToken": str(tok + 1)}
         client = MagicMock(); client.list_objects_v2.side_effect = list_objects_v2
         with patch.object(m, "DELTA_MAX_NODES", 1), patch.object(m, "DELTA_NODE_MAX_PAGES", 2):
-            targets, partial = m._discover_delta_targets(client, bucket, "default", ["wide/"])
+            targets, partial, _ = m._discover_delta_targets(client, bucket, "default", ["wide/"])
         assert partial is True and targets == set()
         assert client.list_objects_v2.call_count == 2, client.list_objects_v2.call_count
 

--- a/benchmark/prodlab/README.md
+++ b/benchmark/prodlab/README.md
@@ -25,3 +25,21 @@ generates keys from a fixed grid so any position is O(1) and any prefix is a bin
 exactly the calls the crawler makes (ListBuckets, HeadBucket, ListObjectsV2 with prefix / delimiter /
 max-keys / continuation-token / start-after) and benign metadata for the UI. What it cannot do: byte
 operations, real provider latency profiles, real throttling policy. Use the read-only production run for those.
+
+## Flat-prefix shape (`spec-flatprefix.json`)
+
+Three top-level prefixes holding 100,000 objects **directly**, with no sub-folders — production's
+`druid/indexing-logs/`, which holds 789,345 objects that way. Delimiter discovery trips its page
+bound on *objects* rather than children here, which no other spec in this directory produces: the
+druid, hive, skew and deepwide layouts are all deep or wide in sub-prefixes.
+
+Append it to another spec to exercise that path alongside the usual gate:
+
+    python3 - <<'PY'
+    import json
+    a=json.load(open("spec-prod.json")); b=json.load(open("spec-flatprefix.json"))
+    a["buckets"] += b["buckets"]; json.dump(a, open("/tmp/spec-gate.json","w"))
+    PY
+
+Set `LARGE_BUCKET_SECONDS` below its full-crawl time (it indexes in ~12 s) or the scheduler treats
+it as a small bucket and full-recrawls it, and delta discovery never runs on it at all.

--- a/benchmark/prodlab/run_variant.sh
+++ b/benchmark/prodlab/run_variant.sh
@@ -12,7 +12,12 @@ kubectl -n lab delete pvc sairo-data --wait=true >/dev/null 2>&1 || true
 kubectl -n lab create configmap s3sim --from-file=s3sim.py="$HERE/s3sim.py" --from-file=spec.json="$SPEC" --dry-run=client -o yaml | kubectl apply -f - >/dev/null
 kubectl -n lab rollout restart deploy/s3sim >/dev/null
 kubectl -n lab rollout status deploy/s3sim --timeout=180s >/dev/null
-helm upgrade sairo "$HERE/../../charts/sairo" -n lab --reuse-values --set image.tag="$TAG" --set replicaCount=1 --wait --timeout 240s >/dev/null
+# --reuse-values inherits whatever the release last had, so telemetry stays on unless it is
+# set explicitly. A gate run is a fresh install that would otherwise report itself to the
+# production dashboard on every restart.
+helm upgrade sairo "$HERE/../../charts/sairo" -n lab --reuse-values --set image.tag="$TAG" --set replicaCount=1 --set telemetry.enabled=false --wait --timeout 240s >/dev/null
+kubectl -n lab exec deploy/sairo -- printenv TELEMETRY 2>/dev/null | grep -qx false \
+  || { echo "REFUSING TO START: TELEMETRY is not false in the pod"; exit 1; }
 [ -d "$HERE/out" ] && mv "$HERE/out" "$HERE/out_$(date +%Y%m%d-%H%M%S)"
 mkdir -p "$HERE/out"; echo "tag=$TAG spec=$(basename "$SPEC") started=$(date -u +%FT%TZ)" > "$HERE/out/RUN"
 kubectl -n lab logs deploy/s3sim --tail=1

--- a/benchmark/prodlab/spec-flatprefix.json
+++ b/benchmark/prodlab/spec-flatprefix.json
@@ -1,0 +1,3 @@
+{"buckets": [
+  {"name": "seg-flatwide", "datasources": 3, "intervals": 100, "partitions": 1000, "layout": "wide"}
+]}


### PR DESCRIPTION
Stacked on #51. Together these two are the 3.7.1 candidate; #52 (PVC reclamation) is explicitly **not** included and stays a draft for 3.7.2.

## The bug, measured in production

```
21× [default:druid-lw-prod] Delta discovery bound hit at 'druid/indexing-logs/':
    still more results after 20 pages of 1000 entries
21× Delta crawl degraded: discovery:truncated
```

`DELTA_NODE_MAX_PAGES` is already raised to 20 on that deployment and it makes no difference, because the bound counts returned **entries** — objects and rolled-up prefixes together — and `druid/indexing-logs/` holds **789,345 objects directly under one prefix** with no sub-folders. Covering it by raising the budget needs ~790 pages, which is a full crawl by another name. So every delta on a 10.3M-object bucket degraded, and it never certified a complete refresh.

## The fix

When the page bound trips, look at what came back. Mostly objects → the folder is flat and no budget will ever cover it, so hand it to the delta's **existing** target phase, which lists a prefix whole through `_delta_list_prefix(..., sink=flush)` with bounded memory. Mostly sub-prefixes → unchanged, still reports the walk partial, because streaming one has no delimiter and would walk the entire subtree.

The delta is marked clean only once that listing succeeds; a failure keeps the degraded state. `_minimal_prefixes()` drops the promoted prefix when it is already a hot target, so in the common case this converts a listing that was happening anyway from permanently-degraded into certifiable rather than adding one.

No new queue, service, migration or dependency — it reuses `_delta_list_prefix`, the existing `_list_slots` global listing semaphore, and the existing target phase.

## What this does NOT do

It does not change how often full reconciles run — those stay on `FULL_CRAWL_INTERVAL`, untouched. What it changes is that deltas can ingest new keys first, so the next scheduled reconcile finds nothing to write and skips its FTS rebuild.

## Evidence

`TestFlatPrefixDiscovery`, reproducing the production shape:

| test | on #51 head | here |
|---|---|---|
| flat prefix becomes a streaming target, delta not truncated | **FAIL** — `assert 'logs/' in set()` | pass |
| wide branch still degrades, is not streamed whole | pass | pass |
| a prefix inside the budget walks normally | pass | pass |
| the streaming lister takes it with a bounded sink (≤1000/batch) | pass | pass |

The three that pass on both are guard tests — they pin behaviour that must not regress, which is the point of including them.

Full backend suite: **190 passed, 2 skipped**.

## Gate criteria this candidate must meet

Three consecutive clean druid deltas; an object beyond discovery page three becomes searchable; `last_error` clears with attempt/end timestamps agreeing; provider and index counts match; FTS stays current through the triggers; zero OOM, restarts, lock errors and pool overflows; anonymous memory under 800 MiB; measured LIST requests/hour below the current baseline; and the following full reconcile writes zero unchanged rows and skips the FTS rebuild.

Note the earlier lab run is **not** evidence for any of this: `sairo:v371gate` was built from the stacked #52 head, and that pod has now been OOMKilled four times under the 1 GiB limit. The gate will be rerun on a clean image built from this branch.