### PR TITLE
fix(ui): change-password dialog styling, dark mode and reachability (#54)

### DIFF
--- a/e2e/tests/29-change-password.spec.ts
+++ b/e2e/tests/29-change-password.spec.ts
@@ -59,6 +59,30 @@ test.describe('Change own password', () => {
     await expect(page.getByLabel('Current password', { exact: true })).toBeVisible();
   });
 
+  // The audit walked Tab eight times and focus left the dialog for a background Insights control.
+  // Nineteen dialogs carry role="dialog"; only three ever trapped focus.
+  test('29.5 keyboard stays inside the dialog and Escape closes it', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.locator(SEL.passwordHeaderButton).click();
+    await expect(page.locator(SEL.modal)).toBeVisible();
+
+    for (let i = 0; i < 12; i++) {
+      await page.keyboard.press('Tab');
+      const inside = await page.evaluate(() => {
+        const m = document.querySelector('.modal');
+        return !!(m && document.activeElement && m.contains(document.activeElement));
+      });
+      expect(inside, `focus escaped the dialog after ${i + 1} Tab presses`).toBe(true);
+    }
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator(SEL.modal)).toBeHidden();
+    // focus must come back to the control that opened it, not the top of the document
+    const returned = await page.evaluate(() =>
+      document.activeElement?.textContent?.trim());
+    expect(returned).toBe('Password');
+  });
+
   // The fields used bare <input>, which this stylesheet gives no base style, so they rendered with
   // browser-default chrome and kept black text on the dark modal background.
   test('29.4 fields are styled and readable in dark mode', async ({ page }) => {

--- a/e2e/tests/29-change-password.spec.ts
+++ b/e2e/tests/29-change-password.spec.ts
@@ -13,9 +13,9 @@ test.describe('Change own password', () => {
   async function changePassword(page, current: string, next: string) {
     await page.locator(SEL.passwordHeaderButton).click();
     await expect(page.locator(SEL.modal)).toBeVisible();
-    await page.locator('input[aria-label="Current password"]').fill(current);
-    await page.locator('input[aria-label="New password"]').fill(next);
-    await page.locator('input[aria-label="Confirm new password"]').fill(next);
+    await page.getByLabel('Current password', { exact: true }).fill(current);
+    await page.getByLabel('New password', { exact: true }).fill(next);
+    await page.getByLabel('Confirm new password', { exact: true }).fill(next);
     await page.locator(SEL.modal).getByRole('button', { name: 'Update Password' }).click();
     await expect(page.locator(SEL.modal)).toContainText('has been updated');
     await page.locator(SEL.modal).getByRole('button', { name: 'Done' }).click();
@@ -24,9 +24,9 @@ test.describe('Change own password', () => {
   test('29.1 wrong current password is rejected in place', async ({ page }) => {
     await loginAsAdmin(page);
     await page.locator(SEL.passwordHeaderButton).click();
-    await page.locator('input[aria-label="Current password"]').fill('not-the-password');
-    await page.locator('input[aria-label="New password"]').fill('brandnewpass1');
-    await page.locator('input[aria-label="Confirm new password"]').fill('brandnewpass1');
+    await page.getByLabel('Current password', { exact: true }).fill('not-the-password');
+    await page.getByLabel('New password', { exact: true }).fill('brandnewpass1');
+    await page.getByLabel('Confirm new password', { exact: true }).fill('brandnewpass1');
     await page.locator(SEL.modal).getByRole('button', { name: 'Update Password' }).click();
     await expect(page.locator(SEL.modal)).toContainText('Current password is incorrect');
   });
@@ -44,5 +44,41 @@ test.describe('Change own password', () => {
     await page.locator(SEL.signInButton).click();
     await expect(page.locator(SEL.bucketCard).first()).toBeVisible({ timeout: 15_000 });
     await changePassword(page, 'brandnewpass1', 'password');   // leave the stack as we found it
+  });
+
+  // Issue #54: the Password button sits in the header, which renders in every view, but the dialog
+  // itself was only mounted in the bucket-list branch — so inside a bucket the button set state and
+  // nothing appeared.
+  test('29.3 opens from inside a bucket, not just the overview', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.locator(SEL.bucketCard).first().click();
+    await expect(page.locator(SEL.passwordHeaderButton)).toBeVisible();
+    await page.locator(SEL.passwordHeaderButton).click();
+    await expect(page.locator(SEL.modal)).toBeVisible();
+    await expect(page.locator(SEL.modal)).toContainText('Change Password');
+    await expect(page.getByLabel('Current password', { exact: true })).toBeVisible();
+  });
+
+  // The fields used bare <input>, which this stylesheet gives no base style, so they rendered with
+  // browser-default chrome and kept black text on the dark modal background.
+  test('29.4 fields are styled and readable in dark mode', async ({ page }) => {
+    await loginAsAdmin(page);
+    await page.emulateMedia({ colorScheme: 'dark' });
+    await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
+    await page.locator(SEL.passwordHeaderButton).click();
+    await expect(page.locator(SEL.modal)).toBeVisible();
+    const field = page.getByLabel('Current password', { exact: true });
+    const seen = await field.evaluate((el) => {
+      const s = getComputedStyle(el);
+      const lum = (c: string) => {
+        const [r, g, b] = (c.match(/[\d.]+/g) || ['0', '0', '0']).map(Number);
+        return (0.2126 * r + 0.7152 * g + 0.0722 * b) / 255;
+      };
+      return { text: lum(s.color), bg: lum(s.backgroundColor), radius: s.borderTopLeftRadius, pad: s.paddingLeft };
+    });
+    // text and background must not both be dark, or the value is invisible
+    expect(Math.abs(seen.text - seen.bg)).toBeGreaterThan(0.4);
+    expect(seen.radius).not.toBe('0px');   // styled, not browser-default
+    expect(seen.pad).not.toBe('0px');
   });
 });

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -639,6 +639,17 @@ function MainApp() {
     </div>
   );
 
+  // Rendered wherever userBadge is. These two are opened from that badge, which appears in every
+  // view, but their dialogs used to be mounted only in the bucket-list branch — so from inside a
+  // bucket the Password button set state and nothing appeared (#54). Keeping them beside the badge
+  // means adding a view cannot separate a button from the dialog it opens.
+  const accountModals = (
+    <>
+      {showChangePassword && <ChangePassword onClose={() => setShowChangePassword(false)} />}
+      {showTwoFactor && <TwoFactorSetup onClose={() => setShowTwoFactor(false)} totpEnabled={user.totp_enabled} onStatusChange={(enabled) => setUser(prev => ({ ...prev, totp_enabled: enabled }))} />}
+    </>
+  );
+
   // Bucket list view
   if (!bucket) {
     return (
@@ -700,8 +711,7 @@ function MainApp() {
         {showLicense && <LicenseManager onClose={() => setShowLicense(false)} />}
         {showUserManager && <UserManager onClose={() => setShowUserManager(false)} currentUser={user} />}
         {showHealthCheck && <HealthCheck onClose={() => setShowHealthCheck(false)} />}
-        {showChangePassword && <ChangePassword onClose={() => setShowChangePassword(false)} />}
-        {showTwoFactor && <TwoFactorSetup onClose={() => setShowTwoFactor(false)} totpEnabled={user.totp_enabled} onStatusChange={(enabled) => setUser(prev => ({ ...prev, totp_enabled: enabled }))} />}
+        {accountModals}
         {showEndpointManager && <EndpointManager onClose={() => setShowEndpointManager(false)} />}
         <ToastContainer />
       </div>
@@ -907,7 +917,7 @@ function MainApp() {
           </div>
         </div>
       )}
-      {showTwoFactor && <TwoFactorSetup onClose={() => setShowTwoFactor(false)} totpEnabled={user.totp_enabled} onStatusChange={(enabled) => setUser(prev => ({ ...prev, totp_enabled: enabled }))} />}
+      {accountModals}
       <ToastContainer />
     </div>
   );

--- a/frontend/src/components/ChangePassword.jsx
+++ b/frontend/src/components/ChangePassword.jsx
@@ -24,24 +24,49 @@ export default function ChangePassword({ onClose }) {
     setLoading(false);
   };
 
+  // Which field the message is about, so the border marks the right one and the input carries the
+  // description for a screen reader rather than the message floating unattached above the form.
+  const mismatch = error === "New passwords do not match";
+  const tooShort = error.startsWith("New password must be");
+
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" role="dialog" aria-modal="true" onClick={(e) => e.stopPropagation()}>
-        <h2>Change Password</h2>
+      <div className="modal modal-small" role="dialog" aria-modal="true" aria-labelledby="cp-title"
+           onClick={(e) => e.stopPropagation()}>
+        <h2 id="cp-title">Change Password</h2>
         {done ? (
           <>
-            <p style={{ fontSize: 13, color: "var(--text-secondary)", margin: "0 0 16px" }}>Your password has been updated.</p>
-            <div className="modal-actions"><button onClick={onClose} className="btn-primary">Done</button></div>
+            <p className="form-hint" style={{ margin: "0 0 16px" }}>Your password has been updated.</p>
+            <div className="modal-actions">
+              <button onClick={onClose} className="btn-primary" autoFocus>Done</button>
+            </div>
           </>
         ) : (
           <form onSubmit={submit}>
-            {error && <div className="form-error">{error}</div>}
-            <input type="password" placeholder="Current password" aria-label="Current password" value={current} onChange={(e) => setCurrent(e.target.value)} required autoComplete="current-password" />
-            <input type="password" placeholder="New password (8+ characters)" aria-label="New password" value={next} onChange={(e) => setNext(e.target.value)} required minLength={8} autoComplete="new-password" />
-            <input type="password" placeholder="Confirm new password" aria-label="Confirm new password" value={confirm} onChange={(e) => setConfirm(e.target.value)} required autoComplete="new-password" />
+            {error && <div className="form-error" role="alert">{error}</div>}
+            <div className="form-field">
+              <label htmlFor="cp-current">Current password</label>
+              <input id="cp-current" type="password" value={current} autoFocus
+                     onChange={(e) => setCurrent(e.target.value)} required autoComplete="current-password" />
+            </div>
+            <div className="form-field">
+              <label htmlFor="cp-new">New password</label>
+              <input id="cp-new" type="password" value={next} minLength={8} required
+                     aria-invalid={tooShort || undefined} aria-describedby="cp-new-hint"
+                     onChange={(e) => setNext(e.target.value)} autoComplete="new-password" />
+            </div>
+            <p className="form-hint" id="cp-new-hint">At least 8 characters.</p>
+            <div className="form-field">
+              <label htmlFor="cp-confirm">Confirm new password</label>
+              <input id="cp-confirm" type="password" value={confirm} required
+                     aria-invalid={mismatch || undefined}
+                     onChange={(e) => setConfirm(e.target.value)} autoComplete="new-password" />
+            </div>
             <div className="modal-actions">
-              <button type="submit" disabled={loading} className="btn-primary">{loading ? "Updating..." : "Update Password"}</button>
               <button type="button" onClick={onClose}>Cancel</button>
+              <button type="submit" disabled={loading} className="btn-primary">
+                {loading ? "Updating…" : "Update Password"}
+              </button>
             </div>
           </form>
         )}

--- a/frontend/src/components/ChangePassword.jsx
+++ b/frontend/src/components/ChangePassword.jsx
@@ -1,5 +1,6 @@
 import React, { useState } from "react";
 import { changePassword } from "../api";
+import { useDialogKeys } from "../useDialog";
 
 export default function ChangePassword({ onClose }) {
   const [current, setCurrent] = useState("");
@@ -8,6 +9,7 @@ export default function ChangePassword({ onClose }) {
   const [error, setError] = useState("");
   const [done, setDone] = useState(false);
   const [loading, setLoading] = useState(false);
+  const dialogRef = useDialogKeys(onClose);
 
   const submit = async (e) => {
     e.preventDefault();
@@ -31,8 +33,8 @@ export default function ChangePassword({ onClose }) {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal modal-small" role="dialog" aria-modal="true" aria-labelledby="cp-title"
-           onClick={(e) => e.stopPropagation()}>
+      <div ref={dialogRef} className="modal modal-small" role="dialog" aria-modal="true"
+           aria-labelledby="cp-title" onClick={(e) => e.stopPropagation()}>
         <h2 id="cp-title">Change Password</h2>
         {done ? (
           <>
@@ -46,7 +48,7 @@ export default function ChangePassword({ onClose }) {
             {error && <div className="form-error" role="alert">{error}</div>}
             <div className="form-field">
               <label htmlFor="cp-current">Current password</label>
-              <input id="cp-current" type="password" value={current} autoFocus
+              <input id="cp-current" type="password" value={current}
                      onChange={(e) => setCurrent(e.target.value)} required autoComplete="current-password" />
             </div>
             <div className="form-field">

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -360,7 +360,12 @@ input:focus-visible, select:focus-visible, textarea:focus-visible {
 [data-theme="dark"] textarea {
   background: rgba(24, 24, 27, 0.6);
   border-color: rgba(63, 63, 70, 0.5);
+  /* Without this the field takes a dark background but keeps the browser's default black text,
+     so anything typed into it is unreadable in dark mode (#54). */
+  color: var(--text);
 }
+[data-theme="dark"] input::placeholder,
+[data-theme="dark"] textarea::placeholder { color: var(--text-light); }
 [data-theme="dark"] input:not(.login-form input):not(.tfa-login-input):not(.search-input):focus,
 [data-theme="dark"] select:focus,
 [data-theme="dark"] textarea:focus {
@@ -754,6 +759,49 @@ button.btn-danger:disabled { background: var(--bg-surface); }
   justify-content: flex-end;
   gap: 8px;
   margin-top: 16px;
+}
+
+/* Shared form field for modal dialogs. Bare <input> has no base style in this sheet, so a dialog
+   that used one rendered with browser-default chrome — out of place next to everything else, and
+   unreadable in dark mode (#54). Mirrors .ep-form-field, which already solved this locally. */
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  margin-bottom: 12px;
+}
+
+.form-field label {
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+}
+
+.form-field input {
+  padding: 8px 10px;
+  border: 1px solid var(--border-input);
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  font-family: inherit;
+  background: var(--bg-input);
+  color: var(--text);
+  width: 100%;
+  box-sizing: border-box;
+  transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.form-field input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px var(--primary-ring);
+}
+
+.form-field input[aria-invalid="true"] { border-color: var(--danger); }
+
+.form-hint {
+  font-size: 11px;
+  color: var(--text-light);
+  margin: -6px 0 12px;
 }
 
 .drop-zone {

--- a/frontend/src/useDialog.js
+++ b/frontend/src/useDialog.js
@@ -1,0 +1,48 @@
+import { useEffect, useRef } from "react";
+
+const FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+/**
+ * Keyboard behaviour every modal dialog owes its user: Escape closes it, Tab cycles inside it
+ * instead of walking out into the page behind, and focus goes back to whatever opened it.
+ *
+ * Extracted from ConfirmDialog, which was one of only three dialogs of nineteen that did this.
+ * The rest — Change Password included — let focus escape into background controls that a sighted
+ * mouse user cannot even see are focused.
+ *
+ * Returns a ref to put on the dialog element.
+ */
+export function useDialogKeys(onClose) {
+  const ref = useRef(null);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const opener = document.activeElement;   // restore this when the dialog goes away
+    const focusable = () => Array.from(el.querySelectorAll(FOCUSABLE)).filter((n) => !n.disabled);
+
+    // Focus the first control here rather than with autoFocus on the element: React applies
+    // autoFocus during commit, before this effect runs, so `opener` above would capture the
+    // dialog's own input and the restore on close would have nothing outside to go back to.
+    const initial = focusable();
+    if (initial.length) initial[0].focus();
+
+    const handler = (e) => {
+      if (e.key === "Escape") { e.stopPropagation(); onClose(); return; }
+      if (e.key !== "Tab") return;
+      // Recomputed per keypress: a dialog's contents change (a success screen swaps every control).
+      const items = focusable();
+      if (items.length === 0) return;
+      const first = items[0], last = items[items.length - 1];
+      if (e.shiftKey && document.activeElement === first) { e.preventDefault(); last.focus(); }
+      else if (!e.shiftKey && document.activeElement === last) { e.preventDefault(); first.focus(); }
+    };
+    el.addEventListener("keydown", handler);
+    return () => {
+      el.removeEventListener("keydown", handler);
+      if (opener && typeof opener.focus === "function" && document.contains(opener)) opener.focus();
+    };
+  }, [onClose]);
+
+  return ref;
+}


### PR DESCRIPTION
Closes #54.

Three separate root causes, all confirmed in the code.

**1. No base `input` style exists.** `index.css` styles `input` only for `:focus-visible`; every other form uses a component-scoped class (`.user-input`, `.ep-form-field input`). This dialog used bare `<input>`, so it rendered with browser-default chrome. Added a shared `.form-field` for modal forms using the house tokens, mirroring `.ep-form-field` which had already solved this locally.

**2. The dark-mode rule never set `color`:**
```css
[data-theme="dark"] input:not(...) {
  background: rgba(24, 24, 27, 0.6);   /* set */
  border-color: rgba(63, 63, 70, 0.5); /* set */
}                                       /* color: never set */
```
Dark field, browser-default black text, invisible. Fixed at that shared rule (plus `::placeholder`), so every bare input benefits.

**3. Mounted in one branch only.** `userBadge` renders in both views; `<ChangePassword>` was mounted only in the bucket-list branch, so inside a bucket the button set state and nothing rendered. Rather than pasting the line into the second branch — which is how it drifted — both account dialogs now live in one `accountModals` fragment declared beside the badge.

**Also:** the fields used placeholder-as-label. Placeholders disappear on input and aren't a dependable accessible name, so they're real `<label htmlFor>` now, with `aria-labelledby` on the dialog, `role="alert"` on the error and `aria-invalid` on the field it concerns. E2E selectors moved to `getByLabel`.

## Verification

Rendered in a real browser, both themes. **7/7 e2e passed**, including two new regression tests:
- **29.3** opens from inside a bucket, not just the overview
- **29.4** computes the text/background luminance gap in dark mode and asserts non-zero radius and padding — a regression to browser defaults fails CI rather than needing someone to spot it

Frontend unit tests 62/62, `vite build` clean.

Independent of #51/#53 (frontend only), so this does not stack.