### PR TITLE
test(e2e): stop the browser-test stack reporting itself as a real deployment

### DIFF
--- a/e2e/docker-compose.test.yml
+++ b/e2e/docker-compose.test.yml
@@ -29,6 +29,10 @@ services:
       ADMIN_PASS: password
       JWT_SECRET: e2e-test-secret-key-32chars-long!
       SECURE_COOKIE: "false"
+      # Every run of this stack is a fresh install that would otherwise report itself as a
+      # real deployment. The backend and frontend CI lanes already set this; the e2e lane
+      # brings the stack up through compose, so it has to be set here too.
+      TELEMETRY: "false"
       SESSION_HOURS: "24"
       # #35: the login form only offers LDAP when the server reports it enabled.
       # The directory is deliberately unreachable — the smoke proves the form


### PR DESCRIPTION
The backend and frontend CI lanes set `TELEMETRY: "false"` (ci.yaml:25, :57). The **critical-path** lane brings its stack up through `docker-compose.test.yml`, which never set it.

So every e2e run — every PR, and every local run — started a fresh install that reported itself as a deployment. That is where the long tail of identical `6 buckets / 12 objects / 2.3 KB / minio` rows in the telemetry dashboard comes from: they are this fixture, not real installs.

One line in the compose env. No product code.

Worth noting the same rule caught me elsewhere today: the kind-cluster lab and gate instances were run with `--set telemetry.enabled=false` and never reported (verified — zero "Anonymous telemetry enabled" lines in either). This stack was the gap.