### PR TITLE
ci: pull MinIO from its own registry, pinned (critical-path lane is red on main)

### DIFF
--- a/e2e/docker-compose.test.yml
+++ b/e2e/docker-compose.test.yml
@@ -1,6 +1,9 @@
 services:
   minio:
-    image: minio/minio:latest
+    # MinIO no longer serves this image to anonymous pulls from Docker Hub, so CI died on
+    # `pull access denied for minio/minio` while local runs kept working off a cached layer.
+    # quay.io is MinIO's own registry. Pinned, so a new upstream release cannot break CI again.
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     command: server /data --console-address ":9001"
     ports:
       - "${MINIO_PORT:-9100}:9000"


### PR DESCRIPTION
## What broke

`critical-path` on main fails in global setup, before any test runs:

```
minio Error pull access denied for minio/minio, repository does not exist
or may require 'docker login': denied
```

MinIO no longer serves that image to anonymous Docker Hub pulls. Reproduced directly:

```
docker.io/minio/minio:latest   -> DENIED
quay.io/minio/minio:latest     -> OK
```

**Not caused by anything merged.** On the failing run `backend`, `frontend`, `mcp` and `cli` all passed; only `critical-path` died, at infrastructure setup. Every PR merged from here fails identically until this lands. It hid locally because a cached layer kept working — CI runners pull fresh, which is why it surfaced on the first merge after the restriction took effect.

## Fix

```yaml
image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
```

quay.io is MinIO's own registry. **Pinned** rather than `:latest` so a future upstream release cannot break the lane the same way.

## Verified locally

- image pulls anonymously
- contains `/usr/bin/mc` (the healthcheck runs `mc ready local`) and `/usr/bin/minio`
- `docker compose up --wait` -> both containers **healthy**
- the exact six specs the lane runs: **63/63 passed**
- the container reports `TELEMETRY=false`, confirming #56 works on main

One line, no product code.