### PR TITLE
ci: the nightly restart harness pulls MinIO from its own registry too

### DIFF
--- a/benchmark/restart_harness/docker-compose.yml
+++ b/benchmark/restart_harness/docker-compose.yml
@@ -1,7 +1,10 @@
 # Restart harness infra: MinIO + toxiproxy (adds latency so a crawl is slow enough to interrupt).
 services:
   minio:
-    image: minio/minio:latest
+    # Same reason as e2e/docker-compose.test.yml (#57): MinIO no longer serves this image to
+    # anonymous Docker Hub pulls, so the nightly harness died in global setup before running a
+    # single scenario. quay.io is MinIO's own registry; pinned so a new release cannot repeat it.
+    image: quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z
     command: server /data
     environment: { MINIO_ROOT_USER: minioadmin, MINIO_ROOT_PASSWORD: minioadmin }
     ports: ["9000:9000"]


### PR DESCRIPTION
#57 fixed `e2e/docker-compose.test.yml` but missed `benchmark/restart_harness/docker-compose.yml`, so the **nightly gate has been dead** on the same cause.

```
Restart Harness (nightly)  2026-09-12  failure  22s   <- never reached a scenario
Restart Harness (nightly)  2026-09-11  success  8m36s
Restart Harness (nightly)  2026-09-10  success  10m25s
```

A 22-second failure against 8-10 minute successes is the signature of dying in setup. MinIO no longer serves that image to anonymous Docker Hub pulls.

Same pinned image #57 adopted: `quay.io/minio/minio:RELEASE.2025-09-07T16-13-09Z`.

**Verified:** the container starts and serves (`Up 8 seconds, 0.0.0.0:9000->9000`), and `grep -rn minio/minio:latest` now returns nothing repository-wide — this was the last one.

One line, no product code. Worth landing quickly: until it does, the nightly restart regression signal stays silently off.