### PR TITLE
release: 3.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ All notable changes to Sairo are documented here. This project uses [Semantic Ve
 
 ## [Unreleased]
 
+## [3.7.1] - 2026-09-13
+
+### Rollout
+
+This patch fixes freshness certification for buckets containing very large flat folders and prevents
+a stalled search-index verification from freezing a bucket. It has no schema migration; rollback to
+the 3.7.0 chart leaves the existing index usable.
+
+The exact release candidate was exercised as an in-place restart against an existing production-shaped
+index: 20 buckets and 18.5M objects in a 1 GiB pod. During the 68-minute crawler gate window, all
+20 buckets matched provider truth (18,500,000 of 18,500,000), the flat bucket completed six consecutive
+certified deltas, and the crawler recorded 21 flat-prefix promotions with zero truncated walks. A
+9.9M-object reconcile completed in 869.8 s and its FTS rebuild in 1,034.0 s. Peak anonymous memory was
+569 MiB, with zero crawler-window restarts, OOM kills, lock errors, or rebuilds abandoned to their ceiling.
+
+Cold reconstruction remains outside the supported 1 GiB envelope. A measured 15.8M-object build from
+an empty volume restarted twice, and 3.7.0 cannot complete the equivalent cold-build phase at 1 GiB
+either. Size the pod for reconstruction or seed it from an existing volume.
+
+This release does not eliminate every possible OOM. The legacy unbounded form of
+`GET /api/buckets/{bucket}/list` can still materialise a whole very large folder; a separate post-gate
+request for one million files reproduced an OOM. The normal browser view already paginates, the path is
+unchanged from 3.7.0, and the server-side ceiling and remaining client pagination are tracked in #59.
+
 ### Fixed
 
 - **A folder holding only objects could never be covered by delta discovery, so its bucket never

--- a/backend/main.py
+++ b/backend/main.py
@@ -310,7 +310,7 @@ async def s3_error_handler(request, exc):
 
 
 _app_start_time = time.time()
-SAIRO_VERSION = "3.7.0"
+SAIRO_VERSION = "3.7.1"
 
 
 def _version_gt(a: str, b: str) -> bool:

--- a/benchmark/prodlab/RESULTS.md
+++ b/benchmark/prodlab/RESULTS.md
@@ -305,3 +305,49 @@ identities (a rollout resets `restartCount`, so one real OOM computed as zero); 
 only the live container, where an OOM hides its evidence in the terminated one; a missing FTS
 generation passed vacuously; and `seg-main` was scored on `status` alone rather than on
 `last_error` being clear and `last_crawl_end >= last_attempt_at`.
+
+---
+
+## Run 13 — 3.7.1 release gate: flat-prefix freshness, 20 buckets / 18.5M objects, 1 GiB pod
+
+The exact candidate started against an index already present on the persistent volume, matching the
+deployed restart path rather than a cold reconstruction. The volume had previously run 3.7.0 and
+intermediate candidates; this proves compatibility with the persisted index, not a byte-for-byte direct
+3.7.0-to-candidate transition.
+
+`seg-flatwide` supplied the missing production shape: three prefixes with 1,000,000 objects directly
+under each and no sub-folders. At 3M objects its full crawl took 199.0 s, exceeding
+`LARGE_BUCKET_SECONDS` (60), so subsequent refreshes exercised delta discovery rather than masking the
+new path with short full crawls.
+
+### Crawler gate window
+
+| Metric | Result |
+|---|---|
+| Objects vs provider truth | 18,500,000 / 18,500,000 — all 20 buckets exact |
+| Flat-prefix promotions | 21 |
+| Truncated discovery walks | 0; pre-fix: every cycle |
+| Consecutive certified deltas on the flat bucket | 6 |
+| 9.9M-object reconcile | 869.8 s; one stale key removed |
+| Search-index rebuild, 9.9M keys | 1,034.0 s |
+| Peak anonymous memory | 569 MiB |
+| Restarts / OOM kills / `database is locked` | 0 / 0 / 0 |
+| Rebuilds abandoned to `REBUILD_MAX_DURATION` | 0 |
+| Search indexes at gate completion | 20 of 20 healthy; no orphaned shadow table |
+| Telemetry | disabled for the entire gate |
+
+`DELTA_FLAT_MAX_OBJECTS` did not fire live because each promoted prefix held 1M objects against its
+2M default; the rejection path is unit-tested.
+
+### Separately measured limits
+
+Cold reconstruction was not part of the crawler verdict. Building the 15.8M-object form of the lab
+index from an empty volume restarted twice at 1 GiB, and 3.7.0 cannot complete the equivalent phase at
+that memory limit either. Reconstruction at this scale requires a larger pod or a seeded volume.
+
+After the successful crawler window, a deliberately unbounded `GET /list` request materialised
+1,000,000 file rows in one response (21.3 s) and OOM-killed the pod. The persisted index recovered with
+all 18.5M objects intact. This endpoint behaviour predates 3.7.1 and is outside the crawler change;
+the normal browser view already uses pagination. Server-side protection and pagination for the remaining
+legacy callers are tracked in issue #59. The bounded control (`limit=200`) returned the same prefix's
+first page in 1,203 ms with a continuation cursor.

--- a/charts/sairo/Chart.yaml
+++ b/charts/sairo/Chart.yaml
@@ -2,8 +2,8 @@ apiVersion: v2
 name: sairo-helm
 description: S3-compatible object storage browser with search, versioning, and analytics
 type: application
-version: 1.5.0
-appVersion: "3.7.0"
+version: 1.5.1
+appVersion: "3.7.1"
 keywords:
   - s3
   - object-storage

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "sairo",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sairo",
-      "version": "3.7.0",
+      "version": "3.7.1",
       "dependencies": {
         "@tanstack/react-virtual": "^3.13.19",
         "lucide-react": "^0.575.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sairo",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "description": "S3-compatible object storage browser with search, versioning, and analytics",
   "private": true,
   "type": "module",

--- a/website/src/content/docs/installation/helm.mdx
+++ b/website/src/content/docs/installation/helm.mdx
@@ -13,7 +13,7 @@ Sairo provides an official Helm chart for Kubernetes deployments. The chart bund
 | ----------- | ------------------------ |
 | Registry      | `oci://registry-1.docker.io/stephenjr002/sairo-helm` |
 
-The chart version (currently `1.5.0`) is independent of the app version (currently `3.7.0`). Each chart release bundles the matching Docker image tag via `appVersion`. When you install without `--version`, you get the latest published chart.
+The chart version (currently `1.5.1`) is independent of the app version (currently `3.7.1`). Each chart release bundles the matching Docker image tag via `appVersion`. When you install without `--version`, you get the latest published chart.
 
 ## Install
 

--- a/website/src/content/docs/reference/changelog.mdx
+++ b/website/src/content/docs/reference/changelog.mdx
@@ -13,6 +13,16 @@ Each version release produces all three artifacts from the same `v*` tag:
 
 ---
 
+## v3.7.1
+
+**Large flat folders can certify freshness without forcing continuous full crawls.**
+
+- Delta discovery now recognises a folder dominated by direct objects and hands it to the existing bounded target-listing phase. Wide sub-folder trees still degrade safely instead of becoming accidental full crawls.
+- Promoted flat prefixes are capped by `DELTA_FLAT_MAX_OBJECTS` (default 2,000,000), and discovery retains counts instead of millions of object dictionaries.
+- A stalled search-index rebuild no longer freezes its bucket, corrupt-index health probes are time-bounded, and the status path no longer scans every object merely to test whether one exists.
+- Release gate: 20 buckets and 18.5M objects matched provider truth; six consecutive flat-bucket deltas certified; a 9.9M reconcile and FTS rebuild completed with 569 MiB peak anonymous memory and no crawler-window restarts or OOM kills.
+- Cold reconstruction at 1 GiB remains unsupported. The legacy unbounded listing response is unchanged and tracked in [#59](https://github.com/AshwathStephen/sairo/issues/59); the normal browser view already paginates.
+
 ## v3.7.0
 
 **The crawler keeps up with the storage instead of re-copying it** (Core program: SAE-63…SAE-85)


### PR DESCRIPTION
## Summary

- Bump the application to 3.7.1 and the Helm chart to 1.5.1.
- Publish the flat-prefix freshness fix and stalled FTS-rebuild safeguards merged in #51 and #53.
- Record Run 13 with its measured production-shaped results and explicitly separate the successful crawler gate from the later unbounded-listing OOM tracked in #59.
- Refresh the Helm and website release documentation.

## Release evidence

- Exact candidate exercised against an existing persistent index: 20 buckets, 18.5M objects, 1 GiB pod.
- During the 68-minute crawler gate window: 18,500,000/18,500,000 objects, six consecutive certified flat-bucket deltas, 21 flat-prefix promotions, zero truncated walks, zero restarts/OOM kills/lock errors.
- 9.9M reconcile: 869.8 s; 9.9M FTS rebuild: 1,034.0 s; peak anonymous memory: 569 MiB.
- Telemetry was disabled for the entire gate and every local validation command.

## Local validation

- Backend: 193 passed, 2 skipped.
- Frontend: 62 passed; production build passed.
- Helm: lint passed.
- Website: static production build passed.
- `git diff --check`: passed.
- Frontend production dependency audit: 0 vulnerabilities.

## Known limits

- Cold reconstruction of the 15.8M-object lab form at 1 GiB restarted twice; the equivalent 3.7.0 phase also cannot complete at that limit. Reconstruction needs a larger pod or a seeded volume.
- A deliberately unbounded one-million-file listing OOM-killed the pod after the crawler gate. This predates 3.7.1, does not affect the already-paginated normal browser view, and is tracked in #59.
- The static website build toolchain has inherited Astro ecosystem advisories. This PR changes no website dependency, and the deployed documentation output is static; dependency remediation should be reviewed separately rather than mixed into the crawler patch.

Do not tag `v3.7.1` until this PR is merged and all hosted checks are green.
